### PR TITLE
fix the inner products used in TCG

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.16] - 18/04/2023
+
+### Fixed
+
+* the inner products used in `truncated_gradient_descent` now also work thoroughly on complex
+  matrix manifolds
+
 ## [0.4.15] - 13/04/2023
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.15"
+version = "0.4.16"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"


### PR DESCRIPTION
in order to handle complex manifolds correctly, some inner products need an additional `real` since some numerical imprecision might lead to small imaginary perturbations.