### PR TITLE
Introduce a stop_step fallback for backtracking-type line searches and a corresponding stopping criterion

### DIFF
--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -289,7 +289,7 @@ export StopIfResidualIsReducedByFactor,
     StopWhenTrustRegionIsExceeded,
     StopWhenModelIncreased
 export StopAfterIteration, StopWhenChangeLess, StopWhenGradientNormLess, StopWhenCostLess
-export StopAfter, StopWhenAll, StopWhenAny
+export StopWhenStepSizeLess, StopAfter, StopWhenAll, StopWhenAny
 export get_active_stopping_criteria, get_stopping_criteria, get_reason
 export are_these_stopping_critera_active
 export StoppingCriterion, StoppingCriterionSet, Stepsize

--- a/src/plans/nonmutating_manifolds_plans.jl
+++ b/src/plans/nonmutating_manifolds_plans.jl
@@ -19,7 +19,8 @@ function linesearch_backtrack(
     contract,
     retr::AbstractRetractionMethod=ExponentialRetraction(),
     η::T=-gradF,
-    f0=F(x),
+    f0=F(x);
+    stop_step=0.0,
 ) where {TF,T}
     x_new = retract(M, x, s * η, retr)
     fNew = F(x_new)
@@ -33,6 +34,7 @@ function linesearch_backtrack(
         s = contract * s
         x_new = retract(M, x, s * η, retr)
         fNew = F(x_new)
+        (s < stop_step) && break
     end
     return s
 end

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -116,9 +116,11 @@ mutable struct ArmijoLinesearch{TRM<:AbstractRetractionMethod} <: Linesearch
         r::AbstractRetractionMethod=ExponentialRetraction(),
         contractionFactor::Float64=0.95,
         sufficientDecrease::Float64=0.1,
-        linesearch_stopsize::Float64 = 0.0,
+        linesearch_stopsize::Float64=0.0,
     )
-        return new{typeof(r)}(s, r, contractionFactor, sufficientDecrease, s, linesearch_stopsize)
+        return new{typeof(r)}(
+            s, r, contractionFactor, sufficientDecrease, s, linesearch_stopsize
+        )
     end
 end
 function (a::ArmijoLinesearch)(
@@ -134,14 +136,14 @@ function (a::ArmijoLinesearch)(
         a.contractionFactor,
         a.retraction_method,
         η;
-        stop = a.linesearch_stopsize,
+        stop_step=a.linesearch_stopsize,
     )
     return a.stepsizeOld
 end
 get_initial_stepsize(a::ArmijoLinesearch) = a.initialStepsize
 
 @doc raw"""
-    linesearch_backtrack(M, F, x, gradFx, s, decrease, contract, retr, η = -gradFx, f0 = F(x); stop=0.)
+    linesearch_backtrack(M, F, x, gradFx, s, decrease, contract, retr, η = -gradFx, f0 = F(x); stop_step=0.)
 
 perform a linesearch for
 * a manifold `M`
@@ -154,7 +156,7 @@ perform a linesearch for
 * a `retr`action, which defaults to the `ExponentialRetraction()`
 * a search direction ``η = -\operatorname{grad}F(x)``
 * an offset, ``f_0 = F(x)``
-* a keyword `stop` as a minimal step size when to stop
+* a keyword `stop_step` as a minimal step size when to stop
 """
 function linesearch_backtrack(
     M::AbstractManifold,
@@ -167,7 +169,7 @@ function linesearch_backtrack(
     retr::AbstractRetractionMethod=ExponentialRetraction(),
     η::T=-gradFx,
     f0=F(x);
-    min_step=0.0
+    stop_step=0.0,
 ) where {TF,T}
     xNew = retract(M, x, s * η, retr)
     fNew = F(xNew)
@@ -181,7 +183,7 @@ function linesearch_backtrack(
         s = contract * s
         retract!(M, xNew, x, s * η, retr)
         fNew = F(xNew)
-        (s < min_step) && break
+        (s < stop_step) && break
     end
     return s
 end
@@ -415,7 +417,7 @@ function (a::NonmonotoneLinesearch)(
         a.retraction_method,
         η,
         maximum([a.old_costs[j] for j in 1:min(iter, memory_size)]);
-        stop = a.linesearch_stopsize
+        stop_step=a.linesearch_stopsize,
     )
     return a.initial_stepsize
 end

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -543,7 +543,7 @@ Then with
 
 ```math
 A(t) = f(x_+) ≤ c_1 t ⟨\operatorname{grad}f(x), η⟩_{x}
-\quad\text{and}\quad 
+\quad\text{and}\quad
 W(t) = ⟨\operatorname{grad}f(x_+), \text{V}_{x_+\gets x}η⟩_{x_+} ≥ c_2 ⟨η, \operatorname{grad}f(x)⟩_x,
 ```
 

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -60,9 +60,7 @@ mutable struct DecreasingStepsize <: Stepsize
     subtrahend::Float64
     exponent::Float64
     shift::Int
-    function DecreasingStepsize(
-        l::Real=1.0, f::Real=1.0, a::Real=0.0, e::Real=1.0, s::Int=0
-    )
+    function DecreasingStepsize(l::Real, f::Real=1.0, a::Real=0.0, e::Real=1.0, s::Int=0)
         return new(l, f, a, e, s)
     end
 end

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -99,7 +99,6 @@ function (c::StopWhenChangeLess)(p::P, o::O, i::Int) where {P<:Problem,O<:Option
     return false
 end
 
-
 """
     StopWhenStepsizeLess <: StoppingCriterion
 

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -98,6 +98,36 @@ function (c::StopWhenChangeLess)(p::P, o::O, i::Int) where {P<:Problem,O<:Option
     c.storage(p, o, i)
     return false
 end
+
+
+"""
+    StopWhenStepsizeLess <: StoppingCriterion
+
+stores a threshold when to stop looking at the last step size determined or found
+during the last iteration from within a [`Options`](@ref).
+
+# Constructor
+
+    StopWhenStepsizeLess(ε)
+
+initialize the stopping criterion to a threshold `ε`.
+"""
+mutable struct StopWhenStepSizeLess <: StoppingCriterion
+    threshold::Float64
+    reason::String
+    function StopWhenStepSizeLess(ε::Float64)
+        return new(ε)
+    end
+end
+function (c::StopWhenStepSizeLess)(p::P, o::O, i::Int) where {P<:Problem,O<:Options}
+    s = get_last_stepsize(p, o)
+    if s < c.threshold && i > 0
+        c.reason = "The algorithm computed a step size ($s) less than $(c.threshold).\n"
+        return true
+    end
+    return false
+end
+
 @doc raw"""
     StopWhenAll <: StoppingCriterion
 

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -115,11 +115,11 @@ mutable struct StopWhenStepSizeLess <: StoppingCriterion
     threshold::Float64
     reason::String
     function StopWhenStepSizeLess(ε::Float64)
-        return new(ε)
+        return new(ε, "")
     end
 end
 function (c::StopWhenStepSizeLess)(p::P, o::O, i::Int) where {P<:Problem,O<:Options}
-    s = get_last_stepsize(p, o)
+    s = get_last_stepsize(p, o, i)
     if s < c.threshold && i > 0
         c.reason = "The algorithm computed a step size ($s) less than $(c.threshold).\n"
         return true

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -85,7 +85,7 @@ end
     o = GradientDescentOptions(1.0)
     s1 = StopWhenStepSizeLess(0.5)
     @test !s1(p, o, 1)
-    @test sr.reason == ""
+    @test s1.reason == ""
     o.stepsize = ConstantStepsize(0.25)
     @test s1(p, o, 2)
     @test length(s1.reason) > 0

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -79,3 +79,14 @@ end
     @test s2(p, o, 1)
     @test length(s2.reason) > 0
 end
+
+@testset "Stop with step size" begin
+    p = GradientProblem(Euclidean(1), (M, x) -> x^2, x -> 2x)
+    o = GradientDescentOptions(1.0)
+    s1 = StopWhenStepSizeLess(0.5)
+    @test !s1(p, o, 1)
+    @test sr.reason == ""
+    o.stepsize = ConstantStepsize(0.25)
+    @test s1(p, o, 2)
+    @test length(s1.reason) > 0
+end


### PR DESCRIPTION
Based on an idea by @const-ae this PR introduces
* a `stop_step` fallback in the `linesearch_backtrack` to avoid too small steps; which is now an option in `Armijo` and `Nonmonotone` linesearches (as `linesearch_stopsize`). 
to also safely end an algorithm then, this PR also introduces `StopWhenStepsizeLess`.

* [x] check code coverage
