### PR TITLE
Take adjoint of `Q` rather than transpose

### DIFF
--- a/src/helpers/random.jl
+++ b/src/helpers/random.jl
@@ -135,7 +135,7 @@ function random_point(
 ) where {N}
     D = Diagonal(1 .+ rand(N)) # random diagonal matrix
     s = qr(σ * randn(N, N)) # random q
-    return Matrix(Symmetric(s.Q * D * transpose(s.Q)))
+    return Matrix(Symmetric(s.Q * D * s.Q'))
 end
 
 @doc raw"""


### PR DESCRIPTION
This came up in a nanosoldier run in https://github.com/JuliaLang/julia/pull/46196. Transposes of Q's don't have specialized functions and fall back to `AbstractMatrix` methods, in particular in multiplication. Generic multiplication, however, is defined in terms of elementwise `getindex`, which is expensive and very slow in contrast to dense or structured matrices.