### PR TITLE
Fix StopWhenChangeLess for Particle Swarm.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.35"
+version = "0.3.36"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -34,6 +34,7 @@ import ManifoldsBase:
     DefaultOrthonormalBasis,
     ExponentialRetraction,
     LogarithmicInverseRetraction,
+    NestedPowerRepresentation,
     ParallelTransport,
     PowerManifold,
     AbstractManifold,

--- a/src/functions/adjoint_differentials.jl
+++ b/src/functions/adjoint_differentials.jl
@@ -365,6 +365,8 @@ function adjoint_differential_forward_logs!(
     N = PowerManifold(M.manifold, TPR(), power_size..., d)
     R = CartesianIndices(Tuple(power_size))
     maxInd = last(R).I
+    # since we add things in Y, make sure we start at zero.
+    zero_vector!(M, Y, p)
     for i in R # iterate over all pixel
         for k in 1:d # for all direction combinations
             I = [i.I...] # array of index

--- a/src/plans/particle_swarm_plan.jl
+++ b/src/plans/particle_swarm_plan.jl
@@ -8,7 +8,7 @@ Describes a particle swarm optimizing algorithm, with
 
 # Fields
 
-* `x0` – a set of points (of type `AbstractVector{P}`) on a manifold as initial particle positions
+* `x` – a set of points (of type `AbstractVector{P}`) on a manifold as initial particle positions
 * `velocity` – a set of tangent vectors (of type `AbstractVector{T}`) representing the velocities of the particles
 * `inertia` – (`0.65`) the inertia of the patricles
 * `social_weight` – (`1.4`) a social weight factor
@@ -23,7 +23,7 @@ Describes a particle swarm optimizing algorithm, with
 
     ParticleSwarmOptions(M, x0, velocity; kawrgs...)
 
-construct a particle swarm Option for the manifold `M` starting at point `x0` with velocities `x0`,
+construct a particle swarm Option for the manifold `M` starting at initial population `x0` with velocities `x0`,
 where the manifold is used within the defaults of the other fields mentioned above,
 which are keyword arguments here.
 

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -97,16 +97,17 @@ mutable struct StopWhenChangeLess <: StoppingCriterion
         return new(ε, "", a)
     end
 end
-function (c::StopWhenChangeLess)(p::P, o::O, i::Int) where {P<:Problem,O<:Options}
+function (c::StopWhenChangeLess)(P::Problem, O::Options, i)
     if has_storage(c.storage, :x)
-        xOld = get_storage(c.storage, :x)
-        if distance(p.M, o.x, xOld) < c.threshold && i > 0
-            c.reason = "The algorithm performed a step with a change ($(distance(p.M, o.x, xOld))) less than $(c.threshold).\n"
-            c.storage(p, o, i)
+        x_old = get_storage(c.storage, :x)
+        d = distance(P.M, O.x, x_old)
+        if d < c.threshold && i > 0
+            c.reason = "The algorithm performed a step with a change ($d) less than $(c.threshold).\n"
+            c.storage(P, O, i)
             return true
         end
     end
-    c.storage(p, o, i)
+    c.storage(P, O, i)
     return false
 end
 

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -184,7 +184,7 @@ function (c::StopWhenChangeLess)(P::CostProblem, O::ParticleSwarmOptions, i)
     if has_storage(c.storage, :x)
         x_old = get_storage(c.storage, :x)
         n = length(O.x)
-        d = distance(P.M^n, O.x, x_old)
+        d = distance(PowerManifold(P.M, NestedPowerRepresentation(), n), O.x, x_old)
         if d < c.threshold && i > 0
             c.reason = "The algorithm performed a step with a change ($d in the population) less than $(c.threshold).\n"
             c.storage(P, O, i)

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -8,9 +8,11 @@ The aim of PSO is to find the particle position ``g`` on the `Manifold M` that s
 ```
 To this end, a swarm of particles is moved around the `Manifold M` in the following manner.
 For every particle ``k`` we compute the new particle velocities ``v_k^{(i)}`` in every step ``i`` of the algorithm by
+
 ```math
 v_k^{(i)} = ω \, \operatorname{T}_{x_k^{(i)}\gets x_k^{(i-1)}}v_k^{(i-1)} + c \,  r_1  \operatorname{retr}_{x_k^{(i)}}^{-1}(p_k^{(i)}) + s \,  r_2 \operatorname{retr}_{x_k^{(i)}}^{-1}(g),
 ```
+
 where ``x_k^{(i)}`` is the current particle position, ``ω`` denotes the inertia,
 ``c`` and ``s`` are a cognitive and a social weight, respectively,
 ``r_j``, ``j=1,2`` are random factors which are computed new for each particle and step,
@@ -18,15 +20,19 @@ where ``x_k^{(i)}`` is the current particle position, ``ω`` denotes the inertia
 ``\operatorname{T}`` is a vector transport.
 
 Then the position of the particle is updated as
+
 ```math
 x_k^{(i+1)} = \operatorname{retr}_{x_k^{(i)}}(v_k^{(i)}),
 ```
+
 where ``\operatorname{retr}`` denotes a retraction on the `Manifold` `M`. At the end of each step for every particle, we set
+
 ```math
 p_k^{(i+1)} = \begin{cases}
 x_k^{(i+1)},  & \text{if } F(x_k^{(i+1)})<F(p_{k}^{(i)}),\\
 p_{k}^{(i)}, & \text{else,}
 \end{cases}
+
 ```
 and
 ```math
@@ -80,6 +86,7 @@ function particle_swarm(
     x_res = copy.(Ref(M), x0)
     return particle_swarm!(M, F; n=n, x0=x_res, kwargs...)
 end
+
 @doc raw"""
     patricle_swarm!(M, F; n=100, x0::AbstractVector=[random_point(M) for i in 1:n], kwargs...)
 
@@ -168,3 +175,22 @@ function step_solver!(p::CostProblem, o::ParticleSwarmOptions, iter)
     end
 end
 get_solver_result(o::ParticleSwarmOptions) = o.g
+
+#
+# Change not only refers to different iterates (x=the whole population)
+# but also lives in the power manifold on M, so we have to adapt StopWhenChangeless
+#
+function (c::StopWhenChangeLess)(P::CostProblem, O::ParticleSwarmOptions, i)
+    if has_storage(c.storage, :x)
+        x_old = get_storage(c.storage, :x)
+        n = length(O.x)
+        d = distance(P.M^n, O.x, x_old)
+        if d < c.threshold && i > 0
+            c.reason = "The algorithm performed a step with a change ($d in the population) less than $(c.threshold).\n"
+            c.storage(P, O, i)
+            return true
+        end
+    end
+    c.storage(P, O, i)
+    return false
+end

--- a/test/functions/test_adjoint_differentials.jl
+++ b/test/functions/test_adjoint_differentials.jl
@@ -39,7 +39,7 @@ using Manifolds, Manopt, Test, ManifoldsBase
     @test norm(Mp, pP, ZP - [-X, zero_vector(M, p), zero_vector(M, p)]) ≈ 0 atol =
         4 * 10.0^(-16)
     adjoint_differential_forward_logs!(Mp, YP, pP, XP)
-    @test isapprox(Mp, pP, YP, ZP; atol=4 * 10.0^(-16))
+    @test isapprox(Mp, pP, YP, ZP)
     ZP = [[0.0, π / 2, 0.0], [0.0, 0.0, 0.0], [π / 2, 0.0, 0.0]]
     @test adjoint_differential_log_argument(Mp, pP, qP, XP) == ZP
     adjoint_differential_log_argument!(Mp, YP, pP, qP, XP)


### PR DESCRIPTION
Fixes two bugs:

As noticed in JuliaManifolds/Manifolds.jl#514 the particle swarm StopWhenChangeLess assumed implicitly that  M also works as its power manifold (which until that PR Euclidean did). This is now fixed

The sometimes randomly failing test on adjoint forward logarithm is fixed by initialising the in-place variable `Y` to zero since in these elements we add effects. Without that initialisation the computation fails if you pass NaN (in the test) or any nonzero vector (in general).