### PR TITLE
Don't allocate initial_operator for L-BFGS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.3.50"
+version = "0.3.51"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -82,8 +82,12 @@ function quasi_Newton!(
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     memory_size::Int=20,
     stabilize=true,
-    initial_operator::AbstractMatrix=Matrix{Float64}(
-        I, manifold_dimension(M), manifold_dimension(M)
+    initial_operator::AbstractMatrix=(
+        if memory_size >= 0
+            fill(1.0, 0, 0) # don't allocate initial_operator for limited memory operation
+        else
+            Matrix{Float64}(I, manifold_dimension(M), manifold_dimension(M))
+        end
     ),
     scale_initial_operator::Bool=true,
     stepsize::Stepsize=WolfePowellLinesearch(


### PR DESCRIPTION
It can be very large for high-dimensional manifolds.