### PR TITLE
Make types of retraction and VT in line searches constant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.31"
+version = "0.3.32"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -559,9 +559,11 @@ For the old (deprecated) signature the `linesearch_stopsize` is set to the old h
         linesearch_stopsize = 0.0
     )
 """
-mutable struct WolfePowellLinesearch <: Linesearch
-    retraction_method::AbstractRetractionMethod
-    vector_transport_method::AbstractVectorTransportMethod
+mutable struct WolfePowellLinesearch{
+    TRM<:AbstractRetractionMethod,VTM<:AbstractVectorTransportMethod
+} <: Linesearch
+    retraction_method::TRM
+    vector_transport_method::VTM
     c1::Float64
     c2::Float64
     last_stepsize::Float64
@@ -590,7 +592,7 @@ mutable struct WolfePowellLinesearch <: Linesearch
         ),
         linesearch_stopsize::Float64=0.0,
     )
-        return new(
+        return new{typeof(retraction_method),typeof(vector_transport_method)}(
             retraction_method, vector_transport_method, c1, c2, 0.0, linesearch_stopsize
         )
     end
@@ -701,9 +703,11 @@ new signature including `M`, for the first it is set to the old default of `1e-9
     > Dissertation, Flordia State University, 2014.
     > [pdf](https://www.math.fsu.edu/~whuang2/pdf/Huang_W_Dissertation_2013.pdf)
 """
-mutable struct WolfePowellBinaryLinesearch <: Linesearch
-    retraction_method::AbstractRetractionMethod
-    vector_transport_method::AbstractVectorTransportMethod
+mutable struct WolfePowellBinaryLinesearch{
+    TRM<:AbstractRetractionMethod,VTM<:AbstractVectorTransportMethod
+} <: Linesearch
+    retraction_method::TRM
+    vector_transport_method::VTM
     c1::Float64
     c2::Float64
     last_stepsize::Float64
@@ -732,7 +736,7 @@ mutable struct WolfePowellBinaryLinesearch <: Linesearch
         ),
         linesearch_stopsize::Float64=0.0,
     )
-        return new(
+        return new{typeof(retraction_method),typeof(vector_transport_method)}(
             retraction_method, vector_transport_method, c1, c2, 0.0, linesearch_stopsize
         )
     end


### PR DESCRIPTION
As discussed on Slack.