### PR TITLE
Max stepsize on tangent bundle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/functions/manifold_functions.jl
+++ b/src/functions/manifold_functions.jl
@@ -1,3 +1,15 @@
+
+"""
+    max_stepsize(M::TangentBundle, p)
+
+Tangent bundle has injectivity radius of either infinity (for flat manifolds) or 0
+(for non-flat manifolds). This makes a guess of what a reasonable maximum stepsize
+on a tangent bundle might be.
+"""
+function max_stepsize(M::TangentBundle, p)
+    return max_stepsize(M.manifold, p[M, :point])
+end
+
 """
     mid_point(M, p, q, x)
     mid_point!(M, y, p, q, x)

--- a/test/functions/test_manifold.jl
+++ b/test/functions/test_manifold.jl
@@ -60,4 +60,24 @@ Random.seed!(42)
         @test mid_point(M, p, q, -1.0) ≈ -π / 2
         @test mid_point(M, 0, π / 2) ≈ π / 4
     end
+
+    @testset "max_stepsize" begin
+        M = Sphere(2)
+        TM = TangentBundle(M)
+        TTM = TangentBundle(TM)
+
+        R3 = Euclidean(3)
+        TR3 = TangentBundle(R3)
+        p = [0.0, 1.0, 0.0]
+        X = [0.0, 0.0, 0.0]
+
+        @test Manopt.max_stepsize(M, p) == π
+        @test Manopt.max_stepsize(TM, ArrayPartition(p, X)) == π
+        @test Manopt.max_stepsize(
+            TTM, ArrayPartition(ArrayPartition(p, X), ArrayPartition(X, X))
+        ) == π
+
+        @test Manopt.max_stepsize(R3, p) == Inf
+        @test Manopt.max_stepsize(TR3, ArrayPartition(p, X)) == Inf
+    end
 end


### PR DESCRIPTION
I've done this parallel to https://github.com/JuliaManifolds/Manifolds.jl/pull/567 because that change doesn't resolve the underlying issue of needing a good guess for maximum stepsize. This change should be reasonable and hopefully fix the tutorial docs.