### PR TITLE
Fix latex typo in JacobiFields tutorial

### DIFF
--- a/src/tutorials/JacobiFields.jl
+++ b/src/tutorials/JacobiFields.jl
@@ -76,8 +76,8 @@ X = [0.0, 0.4, 0.5]
 # ````
 # Intuitively we make a small step $s$ into direction $\xi$ using the geodesic
 # $g(\cdot; p,X)$ and from $r=g(s; p,X)$ we follow (in $t$) the geodesic
-# $g(\cdot; r,q)$. The corresponding Jacobi field~\(J_{g,X}\)
-# along~\(g(\cdot; p,q)\) is given
+# $g(\cdot; r,q)$. The corresponding Jacobi field~$J_{g,X}$
+# along~$g(\cdot; p,q)$ is given by
 #
 # ````math
 # J_{g,X}(t):=\frac{D}{\partial s}\Gamma_{g,X}(s,t)\Bigl\rvert_{s=0}

--- a/src/tutorials/JacobiFields.jl
+++ b/src/tutorials/JacobiFields.jl
@@ -80,7 +80,7 @@ X = [0.0, 0.4, 0.5]
 # along~\(g(\cdot; p,q)\) is given
 #
 # ````math
-# J_{g,X}(t):=\frac{D}{\partial s}\Gamma_{g,X}(s,t)\Bigl\rvert_{s=0}$
+# J_{g,X}(t):=\frac{D}{\partial s}\Gamma_{g,X}(s,t)\Bigl\rvert_{s=0}
 # ````
 #
 # which is an ODE and we know the boundary conditions $J_{g,X}(0)=X$ and

--- a/src/tutorials/JacobiFields.jl
+++ b/src/tutorials/JacobiFields.jl
@@ -76,8 +76,8 @@ X = [0.0, 0.4, 0.5]
 # ````
 # Intuitively we make a small step $s$ into direction $\xi$ using the geodesic
 # $g(\cdot; p,X)$ and from $r=g(s; p,X)$ we follow (in $t$) the geodesic
-# $g(\cdot; r,q)$. The corresponding Jacobi field~$J_{g,X}$
-# along~$g(\cdot; p,q)$ is given by
+# $g(\cdot; r,q)$. The corresponding Jacobi field $J_{g,X}$
+# along $g(\cdot; p,q)$ is given by
 #
 # ````math
 # J_{g,X}(t):=\frac{D}{\partial s}\Gamma_{g,X}(s,t)\Bigl\rvert_{s=0}


### PR DESCRIPTION
I just deleted a spurious dollar sign which prevented the equation from rendering.