### PR TITLE
Introduce a default to warn about ConstantStepsize in gradient_descent

### DIFF
--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -375,7 +375,7 @@ export DebugGradient, DebugGradientNorm, DebugStepsize
 export DebugPrimalBaseChange, DebugPrimalBaseIterate, DebugPrimalChange, DebugPrimalIterate
 export DebugDualBaseChange, DebugDualBaseIterate, DebugDualChange, DebugDualIterate
 export DebugDualResidual, DebugPrimalDualResidual, DebugPrimalResidual
-export DebugProximalParameter
+export DebugProximalParameter, DebugWarnIfCostIncreases
 export DebugGradient, DebugGradientNorm, DebugStepsize
 #
 # Records - and access functions

--- a/src/plans/debug_options.jl
+++ b/src/plans/debug_options.jl
@@ -407,7 +407,7 @@ function (d::DebugWarnIfCostIncreases)(p::Problem, o::Options, i::Int)
                 d.status = :No
             end
         else
-            d.old_cost = min(d.old_cost,cost)
+            d.old_cost = min(d.old_cost, cost)
         end
     end
     return nothing

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -89,7 +89,7 @@ the negative gradient.
 abstract type Linesearch <: Stepsize end
 
 @doc raw"""
-    ArmijoLineseach <: Linesearch
+    ArmijoLinesearch <: Linesearch
 
 A functor representing Armijo line seach including the last runs state, i.e. a
 last step size.

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -69,6 +69,7 @@ function gradient_descent!(
     retraction_method::AbstractRetractionMethod=default_retraction_method(M),
     stopping_criterion::StoppingCriterion=StopAfterIteration(200) |
                                           StopWhenGradientNormLess(10.0^-8),
+    debug=[DebugWarnIfCostIncreases()],
     direction=IdentityUpdateRule(),
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     return_options=false,
@@ -83,7 +84,7 @@ function gradient_descent!(
         direction=direction,
         retraction_method=retraction_method,
     )
-    o = decorate_options(o; kwargs...)
+    o = decorate_options(o; debug=debug, kwargs...)
     resultO = solve(p, o)
     if return_options
         return resultO

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -202,5 +202,12 @@ using Manopt, Manifolds, Test
         @test_logs (:warn,) (:warn,) gradient_descent(
             M, F, gradF, 1 / sqrt(2) .* [1.0, -1.0, 0.0]
         )
+        @test_logs (:warn,) (:warn,) (warn,) gradient_descent(
+            M,
+            F,
+            gradF,
+            1 / sqrt(2) .* [1.0, -1.0, 0.0];
+            debug=[DebugWarnIfCostIncreases(:Once)],
+        )
     end
 end

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -202,7 +202,7 @@ using Manopt, Manifolds, Test
         @test_logs (:warn,) (:warn,) gradient_descent(
             M, F, gradF, 1 / sqrt(2) .* [1.0, -1.0, 0.0]
         )
-        @test_logs (:warn,) (:warn,) (warn,) gradient_descent(
+        @test_logs (:warn,) (:warn,) (:warn,) gradient_descent(
             M,
             F,
             gradF,


### PR DESCRIPTION
While ConstantStepsize is an easy start, it might not converge.
To avoid users being confused by increasing values, now a default debug is introduced warning about this.
As soon as a user specifies an own debug, this message vanishes, assuming, that the user knows the details by then.

The warning might also be nice in gerneal to check for increasing cost functions when using heuristic optimisers.