### PR TITLE
add a missing evaluation= keyword to the mutating variant of CG.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.44"
+version = "0.3.45"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/solvers/conjugate_gradient_descent.jl
+++ b/src/solvers/conjugate_gradient_descent.jl
@@ -77,6 +77,7 @@ function conjugate_gradient_descent!(
     gradF::TDF,
     x;
     coefficient::DirectionUpdateRule=ConjugateDescentCoefficient(),
+    evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     stepsize::Stepsize=ConstantStepsize(M),
     retraction_method::AbstractRetractionMethod=default_retraction_method(M),
     stopping_criterion::StoppingCriterion=StopWhenAny(
@@ -85,7 +86,7 @@ function conjugate_gradient_descent!(
     vector_transport_method=default_vector_transport_method(M),
     kwargs...,
 ) where {TF,TDF}
-    p = GradientProblem(M, F, gradF)
+    p = GradientProblem(M, F, gradF; evaluation=evaluation)
     X = zero_vector(M, x)
     o = ConjugateGradientDescentOptions(
         M,


### PR DESCRIPTION
This is a quick bugfix, since the `evaluation=`keyword was documented for, but missing in CG.