### PR TITLE
Random point for tangent space

### DIFF
--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -122,6 +122,7 @@ function __init__()
             Stiefel,
             Sphere,
             TangentBundle,
+            TangentSpaceAtPoint,
             FixedRankMatrices,
             SVDMPoint,
             UMVTVector,

--- a/src/helpers/random.jl
+++ b/src/helpers/random.jl
@@ -61,7 +61,7 @@ optional parameter determines the type of the entries of the
 resulting point on the Euclidean space d.
 """
 random_point(M::Euclidean) = randn(representation_size(M))
-random_point(M::Euclidean, ::Val{:Gaussian}, σ=1.0) = σ * randn(manifold_dimension(M))
+random_point(M::Euclidean, ::Val{:Gaussian}, σ=1.0) = σ * randn(representation_size(M))
 
 @doc raw"""
     random_point(M::FixedRankMatrices, options...)
@@ -212,7 +212,7 @@ mean 0 and standard deviation 1.
 random_tangent(::Circle, p, ::Val{:Gaussian}, σ::Real=1.0) = σ * randn()
 
 function random_tangent(M::Euclidean, p, ::Val{:Gaussian}, σ::Float64=1.0)
-    return σ * randn(manifold_dimension(M))
+    return σ * randn(representation_size(M))
 end
 
 @doc raw"""

--- a/src/helpers/random.jl
+++ b/src/helpers/random.jl
@@ -178,6 +178,17 @@ function random_point(M::TangentBundle, options...)
 end
 
 @doc raw"""
+    random_point(M::TangentSpaceAtPoint, options...)
+
+generate a random point in the the tangent space of `M.point` with the
+given `options...`.
+"""
+function random_point(M::TangentSpaceAtPoint, options...)
+    return random_tangent(M.fiber.manifold, M.point, options...)
+end
+
+
+@doc raw"""
     random_tangent(M::AbstractGroupManifold, p, options...)
 
 On an abstract group manifold, the random tangent is taken from the internally stored `M.manifold`s tangent space at `p`.
@@ -359,4 +370,15 @@ function random_tangent(M::TangentBundle, p, options...)
     X = random_tangent(M.manifold, p[M, :point], options...)
     Y = random_tangent(M.manifold, p[M, :point], options...)
     return ProductRepr(X, Y)
+end
+
+@doc raw"""
+    random_tangent(M::TangentSpaceAtPoint, _, options...)
+
+generate a random tangent vector from the tangent space of `M.point`
+with the given `options...`, which is the same as generating a
+point in the tangent space at `M.point`.
+"""
+function random_tangent(M::TangentSpaceAtPoint, _, options...)
+    return random_tangent(M.fiber.manifold, M.point, options...)
 end

--- a/test/helpers/test_random.jl
+++ b/test/helpers/test_random.jl
@@ -2,9 +2,8 @@
     M = Euclidean(3, 5)
     p = random_point(M, :Gaussian, 3.6)
     v = random_tangent(M, p)
-    @test size(p) == (3,5)
-    @test size(v) == (3,5)
-
+    @test size(p) == (3, 5)
+    @test size(v) == (3, 5)
 
     M = Circle()
     p = random_point(M)
@@ -12,39 +11,35 @@
     @test size(p) == ()
     @test size(v) == ()
 
-
     M = FixedRankMatrices(3, 5, 2)
     p = random_point(M)
     v = random_tangent(M, p)
-    @test (size(p.U, 1), size(p.Vt, 2)) == (3,5)
-    @test (size(v.U, 1), size(v.Vt, 2)) == (3,5)
-
+    @test (size(p.U, 1), size(p.Vt, 2)) == (3, 5)
+    @test (size(v.U, 1), size(v.Vt, 2)) == (3, 5)
 
     M = Grassmann(5, 3)
     p = random_point(M, :Gaussian, 3.6)
     v = random_tangent(M, p)
-    @test size(p) == (5,3)
-    @test size(v) == (5,3)
-
+    @test size(p) == (5, 3)
+    @test size(v) == (5, 3)
 
     M = Rotations(5)
     p = random_point(M, :Gaussian, 3.6)
     v = random_tangent(M, p)
-    @test size(p) == (5,5)
-    @test size(v) == (5,5)
-
+    @test size(p) == (5, 5)
+    @test size(v) == (5, 5)
 
     M = SymmetricPositiveDefinite(5)
     p = random_point(M, :Gaussian, 3.6)
     v = random_tangent(M, p)
-    @test size(p) == (5,5)
-    @test size(v) == (5,5)
+    @test size(p) == (5, 5)
+    @test size(v) == (5, 5)
 
     M = Stiefel(5, 3)
     p = random_point(M, :Gaussian, 3.6)
     v = random_tangent(M, p)
-    @test size(p) == (5,3)
-    @test size(v) == (5,3)
+    @test size(p) == (5, 3)
+    @test size(v) == (5, 3)
 
     M = Sphere(5)
     p = random_point(M, :Gaussian, 3.6)
@@ -55,8 +50,8 @@
     M = TangentBundle(Rotations(3))
     p = random_point(M)
     v = random_tangent(M, p)
-    @test size(p[M, :point]) == (3,3)
-    @test size(p[M, :vector]) == (3,3)
-    @test size(v[M, :point]) == (3,3)
-    @test size(v[M, :vector]) == (3,3)
+    @test size(p[M, :point]) == (3, 3)
+    @test size(p[M, :vector]) == (3, 3)
+    @test size(v[M, :point]) == (3, 3)
+    @test size(v[M, :vector]) == (3, 3)
 end

--- a/test/helpers/test_random.jl
+++ b/test/helpers/test_random.jl
@@ -1,0 +1,62 @@
+@testset "random" begin
+    M = Euclidean(3, 5)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (3,5)
+    @test size(v) == (3,5)
+
+
+    M = Circle()
+    p = random_point(M)
+    v = random_tangent(M, p)
+    @test size(p) == ()
+    @test size(v) == ()
+
+
+    M = FixedRankMatrices(3, 5, 2)
+    p = random_point(M)
+    v = random_tangent(M, p)
+    @test (size(p.U, 1), size(p.Vt, 2)) == (3,5)
+    @test (size(v.U, 1), size(v.Vt, 2)) == (3,5)
+
+
+    M = Grassmann(5, 3)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (5,3)
+    @test size(v) == (5,3)
+
+
+    M = Rotations(5)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (5,5)
+    @test size(v) == (5,5)
+
+
+    M = SymmetricPositiveDefinite(5)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (5,5)
+    @test size(v) == (5,5)
+
+    M = Stiefel(5, 3)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (5,3)
+    @test size(v) == (5,3)
+
+    M = Sphere(5)
+    p = random_point(M, :Gaussian, 3.6)
+    v = random_tangent(M, p)
+    @test size(p) == (6,)
+    @test size(v) == (6,)
+
+    M = TangentBundle(Rotations(3))
+    p = random_point(M)
+    v = random_tangent(M, p)
+    @test size(p[M, :point]) == (3,3)
+    @test size(p[M, :vector]) == (3,3)
+    @test size(v[M, :point]) == (3,3)
+    @test size(v[M, :vector]) == (3,3)
+end

--- a/test/helpers/test_random.jl
+++ b/test/helpers/test_random.jl
@@ -54,4 +54,14 @@
     @test size(p[M, :vector]) == (3, 3)
     @test size(v[M, :point]) == (3, 3)
     @test size(v[M, :vector]) == (3, 3)
+
+
+    R = Rotations(4)
+    p = random_point(R)
+    M = TangentSpace(R, p)
+    tp = random_point(M)
+    tv = random_tangent(M, tp)
+    @test size(tp) == (4,4)
+    @test size(tv) == (4,4)
+    @test is_point(M, tp) && is_point(M, tv)
 end


### PR DESCRIPTION
I wrote a `random_point()` and `random_tangent()` function for the `TangentSpaceAtPoint` manifolds. Both are pretty straightforward, as they both simply call `random_tangent()` for the original manifold. Let me know if you think that could be a useful contribution.