### PR TITLE
Implement check Hessian.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,8 +14,6 @@ Manifolds = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 ManifoldsBase = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 Manopt = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
-PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 using Documenter: DocMeta, HTML, MathJax3, deploydocs, makedocs
-using Manopt, Manifolds
+using Manopt, Manifolds, Plots
 
 generated_path = joinpath(@__DIR__, "src")
 base_url = "https://github.com/JuliaManifolds/Manopt.jl/blob/master/"

--- a/docs/src/helpers/checks.md
+++ b/docs/src/helpers/checks.md
@@ -12,4 +12,5 @@ Pages   = ["checks.jl"]
 ```@autodocs
 Modules = [Manopt]
 Pages   = ["check_plots.jl"]
+Private = true
 ```

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -513,5 +513,5 @@ export RecordDualBaseChange, RecordDualBaseIterate, RecordDualChange, RecordDual
 export RecordProximalParameter
 #
 # Helpers
-export check_gradient, check_differential
+export check_gradient, check_differential, check_Hessian
 end

--- a/src/helpers/check_plots.jl
+++ b/src/helpers/check_plots.jl
@@ -1,11 +1,12 @@
 """
 plot_slope(x, y; slope=2, line_base=0, a=0, b=2.0, i=1,j=length(x))
 
-plot the result from the [`check_gradient`](@ref)
+plot the result from the error check functions, e.g.
+[`check_gradient`](@ref), [`check_differential`](@ref), [`check_Hessian`](@ref)
 on data `x,y` with two comparison lines
 
-1) `line_base`+ t`slope`  as the goal the plot should have
-2) `a`+ `b`t` on the interval [`x[i]`, `x[j]`] for some (best fitting) comparison slope
+1) `line_base` + t`slope`  as the global slope the plot should have
+2) `a` + `b*t` on the interval [`x[i]`, `x[j]`] for some (best fitting) comparison slope
 """
 function plot_slope(x, y; slope=2, line_base=0, a=0, b=2.0, i=1, j=length(x))
     fig = plot(
@@ -19,7 +20,9 @@ function plot_slope(x, y; slope=2, line_base=0, a=0, b=2.0, i=1, j=length(x))
         color=:lightblue,
     )
     s_line = [exp10(line_base + t * slope) for t in log10.(x)]
-    plot!(fig, x, s_line; label="slope s=2", linestyle=:dash, color=:black, linewidth=2)
+    plot!(
+        fig, x, s_line; label="slope s=$slope", linestyle=:dash, color=:black, linewidth=2
+    )
     if (i != 0) && (j != 0)
         best_line = [exp10(a + t * b) for t in log10.(x[i:j])]
         plot!(

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -213,7 +213,7 @@ no plot will be generated,
 
 # Keyword arguments
 
-* `check_gradient`   – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
+* `check_grad`   – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
 * `check_linearity`  – (`true`) check whether the Hessian is linear, see [`is_Hessian_linear`](@ref) using `a`, `b`, `X`, and `Y`
 * `check_symmetry`   – (`true`) check whether the Hessian is symmetric, see [`is_Hessian_symmetric`](@ref)
 * `check_vector`     – (`true`) check whether ``\operatorname{Hess} f(p)[X]``  \in T_p\mathcal M`` using `is_vector`.
@@ -271,6 +271,7 @@ function check_Hessian(
         if !check_gradient(
             M, f, grad_f, p, X; gradient=gradient, throw_error=throw_error, io=io, kwargs...
         )
+            return false
         end
     end
     check_vector && (!is_vector(M, p, Hessian, throw_error) && return false)

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -9,7 +9,7 @@ no plot will be generated,
 
 # Keyword arguments
 
-* `eaxctness_tol` - (`1e3*eps(eltype(errors))`) is all errors are below this tolerance, the check is considered to be exact
+* `exactness_tol` - (`1e3*eps(eltype(errors))`) is all errors are below this tolerance, the check is considered to be exact
 * `io` – (`nothing`) provide an `IO` to print the check result to
 * `name` (`"differntial"`) – name to display in the check (e.g. if checking gradient)
 * `plot`- (`false`) whether to plot the resulting check (if `Plots.jl` is loaded). The plot is in log-log-scale. This is returned and can then also be saved.
@@ -26,12 +26,12 @@ function prepare_check_result(
     plot=false,
     throw_error=false,
     window=nothing,
-    eaxctness_tol=1e3 * eps(eltype(errors)),
+    exactness_tol=1e3 * eps(eltype(errors)),
 )
-    if max(errors...) < eaxctness_tol
+    if max(errors...) < exactness_tol
         (io !== nothing) && print(
             io,
-            "All errors are below the exactness tolerance $(eaxctness_tol). Your check can be considered exact, hence there is no use to cheeck for a slope.\n",
+            "All errors are below the exactness tolerance $(exactness_tol). Your check can be considered exact, hence there is no use to cheeck for a slope.\n",
         )
         return true
     end
@@ -128,7 +128,7 @@ function check_differential(
         log_range,
         abs.(costs .- linearized),
         2.0;
-        eaxctness_tol=eaxctness_tol,
+        exactness_tol=exactness_tol,
         io=io,
         name=name,
         plot=plot,
@@ -318,7 +318,7 @@ function check_Hessian(
         log_range,
         abs.(costs .- linearized),
         3.0;
-        eaxctness_tol=eaxctness_tol,
+        exactness_tol=exactness_tol,
         io=io,
         name="Hessian",
         plot=plot,

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -7,14 +7,14 @@ This implements the method described in Section 4.8 [^Boumal2022].
 
 # Keyword arguments
 
-* `N` (`101`) – number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
-* `throw_error` - (`false`) throw an error message if the gradient is wrong
 * `io` – (`nothing`) provide an `IO` to print the check result to
 * `limits` (`(1e-8,1)`) specify the limits in the `log_range`
 * `log_range` (`range(limits[1], limits[2]; length=N)`) - specify the range of points (in log scale) to sample the gradient line
+* `N` (`101`) – number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
 * `plot`- (`false`) whether to plot the resulting check (if `Plots.jl` is loaded). The plot is in log-log-scale. This is returned and can then also be saved.
 * `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
 * `slope_tol` – (`0.1`) tolerance for the slope (global) of the approximation
+* `throw_error` - (`false`) throw an error message if the gradient is wrong
 
 Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
 
@@ -66,39 +66,245 @@ function check_differential(
     # otherwise
     # find best contiguous window of length w
     (ab, bb, ib, jb) = find_best_slope_window(x, y, window; slope_tol=slope_tol)
-    msg = "You gradient fits best on [$(T[ib]),$(T[jb])] with slope  $(@sprintf("%.4f", bb)), but globally your slope $(@sprintf("%.4f", b)) is outside of the tolerance 2 ± $(slope_tol).\n"
+    msg = "The Gradient/Differential fits best on [$(T[ib]),$(T[jb])] with slope  $(@sprintf("%.4f", bb)), but globally your slope $(@sprintf("%.4f", b)) is outside of the tolerance 2 ± $(slope_tol).\n"
     (io !== nothing) && print(io, msg)
-    throw_error && throw(ErrorException(msg))
     plot && return plot_slope(T[L .> 0], L[L .> 0]; line_base=L[1], a=ab, b=bb, i=ib, j=jb)
+    throw_error && throw(ErrorException(msg))
     return false
 end
 
 @doc raw"""
     check_gradient(M, F, gradF, p=rand(M), X=rand(M; vector_at=p); kwargs...)
 
-Check numerivcally whether the gradient `gradF(M,p)` of `F(M,p)` is correct.
+Check numerivcally whether the gradient `gradF(M,p)` of `F(M,p)` is correct, that is whether
 
-This implements the method described in Section 4.8 [^Boumal2022].
 
-Its keyword arguments are the same as for the [`check_differential`](@ref) and Additionally
+```math
+f(\operatorname{retr}_p(tX)) = f(p) + t⟨\operatorname{grad} f(p), X⟩ + \mathcal O(t^2)
+```
 
-* `check_vector` _ (`true`) whether or not to check that the gradient is a tangent vector.
+or in other words, that the error between the function ``f`` and its first order Taylor
+behaves in error ``\mthcal O(t^2)``, which indicates that the gradient is correct,
+cf. also Section 4.8 [^Boumal2022].
+
+# Keyword arguments
+
+* `check_vector` – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M`` using `is_vector`.
+* `io` – (`nothing`) provide an `IO` to print the check result to
+* `gradient` - (`grad_f(M, p)`) instead of the gradient _function_ you can also provide the gradient at `p` directly
+* `N` (`101`) – number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
+* `limits` (`(1e-8,1)`) specify the limits in the `log_range`
+* `log_range` (`range(limits[1], limits[2]; length=N)`) - specify the range of points (in log scale) to sample the gradient line
+* `plot`- (`false`) whether to plot the resulting check (if `Plots.jl` is loaded). The plot is in log-log-scale. This is returned and can then also be saved.
+* `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
+* `slope_tol` – (`0.1`) tolerance for the slope (global) of the approximation
+* `throw_error` - (`false`) throw an error message if the gradient is wrong
+
+Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
+
 """
 function check_gradient(
     M::AbstractManifold,
-    F,
-    gradF,
+    f,
+    grad_f,
     p=rand(M),
     X=rand(M; vector_at=p);
+    gradient = grad_f(M,p),
     check_vector=true,
     throw_error=false,
     kwargs...,
 )
-    gradient = gradF(M, p)
-    check_vector && is_vector(M, p, gradient, throw_error;)
+    check_vector && ( !is_vector(M, p, gradient, throw_error;) && return false )
     # function for the directional derivative - real so it also works on complex manifolds
     df(M, p, Y) = real(inner(M, p, gradient, Y))
-    return check_differential(M, F, df, p, X; throw_error=throw_error, kwargs...)
+    return check_differential(M, f, df, p, X; throw_error=throw_error, kwargs...)
+end
+
+@doc raw"""
+    check_Hessian(M, f, grad_f, Hess_f, p=rand(M), X=rand(M; vector_at=p), Y=rand(M, vector_at=p); kwargs...)
+
+Check numerivcally whether the Hessian `{operatorname{Hess} f(M,p, X)` of `f(M,p)` is correct.
+
+For this we require either a second-order retraction or a critical point ``p`` of `f`.
+
+given that we know  that is whether
+
+```math
+f(\operatorname{retr}_p(tX)) = f(p) + t⟨\operatorname{grad} f(p), X⟩ + \mathcal O(t^2)
+```
+
+or in other words, that the error between the function ``f`` and its first order Taylor
+behaves in error ``\mthcal O(t^2)``, which indicates that the gradient is correct,
+cf. also Section 4.8 [^Boumal2022].
+
+# Keyword arguments
+
+* `check_gradient` – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
+* `check_vector` – (`true`) check whether ``\operatorname{Hess} f(p)[X]``  \in T_p\mathcal M`` using `is_vector`.
+* `check_symmetry` – (`true`) check whether TODO
+* `check_linearity` – (`true`) check whether TODO
+* `check_mode` (`:Default`) specify the mode, by default we assume to have a second order retraction given by `retraction_method=`
+  you can also this method if you already _have_ a cirtical point `p`.
+  Set to `:CritalPoint` to use [`gradient_descent`](@ref) to find a critical point.
+  Note: This requires (and evaluates) new tangent vectors `X` and `Y`
+
+* `a`, `b` – two real values to check linearity of the Hessian (if `check_linearity=true`)
+* `N` (`101`) – number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
+* `io` – (`nothing`) provide an `IO` to print the check result to
+* `gradient`          - (`grad_f(M, p)`) instead of the gradient _function_ you can also provide the gradient at `p` directly
+* `Hessian`           - (`Hess_f(M,p)`) instead of the Hessian _function_ you can provide the result of `\operatorname{Hess} f(p)[X]` directly.
+  Note that evaluations of the Hessian might still be necessary for checking linearity and symmetry.
+* `limits`            - (`(1e-8,1)`) specify the limits in the `log_range`
+* `log_range`         - (`range(limits[1], limits[2]; length=N)`) specify the range of points (in log scale) to sample the gradient line
+* `N`                 - (`101`) number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
+* `plot`              - (`false`) whether to plot the resulting check (if `Plots.jl` is loaded). The plot is in log-log-scale. This is returned and can then also be saved.
+* `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
+* `slope_tol`         – (`0.1`) tolerance for the slope (global) of the approximation
+* `throw_error`       - (`false`) throw an error message if the gradient is wrong
+* `Y` (``)
+Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
+"""
+function check_Hessian(
+    M::AbstractManifold,
+    f,
+    grad_f,
+    Hess_f,
+    p=rand(M),
+    X=rand(M; vector_at=p),
+    Y=rand(M; vector_at=p);
+    a = randn(),
+    b = randn(),
+    check_gradient=true,
+    io::Union{IO,Nothing}=nothing,
+    gradient = grad_f(M, p),
+    Hessian = Hess_f(M, p, X),
+    limits=(-8.0, 0.0),
+    log_range=range(limits[1], limits[2]; length=N),
+    mode::Symbol=:Default,
+    N=101,
+    plot=false,
+    retraction_method=default_retraction_method(M, typeof(p)),
+    slope_tol=0.1,
+    throw_error=false,
+    window=nothing,
+    kwargs...,
+)
+    if chech_gradient
+        if !check_gradient(M, f, grad_f, p, X; gradient=gradient, throw_error=throw_error, kwargs...)
+            return false
+        end
+    end
+    check_vector && ( !is_vector(M, f, p, Hessian; throw_error=throw_error) && return false )
+    if check_linearity
+        if !check_Hessian_linearity(M, Hess_f, p, X, Y, a, b; throw_error=throw_error, kwargs...)
+            return false
+        end
+    end
+    if check_symmetry
+        if !check_Hessian_symmetry(M, Hess_f, p, X, Y; throw_error=throw_error, kwargs...)
+            return false
+        end
+    end
+    if mode===:CriticalPoint # find a critical point and update grad, hess and X
+        p = gradient_descent(M, f, grad_f, p)
+        gradient = grad_f(M, p)
+        Hessian = Hess_f(M, p, X)
+        X=rand(M; vector_at=p)
+    end
+    #
+    # slope check
+    X_n = X ./ norm(M, p, X) # normalize tangent direction
+    Hessian_n = Hessian ./ norm(M, p, X)
+    # function for the directional derivative
+    #
+    T = exp10.(log_range)
+    # points p_i to evaluate our error function at
+    points = map(t -> retract(M, p, Xn, t, retraction_method), T)
+    # F(p_i)
+    costs = [F(M, pi) for pi in points]
+    # linearized
+    linearized = map(
+        t -> F(M, p) + t * real(inner(M, p, gradient, X_n)) + t^2/2 * real(inner(M, p, Hessian_n, X_n)),
+        T
+    )
+    L = abs.(costs .- linearized)
+    # global fit a + bx
+    x = log_range[L .> 0]
+    y = log10.(L[L .> 0])
+    (a, b) = find_best_slope_window(x, y, length(x); slope=3.0)[1:2]
+    if isapprox(b, 3.0; atol=slope_tol)
+        plot && return plot_slope(
+            T[L .> 0], L[L .> 0]; line_base=L[1], a=a, b=b, i=1, j=length(y)
+        )
+        (io !== nothing) && print(
+            io,
+            "The Hessianss slope is globally $(@sprintf("%.4f", b)), so within 3 ± $(slope_tol).\n",
+        )
+        return true
+    end
+    # otherwise
+    # find best contiguous window of length w
+    (ab, bb, ib, jb) = find_best_slope_window(x, y, window; slope_tol=slope_tol)
+    msg = "The Hessian fits best on [$(T[ib]),$(T[jb])] with slope  $(@sprintf("%.4f", bb)), but globally your slope $(@sprintf("%.4f", b)) is outside of the tolerance 3 ± $(slope_tol).\n"
+    (io !== nothing) && print(io, msg)
+    plot && return plot_slope(T[L .> 0], L[L .> 0]; line_base=L[1], a=ab, b=bb, i=ib, j=jb)
+    throw_error && throw(ErrorException(msg))
+    return false
+end
+
+@doc raw"""
+    check_Hessian_linearity(M, Hess_f, p,
+    X=rand(M; vector_at=p), Y=rand(M; vector_at=p), a=randn(), b=randn();
+    throw_error=false, kwargs...
+)
+
+Check whether the Hessian function `Hess_f` fulfills linearity, i.e. that
+
+```math
+\operatorname{Hess} f(p)[aX + bY] = b\operatorname{Hess} f(p)[X]
+ + b\operatorname{Hess} f(p)[Y]
+```
+
+which is checked using `isapptox` and the `kwargs...` are passed to this function.
+
+# Optional Arguments
+* `throw_error`       - (`false`) throw an error message if the gradient is wrong
+
+"""
+function check_Hessian_linearity(M, Hess_f, p, X=rand(M; vector_at=p), Y=rand(M; vector_at=p),
+    a = randn(), b = randn(); throw_error=false, kwargs...)
+    Z1 = Hess_f(M, p, a*X + b*Y)
+    Z2 = a*Hess_f(M, p, X) + b*Hess_f(M, p, Y)
+    return isapprox(M, p, Z1, Z2; error = throw_error ? :error : :none, kwargs...)
+end
+
+
+@doc raw"""
+    check_Hessian_symmetry(M, Hess_f, p=rand(M), X=rand(M; vector_at=p), Y=rand(M; vector_at=p);
+    throw_error=false, atol::Real=0, rtol::Real=atol>0 ? 0 : √eps
+)
+
+Check whether the Hessian function `Hess_f` fulfills symetry, i.e. that
+
+```math
+⟨\operatorname{Hess} f(p)[X], Y⟩ = ⟨X, \operatorname{Hess} f(p)[Y]⟩
+```
+
+which is checked using `isapptox` and the `kwargs...` are passed to this function.
+
+# Optional Arguments
+
+* `atol`, `rtol` - with the same defaults as the usual `isapprox`
+* `throw_error` - (`false`) throw an error message if the gradient is wrong
+"""
+function check_Hessian_symmetry(M, Hess_f, p=rand(M), X=rand(M; vector_at=p), Y=rand(M; vector_at=p);
+    throw_error=false, atol::Real=0, rtol::Real=atol>0 ? 0 : √eps, kwargs...)
+    a = inner(M, p, Hess_f(M, p, X), Y)
+    b = inner(M, p, X, Hess_f(M, p, Y))
+    isapprox(a,b; atol=atol, rtol=rtol) && (return true)
+    m = "Hess f seems to not be symmetric: ⟨Hess f(p)[X], Y⟩ = $a != $b = ⟨Hess f(p)[Y], X⟩"
+    throw_error && throw(ErrorException(m))
+    return false
 end
 
 """

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -79,12 +79,12 @@ no plot will be generated,
 
 # Keyword arguments
 
-* `eaxctness_tol` - (`1e-12`) is all errors are below this tolerance, the check is considered to be exact
+* `exactness_tol` - (`1e-12`) if all errors are below this tolerance, the check is considered to be exact
 * `io` – (`nothing`) provide an `IO` to print the check result to
 * `limits` (`(1e-8,1)`) specify the limits in the `log_range`
 * `log_range` (`range(limits[1], limits[2]; length=N)`) - specify the range of points (in log scale) to sample the gradient line
 * `N` (`101`) – number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
-* `name` (`"differntial"`) – name to display in the check (e.g. if checking gradient)
+* `name` (`"differential"`) – name to display in the check (e.g. if checking gradient)
 * `plot`- (`false`) whether to plot the resulting check (if `Plots.jl` is loaded). The plot is in log-log-scale. This is returned and can then also be saved.
 * `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
 * `slope_tol` – (`0.1`) tolerance for the slope (global) of the approximation
@@ -102,7 +102,7 @@ function check_differential(
     dF,
     p=rand(M),
     X=rand(M; vector_at=p);
-    eaxctness_tol=1e-12,
+    exactness_tol=1e-12,
     io::Union{IO,Nothing}=nothing,
     limits=(-8.0, 0.0),
     N=101,
@@ -153,12 +153,12 @@ behaves in error ``\mathcal O(t^2)``, which indicates that the gradient is corre
 cf. also Section 4.8 [^Boumal2022].
 
 Note that if the errors are below the given tolerance and the method is exact,
-no plot will be generated,
+no plot will be generated.
 
 # Keyword arguments
 
 * `check_vector`      – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M`` using `is_vector`.
-* `eaxctness_tol`     - (`1e-12`) is all errors are below this tolerance, the check is considered to be exact
+* `exactness_tol`     - (`1e-12`) if all errors are below this tolerance, the check is considered to be exact
 * `io`                – (`nothing`) provide an `IO` to print the check result to
 * `gradient`          - (`grad_f(M, p)`) instead of the gradient _function_ you can also provide the gradient at `p` directly
 * `limits`            - (`(1e-8,1)`) specify the limits in the `log_range`
@@ -209,14 +209,14 @@ behaves in error ``\mathcal O(t^3)``, which indicates that the gradient is corre
 cf. also Section 6.8 [^Boumal2022].
 
 Note that if the errors are below the given tolerance and the method is exact,
-no plot will be generated,
+no plot will be generated.
 
 # Keyword arguments
 
 * `check_grad`   – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
 * `check_linearity`  – (`true`) check whether the Hessian is linear, see [`is_Hessian_linear`](@ref) using `a`, `b`, `X`, and `Y`
 * `check_symmetry`   – (`true`) check whether the Hessian is symmetric, see [`is_Hessian_symmetric`](@ref)
-* `check_vector`     – (`true`) check whether ``\operatorname{Hess} f(p)[X]``  \in T_p\mathcal M`` using `is_vector`.
+* `check_vector`     – (`true`) check whether ``\operatorname{Hess} f(p)[X] \in T_p\mathcal M`` using `is_vector`.
 * `mode`             - (`:Default`) specify the mode, by default we assume to have a second order retraction given by `retraction_method=`
   you can also this method if you already _have_ a cirtical point `p`.
   Set to `:CritalPoint` to use [`gradient_descent`](@ref) to find a critical point.
@@ -224,10 +224,10 @@ no plot will be generated,
 
 * `a`, `b`            – two real values to check linearity of the Hessian (if `check_linearity=true`)
 * `N`                 - (`101`) number of points to check within the `log_range` default range ``[10^{-8},10^{0}]``
-* `eaxctness_tol`     - (`1e-12`) is all errors are below this tolerance, the check is considered to be exact
+* `exactness_tol`     - (`1e-12`) if all errors are below this tolerance, the check is considered to be exact
 * `io`                – (`nothing`) provide an `IO` to print the check result to
 * `gradient`          - (`grad_f(M, p)`) instead of the gradient _function_ you can also provide the gradient at `p` directly
-* `Hessian`           - (`Hess_f(M,p)`) instead of the Hessian _function_ you can provide the result of ``\operatorname{Hess} f(p)[X]``` directly.
+* `Hessian`           - (`Hess_f(M, p, X)`) instead of the Hessian _function_ you can provide the result of ``\operatorname{Hess} f(p)[X]`` directly.
   Note that evaluations of the Hessian might still be necessary for checking linearity and symmetry and/or when using `:CriticalPoint` mode.
 * `limits`            - (`(1e-8,1)`) specify the limits in the `log_range`
 * `log_range`         - (`range(limits[1], limits[2]; length=N)`) specify the range of points (in log scale) to sample the gradient line
@@ -252,7 +252,7 @@ function check_Hessian(
     check_vector=true,
     check_symmetry=true,
     check_linearity=true,
-    eaxctness_tol=1e-12,
+    exactness_tol=1e-12,
     io::Union{IO,Nothing}=nothing,
     gradient=grad_f(M, p),
     Hessian=Hess_f(M, p, X),

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -89,8 +89,8 @@ no plot will be generated,
 * `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
 * `slope_tol` – (`0.1`) tolerance for the slope (global) of the approximation
 * `throw_error` - (`false`) throw an error message if the gradient is wrong
-
-Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
+* `window` – (`nothing`) specify window sizes within the `log_range` that are used for the slope estimation.
+  the default is, to use all window sizes `2:N`.
 
 [^Boumal2022]:
     > Boumal, N.: _An Introduction to Optimization on Smooth Manifolds_, book in preparation, 2022.
@@ -168,8 +168,9 @@ no plot will be generated.
 * `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
 * `slope_tol`         – (`0.1`) tolerance for the slope (global) of the approximation
 * `throw_error`       - (`false`) throw an error message if the gradient is wrong
+* `window` – (`nothing`) specify window sizes within the `log_range` that are used for the slope estimation.
+  the default is, to use all window sizes `2:N`.
 
-Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
 
 """
 function check_gradient(
@@ -236,7 +237,8 @@ no plot will be generated.
 * `retraction_method` - (`default_retraction_method(M, typeof(p))`) retraction method to use for the check
 * `slope_tol`         – (`0.1`) tolerance for the slope (global) of the approximation
 * `throw_error`       - (`false`) throw an error message if the gradient is wrong
-Note that `throw_error` disables returning the plot, so better use `io=stdout` if you would like to see the message together with the plot.
+* `window` – (`nothing`) specify window sizes within the `log_range` that are used for the slope estimation.
+  the default is, to use all window sizes `2:N`.
 """
 function check_Hessian(
     M::AbstractManifold,

--- a/test/helpers/test_checks.jl
+++ b/test/helpers/test_checks.jl
@@ -2,26 +2,81 @@ using Manifolds, Manopt, Plots, Test
 # don't show plots actually
 default(; show=false, reuse=true)
 
-@testset "Test Gradient checks" begin
-    M = Sphere(10)
-    q = zeros(11)
-    q[1] = 1.0
-    p = zeros(11)
-    p[1:4] .= 1 / sqrt(4)
-    r = log(M, p, q)
+@testset "Numerical Check functions" begin
+    @testset "Test Gradient checks" begin
+        M = Sphere(10)
+        q = zeros(11)
+        q[1] = 1.0
+        p = zeros(11)
+        p[1:4] .= 1 / sqrt(4)
+        X = log(M, p, q)
 
-    f(M, p) = 1 / 2 * distance(M, p, q)^2
-    grad_f(M, p) = -log(M, p, q)
+        f(M, p) = 1 / 2 * distance(M, p, q)^2
+        grad_f(M, p) = -log(M, p, q)
 
-    @test check_gradient(M, f, grad_f, p, r)
+        @test check_gradient(M, f, grad_f, p, X)
 
-    grad_f2(M, p) = -0.5 * log(M, p, q)
-    @test_throws ErrorException check_gradient(M, f, grad_f2, p, r; throw_error=true)
-    @test !check_gradient(M, f, grad_f2, p, r)
+        grad_fb(M, p) = -0.5 * log(M, p, q)
+        @test_throws ErrorException check_gradient(M, f, grad_fb, p, X; throw_error=true)
+        @test !check_gradient(M, f, grad_fb, p, X)
 
-    check_gradient(M, f, grad_f, p, r; plot=true)
+        check_gradient(M, f, grad_f, p, X; plot=true)
 
-    #test windowsize error
-    @test_throws ErrorException Manopt.find_best_slope_window(zeros(2), zeros(2), 20)
-    @test_throws ErrorException Manopt.find_best_slope_window(zeros(2), zeros(2), [2, 20])
+        #test windowsize error
+        @test_throws ErrorException Manopt.find_best_slope_window(zeros(2), zeros(2), 20)
+        @test_throws ErrorException Manopt.find_best_slope_window(
+            zeros(2), zeros(2), [2, 20]
+        )
+        # Linear Euclidean function -> exact
+        M2 = Euclidean(1)
+        f2(M, p) = 3 * p[1]
+        grad_f2(M, p) = [3]
+        p2 = [1.0]
+        X2 = [2.0]
+        # true due to exactness.
+        check_gradient(M2, f2, grad_f2, p2, X2;)
+    end
+    @testset "Hessian Checks" begin
+        M3 = Euclidean(2)
+        A = [2.0 1.0; 1.0 2.0]
+        f3(M, p) = 0.5 * p' * A * p
+        grad_f3(M, p) = A * p
+        Hess_f3(M, p, X) = A * X
+        p3 = [1.0, 2.0]
+        X3 = [1.0, 0.0]
+        #just run all defaults with true and even the grad_desc
+        @test check_Hessian(M3, f3, grad_f3, Hess_f3, p3, X3; mode=:CriticalPoint)
+        # Euclidean and completely exact
+
+        # gradient not correct
+        grad_f3f(M, p) = 2 .* A * p
+        @test !check_Hessian(M3, f3, grad_f3f, Hess_f3, p3, X3)
+
+        # Hessian not linear
+        Hess_f3f1(M, p, X) = X .^ 2
+        @test !check_Hessian(M3, f3, grad_f3, Hess_f3f1, p3, X3)
+
+        # Hessian not symmetric
+        Hess_f3f2(M, p, X) = [0.0 1.0; 0.0 0.0] * X
+        @test !check_Hessian(M3, f3, grad_f3, Hess_f3f2, p3, X3, [0.0, 1.0])
+
+        # Sphere
+        M4 = Sphere(2)
+        A2 = [2.0 1.0 0.0; 1.0 2.0 1.0; 0.0 1.0 2.0]
+        f4(::Sphere, p) = p' * A2 * p
+        grad_f4(::Sphere, p) = 2 * (A2 * p - p * p' * A2 * p)
+        function Hess_f4(::Sphere, p, X)
+            return 2 *
+                   (A2 * X - p * p' * A2 * X - X * p' * A2 * p - p * p' * X * p' * A2 * p)
+        end
+        p4 = [1.0, 0.0, 0.0]
+        X4 = [0.0, 1.0, 1.0]
+
+        #check for a bit smaller scale due to rounding errors
+        @test check_Hessian(M4, f4, grad_f4, Hess_f4, p4, X4; limits=(-5.0, 0.0))
+
+        #Hessian not tangent
+        Hess_f4f1(::Sphere, p, X) = p
+        @test !check_Hessian(M4, f4, grad_f4, Hess_f4f1, p4, X4)
+    end
 end


### PR DESCRIPTION
This PR introduces `check_Hessian` as described in Section 6.8 in Nicolas' book.
It also resolves a small problem with check_differential/check_gradient where when an error was thrown no plot was shown. This can now indeed be combined

One could maybe also do a `check_retraction` as Manopt/matlab as, but that would be a bit easier even, since we just compare exp to said retraction.

But then we should definitely also refactor the error/slope check which is currently nearly doubled between `check_differential` and `check_hessian`

# ToDo

Write (quite a few) tests to cover all things that might go wrong with a Hessian
* [x] add an exactness check? Then the slope might suffer too much from numerical errors.
* [x] Provide a wrong gradient
* [x] Not a tangent vector
* [x] Nonlinear
* [x] nonsymmetric
* [x] Issue a search for a critical point before
* [x] a correct one.