### PR TITLE
Create test_NelderMead_Sphere2_consistency.jl

### DIFF
--- a/test/solvers/test_NelderMead_Sphere2_consistency.jl
+++ b/test/solvers/test_NelderMead_Sphere2_consistency.jl
@@ -1,0 +1,54 @@
+# test NelderMead consistency
+# see lead-up discussions at Manopt #65
+
+using Test
+using Manopt, Manifolds
+using Random
+
+
+##
+
+@testset "check NelderMead consistency on Sphere(2)" begin
+
+## build problem (from Manopt docs)
+n = 100
+σ = π / 8
+M = Sphere(2)
+dim = manifold_dimension(M)
+x = 1 / sqrt(2) * [1.0, 0.0, 1.0]
+Random.seed!(42)
+data = [exp(M, x, random_tangent(M, x, Val(:Gaussian), σ)) for i in 1:n]
+
+F(M, y) = sum(1 / (2 * n) * distance.(Ref(M), Ref(y), data) .^ 2)
+
+
+## solve with defined initialization
+xMean1 = NelderMead(M, F, data[1:(dim+1)])
+xMean2 = NelderMead(M, F, data[(dim+2):(2*dim+1)])
+
+@test isapprox(xMean1, xMean2, atol = 1e-2)
+
+## solve with random initialization
+xMean3 = NelderMead(M, F, data[1:(dim+1)])
+xMean4 = NelderMead(M, F, data[1:(dim+1)])
+xMean5 = NelderMead(M, F, data[1:(dim+1)])
+
+@test isapprox(xMean1, xMean3, atol = 1e-2)
+@test isapprox(xMean1, xMean4, atol = 1e-2)
+@test isapprox(xMean1, xMean5, atol = 1e-2)
+
+@test isapprox(xMean2, xMean3, atol = 1e-2)
+@test isapprox(xMean2, xMean4, atol = 1e-2)
+@test isapprox(xMean2, xMean5, atol = 1e-2)
+
+@test isapprox(xMean3, xMean4, atol = 1e-2)
+@test isapprox(xMean3, xMean5, atol = 1e-2)
+
+@test isapprox(xMean4, xMean5, atol = 1e-2)
+
+##
+
+end
+
+
+#

--- a/test/solvers/test_NelderMead_Sphere2_consistency.jl
+++ b/test/solvers/test_NelderMead_Sphere2_consistency.jl
@@ -29,9 +29,9 @@ xMean2 = NelderMead(M, F, data[(dim+2):(2*dim+1)])
 @test isapprox(xMean1, xMean2, atol = 1e-2)
 
 ## solve with random initialization
-xMean3 = NelderMead(M, F, data[1:(dim+1)])
-xMean4 = NelderMead(M, F, data[1:(dim+1)])
-xMean5 = NelderMead(M, F, data[1:(dim+1)])
+xMean3 = NelderMead(M, F)
+xMean4 = NelderMead(M, F)
+xMean5 = NelderMead(M, F)
 
 @test isapprox(xMean1, xMean3, atol = 1e-2)
 @test isapprox(xMean1, xMean4, atol = 1e-2)


### PR DESCRIPTION
Prior discussion at #65 

Hi @kellertuer ,

I noticed that NelderMead produces changing results for the `Sphere(2)` example from the docs.  Thought I'd PR this short test file as MWE (currently failing and not in runtests.jl yet).  Perhaps I'm misunderstanding something about how to use NelderMead in this case, either way hopefully this helps document or debug.

Best,
Dehann

EDIT, PS, although Nelder-Mead mean optimization is contradictory, I think the result should at least be consistent.  So perhaps good as a test, even though computations are being wasted?  Ref: https://github.com/JuliaManifolds/Manopt.jl/pull/65#issuecomment-803257250