### PR TITLE
Faster storage handling

### DIFF
--- a/src/plans/conjugate_gradient_plan.jl
+++ b/src/plans/conjugate_gradient_plan.jl
@@ -175,7 +175,9 @@ function (u::DaiYuanCoefficient)(
         update_storage!(u.storage, cgs) # if not given store current as old
         return 0.0
     end
-    p_old, X_old, δ_old = get_storage.(Ref(u.storage), [:Iterate, :gradient, :δ])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
+    δ_old = get_storage(u.storage, :δ)
     update_storage!(u.storage, cgs)
 
     gradienttr = vector_transport_to(M, p_old, X_old, cgs.p, u.transport_method)
@@ -221,10 +223,11 @@ function (u::FletcherReevesCoefficient)(
     amp::AbstractManoptProblem, cgs::ConjugateGradientDescentState, i
 )
     M = get_manifold(amp)
-    if !all(has_storage.(Ref(u.storage), [:Iterate, :gradient]))
+    if !has_storage(u.storage, :Iterate) || !has_storage(u.storage, :gradient)
         update_storage!(u.storage, cgs) # if not given store current as old
     end
-    p_old, X_old = get_storage.(Ref(u.storage), [:Iterate, :gradient])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
     update_storage!(u.storage, cgs)
     return inner(M, cgs.p, cgs.X, cgs.X) / inner(M, p_old, X_old, X_old)
 end
@@ -284,7 +287,9 @@ function (u::HagerZhangCoefficient)(
         update_storage!(u.storage, cgs) # if not given store current as old
         return 0.0
     end
-    p_old, X_old, δ_old = get_storage.(Ref(u.storage), [:Iterate, :gradient, :δ])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
+    δ_old = get_storage(u.storage, :δ)
     update_storage!(u.storage, cgs)
 
     gradienttr = vector_transport_to(M, p_old, X_old, cgs.p, u.transport_method)
@@ -355,7 +360,9 @@ function (u::HestenesStiefelCoefficient)(
         update_storage!(u.storage, cgs) # if not given store current as old
         return 0.0
     end
-    p_old, X_old, δ_old = get_storage.(Ref(u.storage), [:Iterate, :gradient, :δ])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
+    δ_old = get_storage(u.storage, :δ)
     update_storage!(u.storage, cgs)
     gradienttr = vector_transport_to(M, p_old, X_old, cgs.p, u.transport_method)
     δtr = vector_transport_to(M, p_old, δ_old, cgs.p, u.transport_method)
@@ -418,7 +425,9 @@ function (u::LiuStoreyCoefficient)(
     if !all(has_storage.(Ref(u.storage), [:Iterate, :gradient, :δ]))
         update_storage!(u.storage, cgs) # if not given store current as old
     end
-    p_old, X_old, δ_old = get_storage.(Ref(u.storage), [:Iterate, :gradient, :δ])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
+    δ_old = get_storage(u.storage, :δ)
     update_storage!(u.storage, cgs)
     gradienttr = vector_transport_to(M, p_old, X_old, cgs.p, u.transport_method)
     ν = cgs.X - gradienttr # notation y from [HZ06]
@@ -485,7 +494,8 @@ function (u::PolakRibiereCoefficient)(
     if !all(has_storage.(Ref(u.storage), [:Iterate, :gradient]))
         update_storage!(u.storage, cgs) # if not given store current as old
     end
-    p_old, X_old = get_storage.(Ref(u.storage), [:Iterate, :gradient])
+    p_old = get_storage(u.storage, :Iterate)
+    X_old = get_storage(u.storage, :gradient)
     update_storage!(u.storage, cgs)
 
     gradienttr = vector_transport_to(M, p_old, X_old, cgs.p, u.transport_method)

--- a/src/plans/solver_state.jl
+++ b/src/plans/solver_state.jl
@@ -223,17 +223,20 @@ mutable struct StoreStateAction <: AbstractStateAction
     end
 end
 function (a::StoreStateAction)(
-    ::AbstractManoptProblem, s::AbstractManoptSolverState, i::Int
+    amp::AbstractManoptProblem, s::AbstractManoptSolverState, i::Int
 )
     #update values (maybe only once)
     if !a.once || a.last_stored != i
         for key in a.keys
-            if hasproperty(s, key)
-                merge!(a.values, Dict{Symbol,Any}(key => deepcopy(getproperty(s, key))))
-            elseif key == :Iterate
-                merge!(a.values, Dict{Symbol,Any}(key => deepcopy(get_iterate(s))))
-            elseif key == :Gradient
-                merge!(a.values, Dict{Symbol,Any}(key => deepcopy(get_gradient(s))))
+            if key === :Iterate
+                M = get_manifold(amp)
+                a.values[key] = copy(M, get_iterate(s))
+            elseif key === :Gradient
+                M = get_manifold(amp)
+                p = get_iterate(s)
+                a.values[key] = copy(M, p, get_gradient(s))
+            elseif hasproperty(s, key)
+                a.values[key] = deepcopy(getproperty(s, key))
             end
         end
     end
@@ -257,31 +260,28 @@ return whether the [`AbstractStateAction`](@ref) `a` has a value stored at the
 has_storage(a::AbstractStateAction, key) = haskey(a.values, key)
 
 """
-    update_storage!(a,o)
+    update_storage!(a, s)
 
 update the [`AbstractStateAction`](@ref) `a` internal values to the ones given on
-the [`AbstractManoptSolverState`](@ref) `o`.
+the [`AbstractManoptSolverState`](@ref) `s`.
 """
 function update_storage!(a::AbstractStateAction, s::AbstractManoptSolverState)
-    return update_storage!(
-        a, Dict(key => if key === :Iterate
-            get_iterate(s)
+    for key in a.keys
+        if key === :Iterate
+            a.values[key] = deepcopy(get_iterate(s))
+        elseif key === :gradient
+            a.values[key] = deepcopy(get_gradient(s))
         else
-            (
-                if key === :gradient
-                    deepcopy(get_gradient(s))
-                else
-                    deepcopy(getproperty(s, key))
-                end
-            )
-        end for key in a.keys)
-    )
+            a.values[key] = deepcopy(getproperty(s, key))
+        end
+    end
+    return a.keys
 end
 
 """
-    update_storage!(a,o)
+    update_storage!(a, d)
 
-update the [`AbstractStateAction`](@ref) `a` internal values to the ones given in
+Update the [`AbstractStateAction`](@ref) `a` internal values to the ones given in
 the dictionary `d`. The values are merged, where the values from `d` are preferred.
 """
 function update_storage!(a::AbstractStateAction, d::Dict{Symbol,<:Any})


### PR DESCRIPTION
This takes runtime of the Rosenbrock example from https://github.com/JuliaManifolds/Manifolds.jl/issues/569 from about 80 us to 30 us. A few points:
1. Some places use `:gradient`, while other use `:Gradient`. I think this should be unified because I couldn't figure out which should be used where.
2. This kind of broadcast: `p_old, X_old, δ_old = get_storage.(Ref(u.storage), [:Iterate, :gradient, :δ])` is quite slow at the timescale of Rosenbrock and has a perfectly fine alternative :wink: .
3. I'm not sure why you avoided `a.values[key] = new_value` but it works and is faster than merging a new dictionary.
4. It would be nice to reduce the usage of `deepcopy` in storage code but it's a fairly ambitious goal and not a big issue.
5. The old code missed one `deepcopy` so this PR is likely also a bugfix.