### PR TITLE
Projection to the tangent space in the truncated conjugate gradient solver

### DIFF
--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -46,6 +46,14 @@ see the reference:
     random tangent vector. If set to true, no preconditioner will be
     used. This option is set to true in some scenarios to escape saddle
     points, but is otherwise seldom activated.
+* `projection_to_tangent` - projection operation to be applied to each
+     iterate; if it is the projection onto the tangent space, it
+     ensures all iterates stay in the tangent space (otherwise, there
+     can be numerical instabilities which make them leave the tangent
+     space). Default is "do nothing".
+     Format : a function of three parameters `(M,p,X)`, where `M` is
+     the manifold, `p` a point on `M` and `X` the tangent vector; the
+     function must rewrite `X` in place and produce no output.
 * `stopping_criterion` – ([`StopWhenAny`](@ref), [`StopAfterIteration`](@ref),
     [`StopIfResidualIsReducedByFactor`](@ref), [`StopIfResidualIsReducedByPower`](@ref),
     [`StopWhenCurvatureIsNegative`](@ref), [`StopWhenTrustRegionIsExceeded`](@ref) )
@@ -121,12 +129,21 @@ function truncated_conjugate_gradient_descent!(
         StopWhenCurvatureIsNegative(),
         StopWhenModelIncreased(),
     ),
+    projection_to_tangent = (M, p, X) -> (),
     return_options=false,
     kwargs..., #collect rest
 ) where {TF,TG,TH,Tprec}
     p = HessianProblem(M, F, gradF, H, preconditioner; evaluation=evaluation)
     o = TruncatedConjugateGradientOptions(
-        p, x, η, trust_region_radius, randomize; θ=θ, κ=κ, stop=stopping_criterion
+        p,
+        x,
+        η,
+        trust_region_radius,
+        randomize;
+        θ = θ,
+        κ = κ,
+        stop = stopping_criterion,
+        projection_to_tangent = projection_to_tangent,
     )
     o = decorate_options(o; kwargs...)
     resultO = solve(p, o)
@@ -193,6 +210,7 @@ function step_solver!(
     β = zr / o.z_r
     o.z_r = zr
     o.δ = -o.z + β * o.δ
+    o.projection_to_tangent(p.M, o.x, o.δ)
     o.ηPδ = β * (α * o.δPδ + o.ηPδ)
     o.δPδ = o.z_r + β^2 * o.δPδ
     return o

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -32,11 +32,17 @@ For a description of the algorithm and more details see
   random tangent vector. If set to true, no preconditioner will be
   used. This option is set to true in some scenarios to escape saddle
   points, but is otherwise seldom activated.
-* `projection_to_tangent` - projection operation to be applied to each
-     iterate of the inner solver. Default is "do nothing". The other
-     sensitive choice is the projection onto the tangent `(M,p,X) ->
-     project!(M,X,p,X)`, which enforces numerical stability and
-     ensures iterates remain in the tangent space
+* `project_to_tangent!` : projection operation to be applied to each
+     iterate of the inner solver; if it is the projection onto the
+     tangent space, it ensures all iterates stay in the tangent space
+     (otherwise, there can be numerical instabilities which make them
+     leave the tangent space). Default is "do nothing".
+     Format : a function of four parameters `(M,X1,p,X2)`, where `M`
+     is the manifold, `p` a point on `M`, `X2` the inner solver
+     iterate and `X1` a vector to store the projected iterate. The
+     function must rewrite `X1` in place and not output anything (if
+     it does, the output will be ignored). It is recommended to use
+     either the default, or `project_to_tangent! = project!`.
 * `retraction` – (`default_retraction_method(M)`) approximation of the exponential map
 * `stopping_criterion` – ([`StopWhenAny`](@ref)([`StopAfterIteration`](@ref)`(1000)`,
   [`StopWhenGradientNormLess`](@ref)`(10^(-6))`) a functor inheriting
@@ -104,12 +110,12 @@ function trust_regions!(
     max_trust_region_radius=sqrt(manifold_dimension(M)),
     trust_region_radius=max_trust_region_radius / 8,
     randomize::Bool=false,
-    projection_to_tangent=(M,p,X) -> (),
+    project_to_tangent!::Proj=copyto!,
     ρ_prime::Float64=0.1,
     ρ_regularization=1000.0,
     return_options=false,
     kwargs..., #collect rest
-) where {TF,TdF,TH,Tprec}
+) where {TF,TdF,TH,Tprec,Proj}
     (ρ_prime >= 0.25) && throw(
         ErrorException("ρ_prime must be strictly smaller than 0.25 but it is $ρ_prime.")
     )
@@ -134,7 +140,7 @@ function trust_regions!(
         randomize,
         stopping_criterion;
         retraction_method=retraction_method,
-        projection_to_tangent=projection_to_tangent,
+        (project_to_tangent!)=project_to_tangent!,
     )
     o = decorate_options(o; kwargs...)
     resultO = solve(p, o)
@@ -162,7 +168,7 @@ function initialize_solver!(p::HessianProblem, o::TrustRegionsOptions)
         o.η,
         o.trust_region_radius,
         o.randomize;
-        projection_to_tangent = o.projection_to_tangent,
+        (project_to_tangent!)=o.project_to_tangent!,
     )
     return o
 end


### PR DESCRIPTION
This projection can be activated/deactivated through an option
`projection_to_tangent`, in the truncated conjugate gradient
solver and in the trust region solver. By default, I have set
this option to true.

Which function should be used as projection depends on what is
implemented on the manifold. It can be
- the identity (if no projection is defined)
- `project!`
- the composition of `project!` and `embed` if `embed` is
  defined (because the vector to be projected must
  be given to `project!` in "ambient space representation"
  if applicable)

I have found no convenient way to test whether `project!` and
`embed` are defined for a given manifold. I used try/catch
tests, see file hessian_plan.jl.