### PR TITLE
Introduce memory efficient versions for ALM and Huber-EPM

### DIFF
--- a/src/solvers/augmented_Lagrangian_method.jl
+++ b/src/solvers/augmented_Lagrangian_method.jl
@@ -16,11 +16,11 @@ where ``μ^{(k-1)} \in \mathbb R^n`` and ``λ^{(k-1)} \in \mathbb R^m`` are the 
 
 The Lagrange multipliers are then updated by
 ```math
-λ_j^{(k)} =\operatorname{clip}_{[λ_{\min},λ_{\max}]} (λ_j^{(k-1)} + ρ^{(k-1)} h_j(x^{(k)})) \text{for all} j=1,…,p,
+λ_j^{(k)} =\operatorname{clip}_{[λ_{\min},λ_{\max}]} (λ_j^{(k-1)} + ρ^{(k-1)} h_j(x^{(k)})) \text{for all} j=1,…,p,
 ```
 and
 ```math
-μ_i^{(k)} =\operatorname{clip}_{[0,μ_{\max}]} (μ_i^{(k-1)} + ρ^{(k-1)} g_i(x^{(k)})) \text{for all}  i=1,…,m,
+μ_i^{(k)} =\operatorname{clip}_{[0,μ_{\max}]} (μ_i^{(k-1)} + ρ^{(k-1)} g_i(x^{(k)})) \text{ for all } i=1,…,m,
 ```
 where ``λ_{\min} \leq λ_{\max}`` and ``μ_{\max}`` are the multiplier boundaries.
 
@@ -82,6 +82,7 @@ the obtained (approximate) minimizer ``x^*``, see [`get_solver_return`](@ref) fo
     > C. Liu, N. Boumal, __Simple Algorithms for Optimization on Riemannian Manifolds with Constraints__,
     > In: Applied Mathematics & Optimization, vol 82, 949–981 (2020),
     > doi [10.1007/s00245-019-09564-3](https://doi.org/10.1007/s00245-019-09564-3),
+    > arXiv: [1901.10000](https://arxiv.org/abs/1901.10000)
     > Matlab source: [https://github.com/losangle/Optimization-on-manifolds-with-extra-constraints](https://github.com/losangle/Optimization-on-manifolds-with-extra-constraints)
 """
 function augmented_Lagrangian_method(

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -44,6 +44,7 @@ where ``θ_ρ \in (0,1)`` is a constant scaling factor.
     > C. Liu, N. Boumal, __Simple Algorithms for Optimization on Riemannian Manifolds with Constraints__,
     > In: Applied Mathematics & Optimization, vol 82, 949–981 (2020),
     > doi [10.1007/s00245-019-09564-3](https://doi.org/10.1007/s00245-019-09564-3),
+    > arXiv: [1901.10000](https://arxiv.org/abs/1901.10000).
     > Matlab source: [https://github.com/losangle/Optimization-on-manifolds-with-extra-constraints](https://github.com/losangle/Optimization-on-manifolds-with-extra-constraints)
 
 # Input


### PR DESCRIPTION
Here the gradient elements are only evaluated if necessary to spare computational time and memory. WE might still have to check code coverage – and a tutorial will check the improvements (but only be part of a next PR after this is registered).