### PR TITLE
Fix two minor bugs in Quasi Newton

### DIFF
--- a/src/functions/bezier_curves.jl
+++ b/src/functions/bezier_curves.jl
@@ -144,16 +144,14 @@ the control points `B`, either a vector of segments of controlpoints.
 """
 function get_bezier_junction_tangent_vectors(
     M::AbstractManifold, B::AbstractVector{<:BezierSegment}
-) where {P}
+)
     return cat(
         [[log(M, b.pts[1], b.pts[2]), log(M, b.pts[end], b.pts[end - 1])] for b in B]...,
         ;
         dims=1,
     )
 end
-function get_bezier_junction_tangent_vectors(
-    M::AbstractManifold, b::BezierSegment
-) where {P,N}
+function get_bezier_junction_tangent_vectors(M::AbstractManifold, b::BezierSegment)
     return get_bezier_junction_tangent_vectors(M, [b])
 end
 

--- a/src/plans/quasi_newton_plan.jl
+++ b/src/plans/quasi_newton_plan.jl
@@ -306,7 +306,9 @@ used with any update rule for the direction.
         M::AbstractManifold,
         x;
         initial_vector=zero_vector(M,x),
-        direction_update=InverseBFGS(),
+        direction_update::D=QuasiNewtonLimitedMemoryDirectionUpdate(M, x, InverseBFGS(), 20;
+            vector_transport_method=vector_transport_method,
+        )
         stopping_criterion=StopAfterIteration(1000) | StopWhenGradientNormLess(1e-6),
         retraction_method::RM=default_retraction_method(M),
         vector_transport_method::VTM=default_vector_transport_method(M),
@@ -339,10 +341,12 @@ function QuasiNewtonOptions(
     M::AbstractManifold,
     x::P;
     initial_vector::T=zero_vector(M, x),
-    direction_update::U=InverseBFGS(),
+    vector_transport_method::VTM=default_vector_transport_method(M),
+    direction_update::D=QuasiNewtonLimitedMemoryDirectionUpdate(
+        M, x, InverseBFGS, 20; vector_transport_method=vector_transport_method
+    ),
     stopping_criterion::SC=StopAfterIteration(1000) | StopWhenGradientNormLess(1e-6),
     retraction_method::RM=default_retraction_method(M),
-    vector_transport_method::VTM=default_vector_transport_method(M),
     stepsize::S=WolfePowellLinesearch(
         M;
         retraction_method=retraction_method,
@@ -352,13 +356,13 @@ function QuasiNewtonOptions(
 ) where {
     P,
     T,
-    U<:AbstractQuasiNewtonDirectionUpdate,
+    D<:AbstractQuasiNewtonDirectionUpdate,
     SC<:StoppingCriterion,
     S<:Stepsize,
     RM<:AbstractRetractionMethod,
     VTM<:AbstractVectorTransportMethod,
 }
-    return QuasiNewtonOptions{P,T,U,SC,S,RM,VTM}(
+    return QuasiNewtonOptions{P,T,D,SC,S,RM,VTM}(
         x,
         initial_vector,
         copy(M, initial_vector),

--- a/src/plans/quasi_newton_plan.jl
+++ b/src/plans/quasi_newton_plan.jl
@@ -321,7 +321,7 @@ used with any update rule for the direction.
 mutable struct QuasiNewtonOptions{
     P,
     T,
-    U<:AbstractQuasiNewtonDirectionUpdate,
+    D<:AbstractQuasiNewtonDirectionUpdate,
     SC<:StoppingCriterion,
     S<:Stepsize,
     RTR<:AbstractRetractionMethod,
@@ -331,7 +331,7 @@ mutable struct QuasiNewtonOptions{
     gradient::T
     sk::T
     yk::T
-    direction_update::U
+    direction_update::D
     retraction_method::RTR
     stepsize::S
     stop::SC
@@ -362,11 +362,12 @@ function QuasiNewtonOptions(
     RM<:AbstractRetractionMethod,
     VTM<:AbstractVectorTransportMethod,
 }
-    return QuasiNewtonOptions{P,T,D,SC,S,RM,VTM}(
+    sk_init = zero_vector(M, x)
+    return QuasiNewtonOptions{P,typeof(sk_init),D,SC,S,RM,VTM}(
         x,
         initial_vector,
-        copy(M, initial_vector),
-        copy(M, initial_vector),
+        sk_init,
+        copy(M, sk_init),
         direction_update,
         retraction_method,
         stepsize,

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -127,11 +127,12 @@ function quasi_Newton!(
 
     p = GradientProblem(M, F, gradF; evaluation=evaluation)
     o = QuasiNewtonOptions(
-        x,
-        get_gradient(p, x),
-        local_dir_upd,
-        stopping_criterion,
-        stepsize;
+        M,
+        x;
+        initial_vector=get_gradient(p, x),
+        direction_update=local_dir_upd,
+        stopping_criterion=stopping_criterion,
+        stepsize=stepsize,
         retraction_method=retraction_method,
         vector_transport_method=vector_transport_method,
     )


### PR DESCRIPTION
Switch the call in the QN solver to use the new interface (with more default values) and fix a bug in these.
Also fixes a bug, where after a copy a to specialised type was used (to be precise when copy introduces arrays from SubArrays).