### PR TITLE
Change defaults for checking vectors/linearity/symmetry in check_ functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.19"
+version = "0.4.20"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -180,11 +180,11 @@ function check_gradient(
     p=rand(M),
     X=rand(M; vector_at=p);
     gradient=grad_f(M, p),
-    check_vector=true,
+    check_vector=false,
     throw_error=false,
     kwargs...,
 )
-    check_vector && (!is_vector(M, p, gradient, throw_error;) && return false)
+    check_vector && (!is_vector(M, p, gradient, throw_error) && return false)
     # function for the directional derivative - real so it also works on complex manifolds
     df(M, p, Y) = real(inner(M, p, gradient, Y))
     return check_differential(
@@ -214,10 +214,10 @@ no plot will be generated.
 
 # Keyword arguments
 
-* `check_grad`   – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
+* `check_grad`       – (`true`) check whether ``\operatorname{grad} f(p) \in T_p\mathcal M``.
 * `check_linearity`  – (`true`) check whether the Hessian is linear, see [`is_Hessian_linear`](@ref) using `a`, `b`, `X`, and `Y`
 * `check_symmetry`   – (`true`) check whether the Hessian is symmetric, see [`is_Hessian_symmetric`](@ref)
-* `check_vector`     – (`true`) check whether ``\operatorname{Hess} f(p)[X] \in T_p\mathcal M`` using `is_vector`.
+* `check_vector`     – (`false`) check whether ``\operatorname{Hess} f(p)[X] \in T_p\mathcal M`` using `is_vector`.
 * `mode`             - (`:Default`) specify the mode, by default we assume to have a second order retraction given by `retraction_method=`
   you can also this method if you already _have_ a cirtical point `p`.
   Set to `:CritalPoint` to use [`gradient_descent`](@ref) to find a critical point.
@@ -251,7 +251,7 @@ function check_Hessian(
     a=randn(),
     b=randn(),
     check_grad=true,
-    check_vector=true,
+    check_vector=false,
     check_symmetry=true,
     check_linearity=true,
     exactness_tol=1e-12,


### PR DESCRIPTION
This introduces `atol` and `rtol` to both the gradient and the Hessian check. These are passed down tp the `is_vector` check and for the Hessian also to the Linearity and symmetry check, in other words all places that call `is_approx`.  

This resolves #245.