### PR TITLE
Fix Revise issue reported on Slack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.15"
+version = "0.3.16"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/functions/manifold_functions.jl
+++ b/src/functions/manifold_functions.jl
@@ -69,7 +69,6 @@ Compute the result in `q`.
 
 see also [`reflect`](@ref reflect(M::AbstractManifold, p, x))`(M,p,x)`.
 """
-
 reflect(M::AbstractManifold, pr::Function, x) = reflect(M, pr(x), x)
 reflect!(M::AbstractManifold, q, pr::Function, x) = reflect!(M, q, pr(x), x)
 


### PR DESCRIPTION
Problem that occurs with this empty line:
```julia
julia> using Revise

julia> using Manifolds

julia> using Manopt
[ Info: Precompiling Manopt [0fc0a36d-df90-57f3-8f93-d78a9fc72bb5]
ERROR: InitError: BoundsError: attempt to access 3-element Vector{Any} at index [4]
Stacktrace:
  [1] getindex
    @ ./array.jl:861 [inlined]
  [2] iterate(iter::JuliaInterpreter.ExprSplitter, state::Nothing)
    @ JuliaInterpreter ~/.julia/packages/JuliaInterpreter/DxOBb/src/construct.jl:529
  [3] iterate
    @ ~/.julia/packages/JuliaInterpreter/DxOBb/src/construct.jl:525 [inlined]
  [4] parse_source!(mod_exprs_sigs::OrderedCollections.OrderedDict{Module, OrderedCollections.OrderedDict{Revise.RelocatableExpr, Union{Nothing, Vector{Any}}}}, src::String, filename::String, mod::Module; mode::Symbol)
    @ Revise ~/.julia/packages/Revise/jHTGK/src/parsing.jl:47
  [5] parse_source!
    @ ~/.julia/packages/Revise/jHTGK/src/parsing.jl:39 [inlined]
  [6] parse_source!(mod_exprs_sigs::OrderedCollections.OrderedDict{Module, OrderedCollections.OrderedDict{Revise.RelocatableExpr, Union{Nothing, Vector{Any}}}}, filename::String, mod::Module; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Revise ~/.julia/packages/Revise/jHTGK/src/parsing.jl:27
  [7] parse_source!
    @ ~/.julia/packages/Revise/jHTGK/src/parsing.jl:23 [inlined]
  [8] #parse_source#11
    @ ~/.julia/packages/Revise/jHTGK/src/parsing.jl:10 [inlined]
  [9] parse_source
    @ ~/.julia/packages/Revise/jHTGK/src/parsing.jl:10 [inlined]
 [10] queue_includes!(pkgdata::Revise.PkgData, id::Base.PkgId)
    @ Revise ~/.julia/packages/Revise/jHTGK/src/pkgs.jl:51
 [11] #invokelatest#2
    @ ./essentials.jl:716 [inlined]
 [12] invokelatest
    @ ./essentials.jl:714 [inlined]
 [13] parse_pkg_files(id::Base.PkgId)
    @ Revise ~/.julia/packages/Revise/jHTGK/src/loading.jl:51
 [14] watch_package(id::Base.PkgId)
    @ Revise ~/.julia/packages/Revise/jHTGK/src/pkgs.jl:346
 [15] add_require(sourcefile::String, modcaller::Module, idmod::String, modname::String, expr::Expr)
    @ Revise ~/.julia/packages/Revise/jHTGK/src/pkgs.jl:188
 [16] withnotifications(::Any, ::Vararg{Any})
    @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:70
 [17] (::Manopt.var"#296#299")()
    @ Manopt ~/.julia/packages/Requires/Z8rfN/src/require.jl:106
 [18] listenpkg(f::Any, pkg::Base.PkgId)
    @ Requires ~/.julia/packages/Requires/Z8rfN/src/require.jl:20
 [19] macro expansion
    @ ~/.julia/packages/Requires/Z8rfN/src/require.jl:98 [inlined]
 [20] __init__()
    @ Manopt ~/.julia/dev/Manopt/src/Manopt.jl:110
 [21] _include_from_serialized(path::String, depmods::Vector{Any})
    @ Base ./loading.jl:768
 [22] _require_from_serialized(path::String)
    @ Base ./loading.jl:821
 [23] _require(pkg::Base.PkgId)
    @ Base ./loading.jl:1130
 [24] require(uuidkey::Base.PkgId)
    @ Base ./loading.jl:1013
 [25] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:997
during initialization of module Manopt
```