### PR TITLE
Custom inverse retraction for `StopWhenChangeLess`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.36"
+version = "0.3.37"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -100,7 +100,7 @@ end
 function (c::StopWhenChangeLess)(P::Problem, O::Options, i)
     if has_storage(c.storage, :x)
         x_old = get_storage(c.storage, :x)
-        d = distance(P.M, O.x, x_old)
+        d = distance(P.M, O.x, x_old, default_inverse_retraction_method(P.M))
         if d < c.threshold && i > 0
             c.reason = "The algorithm performed a step with a change ($d) less than $(c.threshold).\n"
             c.storage(P, O, i)


### PR DESCRIPTION
One small change so that `StopWhenChangeLess` can be used on, for example, tangent bundles.