### PR TITLE
Stepsize limiting on some manifolds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/plans/cache.jl
+++ b/src/plans/cache.jl
@@ -70,7 +70,7 @@ function get_gradient(M::AbstractManifold, sco::SimpleCacheObjective, p)
         copyto!(M, sco.p, p)
         sco.X_valid = true
     end
-    return sco.X
+    return copy(M, p, sco.X)
 end
 function get_gradient!(M::AbstractManifold, X, sco::SimpleCacheObjective, p)
     scop_neq_p = sco.p != p
@@ -130,7 +130,7 @@ function get_gradient(
         sco.X_valid = true
         sco.c_valid = true
     end
-    return sco.X
+    return copy(M, p, sco.X)
 end
 function get_gradient(
     M::AbstractManifold,

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -611,10 +611,10 @@ function (a::WolfePowellLinesearch)(
     max_step = max_stepsize(M, cur_p)
     # max_step_increase is the upper limit for s_plus
     max_step_increase = ifelse(isfinite(max_step), min(1e9, max_step / grad_norm), 1e9)
-    step = ifelse(isfinite(max_step), min(1.0, max_step / (2*grad_norm)), 1.0)
+    step = ifelse(isfinite(max_step), min(1.0, max_step / (2 * grad_norm)), 1.0)
     s_plus = step
     s_minus = step
-    
+
     f0 = get_cost(mp, cur_p)
     p_new = retract(M, cur_p, step * η, a.retraction_method)
     fNew = get_cost(mp, p_new)

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -165,7 +165,7 @@ end
 """
     update_stopping_criterion!(c::StopWhenChangeLess, :MinIterateChange, v::Int)
 
-Update the minimal change blow which an algorithm shall stop.
+Update the minimal change below which an algorithm shall stop.
 """
 function update_stopping_criterion!(c::StopWhenChangeLess, ::Val{:MinIterateChange}, v)
     c.threshold = v


### PR DESCRIPTION
Solves issue https://github.com/JuliaManifolds/Manopt.jl/discussions/191 . Also fixes cache exposing internal state when accessing gradient.

For now I've only applied the limiting step size to `WolfePowellLinesearch` but if you think this a good thing I can apply  this change to other methods as well.