### PR TITLE
Generalize Nelder Mead

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/plans/cost_plan.jl
+++ b/src/plans/cost_plan.jl
@@ -38,6 +38,9 @@ after the description
 * `ρ` – (`1/2`) contraction parameter, $0 < \rho \leq \frac{1}{2}$,
 * `σ` – (`1/2`) shrink coefficient, $0 < \sigma \leq 1$
 * `x` – (`p[1]`) - a field to collect the current best value
+* `retraction_method` – `ExponentialRetraction` the rectraction to use, defaults to
+  the exponential map
+* `inverse_retraction_method` - `LogarithmicInverseRetraction` an `inverse_retraction(M,x,y)` to use.
 
 # Constructors
 
@@ -49,7 +52,15 @@ construct a Nelder-Mead Option with a set of `dimension(M)+1` random points.
 
 construct a Nelder-Mead Option with a set `p` of points
 """
-mutable struct NelderMeadOptions{T,Tα<:Real,Tγ<:Real,Tρ<:Real,Tσ<:Real} <: Options
+mutable struct NelderMeadOptions{
+    T,
+    Tα<:Real,
+    Tγ<:Real,
+    Tρ<:Real,
+    Tσ<:Real,
+    TR<:AbstractRetractionMethod,
+    TI<:AbstractInverseRetractionMethod,
+} <: Options
     population::Vector{T}
     stop::StoppingCriterion
     α::Tα
@@ -58,6 +69,8 @@ mutable struct NelderMeadOptions{T,Tα<:Real,Tγ<:Real,Tρ<:Real,Tσ<:Real} <: O
     σ::Tσ
     x::T
     costs::Vector{Float64}
+    retraction_method::TR
+    inverse_retraction_method::TI
     function NelderMeadOptions(
         M::MT;
         stop::StoppingCriterion=StopAfterIteration(2000),
@@ -65,10 +78,20 @@ mutable struct NelderMeadOptions{T,Tα<:Real,Tγ<:Real,Tρ<:Real,Tσ<:Real} <: O
         γ=2.0,
         ρ=1 / 2,
         σ=1 / 2,
+        retraction_method::AbstractRetractionMethod=ExponentialRetraction(),
+        inverse_retraction_method::AbstractInverseRetractionMethod=LogarithmicInverseRetraction(),
     ) where {MT<:Manifold}
         p = [random_point(M) for i in 1:(manifold_dimension(M) + 1)]
-        return new{eltype(p),typeof(α),typeof(γ),typeof(ρ),typeof(σ)}(
-            p, stop, α, γ, ρ, σ, p[1], []
+        return new{
+            eltype(p),
+            typeof(α),
+            typeof(γ),
+            typeof(ρ),
+            typeof(σ),
+            typeof(retraction_method),
+            typeof(inverse_retraction_method),
+        }(
+            p, stop, α, γ, ρ, σ, p[1], [], retraction_method, inverse_retraction_method
         )
     end
     function NelderMeadOptions(
@@ -78,9 +101,28 @@ mutable struct NelderMeadOptions{T,Tα<:Real,Tγ<:Real,Tρ<:Real,Tσ<:Real} <: O
         γ=2.0,
         ρ=1 / 2,
         σ=1 / 2,
+        retraction::AbstractRetractionMethod=ExponentialRetraction(),
+        inverse_retraction_method::AbstractInverseRetractionMethod=LogarithmicInverseRetraction(),
     ) where {T}
-        return new{T,typeof(α),typeof(γ),typeof(ρ),typeof(σ)}(
-            population, stop, α, γ, ρ, σ, population[1], []
+        return new{
+            T,
+            typeof(α),
+            typeof(γ),
+            typeof(ρ),
+            typeof(σ),
+            typeof(retraction_method),
+            typeof(inverse_retraction_method),
+        }(
+            population,
+            stop,
+            α,
+            γ,
+            ρ,
+            σ,
+            population[1],
+            [],
+            retraction_method,
+            inverse_retraction_method,
         )
     end
 end

--- a/src/plans/cost_plan.jl
+++ b/src/plans/cost_plan.jl
@@ -101,7 +101,7 @@ mutable struct NelderMeadOptions{
         γ=2.0,
         ρ=1 / 2,
         σ=1 / 2,
-        retraction::AbstractRetractionMethod=ExponentialRetraction(),
+        retraction_method::AbstractRetractionMethod=ExponentialRetraction(),
         inverse_retraction_method::AbstractInverseRetractionMethod=LogarithmicInverseRetraction(),
     ) where {T}
         return new{

--- a/src/plans/particle_swarm_plan.jl
+++ b/src/plans/particle_swarm_plan.jl
@@ -16,9 +16,8 @@ a default value is given in brackets if a parameter can be left out in initializ
 * `cognitive_weight` – (`1.4`) a cognitive weight factor
 * `stopping_criterion` – ([`StopWhenAny`](@ref)`(`[`StopAfterIteration`](@ref)`(500)`, [`StopWhenChangeLess`](@ref)`(10^{-4})))`
   a functor inheriting from [`StoppingCriterion`](@ref) indicating when to stop.
-* `retraction_method` – `ExponentialRetraction` the rectraction to use, defaults to
-  the exponential map
-* `inverse_retraction_method` - `LogarithmicInverseRetraction` an `inverse_retraction(M,x,y)` to use.
+* `retraction_method` – (`ExponentialRetraction`) the rectraction to use
+* `inverse_retraction_method` - (`LogarithmicInverseRetraction`) an inverse retraction to use.
 
 # Constructor
 

--- a/src/solvers/NelderMead.jl
+++ b/src/solvers/NelderMead.jl
@@ -24,6 +24,8 @@ and
 * `γ` – (`2.`) expansion parameter ($\gamma$)
 * `ρ` – (`1/2`) contraction parameter, $0 < \rho \leq \frac{1}{2}$,
 * `σ` – (`1/2`) shrink coefficient, $0 < \sigma \leq 1$
+* `retraction_method` – (`ExponentialRetraction`) the rectraction to use
+* `inverse_retraction_method` - (`LogarithmicInverseRetraction`) an inverse retraction to use.
 
 and the ones that are passed to [`decorate_options`](@ref) for decorators.
 
@@ -41,11 +43,22 @@ function NelderMead(
     γ=2.0,
     ρ=1 / 2,
     σ=1 / 2,
+    retraction_method::AbstractRetractionMethod=ExponentialRetraction(),
+    inverse_retraction_method::AbstractInverseRetractionMethod=LogarithmicInverseRetraction(),
     return_options=false,
     kwargs..., #collect rest
 ) where {MT<:Manifold,TF}
     p = CostProblem(M, F)
-    o = NelderMeadOptions(population, stopping_criterion; α=α, γ=γ, ρ=ρ, σ=σ)
+    o = NelderMeadOptions(
+        population,
+        stopping_criterion;
+        α=α,
+        γ=γ,
+        ρ=ρ,
+        σ=σ,
+        retraction_method=retraction_method,
+        inverse_retraction_method=inverse_retraction_method,
+    )
     o = decorate_options(o; kwargs...)
     resultO = solve(p, o)
     if return_options
@@ -57,17 +70,17 @@ end
 #
 # Solver functions
 #
-function initialize_solver!(p::P, o::O) where {P<:CostProblem,O<:NelderMeadOptions}
+function initialize_solver!(p::CostProblem, o::NelderMeadOptions)
     # init cost and x
     o.costs = get_cost.(Ref(p), o.population)
     return o.x = o.population[argmin(o.costs)] # select min
 end
-function step_solver!(p::P, o::O, iter) where {P<:CostProblem,O<:NelderMeadOptions}
+function step_solver!(p::CostProblem, o::NelderMeadOptions, iter)
     m = mean(p.M, o.population)
     ind = sortperm(o.costs) # reordering for cost and p, i.e. minimizer is at ind[1]
-    ξ = log(p.M, m, o.population[last(ind)])
+    ξ = inverse_retract(p.M, m, o.population[last(ind)], o.inverse_retraction_method)
     # reflect last
-    xr = exp(p.M, m, -o.α * ξ)
+    xr = retract(p.M, m, -o.α * ξ, o.retraction_method)
     Costr = get_cost(p, xr)
     # is it better than the worst but not better than the best?
     if Costr >= o.costs[first(ind)] && Costr < o.costs[last(ind)]
@@ -91,7 +104,7 @@ function step_solver!(p::P, o::O, iter) where {P<:CostProblem,O<:NelderMeadOptio
     if Costr > o.costs[ind[end - 1]] # even worse than second worst
         if Costr < o.costs[last(ind)] # but at least better tham last
             # outside contraction
-            xc = exp(p.M, m, -o.ρ * ξ)
+            xc = retract(p.M, m, -o.ρ * ξ, o.retraction_method)
             Costc = get_cost(p, xc)
             if Costc < Costr # better than reflected -> store as last
                 o.population[last(ind)] = xr
@@ -99,7 +112,7 @@ function step_solver!(p::P, o::O, iter) where {P<:CostProblem,O<:NelderMeadOptio
             end
         else # even worse than last -> inside contraction
             # outside contraction
-            xc = exp(p.M, m, o.ρ * ξ)
+            xc = retract(p.M, m, o.ρ * ξ, o.retraction_method)
             Costc = get_cost(p, xc)
             if Costc < o.costs[last(ind)] # better than last ? -> store
                 o.population[last(ind)] = xr
@@ -109,8 +122,11 @@ function step_solver!(p::P, o::O, iter) where {P<:CostProblem,O<:NelderMeadOptio
     end
     # --- Shrink ---
     for i in 2:length(ind)
-        o.population[ind[i]] = shortest_geodesic(
-            p.M, o.population[ind[1]], o.population[ind[i]], o.σ
+        o.population[ind[i]] = retract(
+            p.M,
+            o.population[ind[1]],
+            inverse_retract(p.M, o.population[ind[1]], o.population[ind[i]]),
+            o.σ,
         )
         # update cost
         o.costs[ind[i]] = get_cost(p, o.population[ind[i]])

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -55,9 +55,9 @@ i.e. $p_k^{(i)}$ is the best known position for the particle $k$ and $g^{(i)}$ i
 * `inertia` – (`0.65`) the inertia of the patricles
 * `social_weight` – (`1.4`) a social weight factor
 * `cognitive_weight` – (`1.4`) a cognitive weight factor
-* `retraction_method` – `ExponentialRetraction` a `retraction(M,x,ξ)` to use.
-* `inverse_retraction_method` - `LogarithmicInverseRetraction` an `inverse_retraction(M,x,y)` to use.
-* `vector_transport_mthod` - `ParallelTransport` a vector transport method to use.
+* `retraction_method` – (`ExponentialRetraction`) a `retraction(M,x,ξ)` to use.
+* `inverse_retraction_method` - (`LogarithmicInverseRetraction`) an `inverse_retraction(M,x,y)` to use.
+* `vector_transport_mthod` - (`ParallelTransport`) a vector transport method to use.
 * `stopping_criterion` – ([`StopWhenAny`](@ref)`(`[`StopAfterIteration`](@ref)`(500)`, [`StopWhenChangeLess`](@ref)`(10^{-4})))`
   a functor inheriting from [`StoppingCriterion`](@ref) indicating when to stop.
 * `return_options` – (`false`) – if activated, the extended result, i.e. the

--- a/test/solvers/test_Nelder_Mead.jl
+++ b/test/solvers/test_Nelder_Mead.jl
@@ -1,28 +1,47 @@
 #
 #
 #
-using Random
+using Random, Manifolds, Manopt, LinearAlgebra
 Random.seed!(29)
 @testset "Test Nelder-Mead" begin
-    M = Euclidean(6)
-    # From Wikipedia https://en.wikipedia.org/wiki/Rosenbrock_function
-    function Rosenbrock(x)
-        return sum([
-            100 * (x[2 * i - 1]^2 - x[2 * i])^2 + (x[2 * i - 1] - 1)^2
-            for i in 1:div(length(x), 2)
-        ])
+    @testset "Euclidean" begin
+        M = Euclidean(6)
+        # From Wikipedia https://en.wikipedia.org/wiki/Rosenbrock_function
+        function Rosenbrock(x)
+            return sum([
+                100 * (x[2 * i - 1]^2 - x[2 * i])^2 + (x[2 * i - 1] - 1)^2
+                for i in 1:div(length(x), 2)
+            ])
+        end
+        x0 = [randn(6) for i in 1:7]
+        o = NelderMead(M, Rosenbrock, x0; record=[RecordCost()], return_options=true)
+        x = get_solver_result(o)
+        rec = get_record(o)
+        nonincreasing = [rec[i] >= rec[i + 1] for i in 1:(length(rec) - 1)]
+        @test any(map(!, nonincreasing)) == false
+
+        x2 = o = NelderMead(M, Rosenbrock, x0)
+        @test x == x2
     end
-    x0 = [randn(6) for i in 1:7]
-    o = NelderMead(M, Rosenbrock, x0; record=[RecordCost()], return_options=true)
-
-    x = get_solver_result(o)
-    rec = get_record(o)
-
-    x2 = o = NelderMead(M, Rosenbrock, x0)
-
-    @test x == x2
-
-    nonincreasing = [rec[i] >= rec[i + 1] for i in 1:(length(rec) - 1)]
-
-    @test any(map(!, nonincreasing)) == false
+    @testset "Rotations" begin
+        M = Rotations(3)
+        A = randn(3, 3)
+        A .= (A - A') ./ 2
+        f(x) = norm(A * x * x * A)
+        x0 = [random_point(M) for _ in 1:12]
+        o = NelderMead(
+            M,
+            f,
+            x0;
+            record=[RecordCost()],
+            return_options=true,
+            retraction_method=QRRetraction(),
+            inverse_retraction_method=QRInverseRetraction(),
+            stopping_criterion=StopAfterIteration(500),
+        )
+        x = get_solver_result(o)
+        rec = get_record(o)
+        nonincreasing = [rec[i] >= rec[i + 1] for i in 1:(length(rec) - 1)]
+        @test any(map(!, nonincreasing)) == false
+    end
 end


### PR DESCRIPTION
This PR generalises Nelder Mead to also work with an arbitrary pair of retraction/inverse retraction instead of exp/log and adapts the algorithm accordingly.