### PR TITLE
Switch to `ArrayPartition`

### DIFF
--- a/ext/ManoptManifoldsExt/alternating_gradient.jl
+++ b/ext/ManoptManifoldsExt/alternating_gradient.jl
@@ -12,7 +12,7 @@ function get_gradient(
     mago::ManifoldAlternatingGradientObjective{AllocatingEvaluation,TC,<:AbstractVector},
     p,
 ) where {TC}
-    return ProductRepr([gi(M, p) for gi in mago.gradient!!]...)
+    return ArrayPartition([gi(M, p) for gi in mago.gradient!!]...)
 end
 
 @doc raw"""

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -160,7 +160,7 @@ perform an alternating gradient descent
 * `M` – the product manifold ``\mathcal M = \mathcal M_1 × \mathcal M_2 × ⋯ ×\mathcal M_n``
 * `f` – the objective function (cost) defined on `M`.
 * `grad_f` – a gradient, that can be of two cases
-  * is a single function returning a `ProductRepr` or
+  * is a single function returning an `ArrayPartition` or
   * is a vector functions each returning a component part of the whole gradient
 * `p` – an initial value ``p_0 ∈ \mathcal M``
 

--- a/test/plans/test_higher_order_primal_dual_plan.jl
+++ b/test/plans/test_higher_order_primal_dual_plan.jl
@@ -13,7 +13,7 @@ using Manopt, Manifolds, ManifoldsBase, Test
     p_hat = shortest_geodesic(M, data, reverse(data), δ)
     N = M
     fidelity(M, p) = 1 / 2 * distance(M, p, f)^2
-    Λ(M, p) = ProductRepr(p, forward_logs(M, p))
+    Λ(M, p) = ArrayPartition(p, forward_logs(M, p))
     prior(M, p) = norm(norm.(Ref(M.manifold), p, submanifold_component(N, Λ(p), 2)), 1)
     f(M, p) = (1 / α) * fidelity(M, p) + prior(M, p)
     prox_f(M, λ, p) = prox_distance(M, λ / α, data, p, 2)

--- a/test/plans/test_primal_dual_plan.jl
+++ b/test/plans/test_primal_dual_plan.jl
@@ -15,7 +15,7 @@ include("../utils/dummy_types.jl")
     x_hat = shortest_geodesic(M, data, reverse(data), δ)
     N = TangentBundle(M)
     fidelity(M, x) = 1 / 2 * distance(M, x, f)^2
-    Λ(M, x) = ProductRepr(x, forward_logs(M, x))
+    Λ(M, x) = ArrayPartition(x, forward_logs(M, x))
     function Λ!(M, Y, x)
         N = TangentBundle(M)
         copyto!(M, Y[N, :point], x)
@@ -28,7 +28,7 @@ include("../utils/dummy_types.jl")
     prox_f(M, λ, x) = prox_distance(M, λ / α, data, x, 2)
     prox_f!(M, y, λ, x) = prox_distance!(M, y, λ / α, data, x, 2)
     function prox_g_dual(N, n, λ, ξ)
-        return ProductRepr(
+        return ArrayPartition(
             ξ[N, :point],
             project_collaborative_TV(
                 base_manifold(N), λ, n[N, :point], ξ[N, :vector], Inf, Inf, 1.0
@@ -42,7 +42,7 @@ include("../utils/dummy_types.jl")
         )
         return η
     end
-    DΛ(M, m, X) = ProductRepr(zero_vector(M, m), differential_forward_logs(M, m, X))
+    DΛ(M, m, X) = ArrayPartition(zero_vector(M, m), differential_forward_logs(M, m, X))
     function DΛ!(M, Y, m, X)
         N = TangentBundle(M)
         zero_vector!(M, Y[N, :point], m)
@@ -59,7 +59,7 @@ include("../utils/dummy_types.jl")
     m = fill(mid_point(pixelM, data[1], data[2]), 2)
     n = Λ(M, m)
     p0 = deepcopy(data)
-    X0 = ProductRepr(zero_vector(M, m), zero_vector(M, m))
+    X0 = ArrayPartition(zero_vector(M, m), zero_vector(M, m))
 
     pdmoe = PrimalDualManifoldObjective(f, prox_f, prox_g_dual, adjoint_DΛ; Λ=Λ)
     p_exact = TwoManifoldProblem(M, N, pdmoe)
@@ -69,9 +69,9 @@ include("../utils/dummy_types.jl")
     p_linearized = TwoManifoldProblem(M, N, pdmol)
     s_exact = ChambollePockState(M, m, n, zero.(p0), X0; variant=:exact)
     s_linearized = ChambollePockState(M, m, n, p0, X0; variant=:linearized)
-    n_old = ProductRepr(n[N, :point], n[N, :vector])
+    n_old = ArrayPartition(n[N, :point], n[N, :vector])
     p_old = copy(p0)
-    ξ_old = ProductRepr(X0[N, :point], X0[N, :vector])
+    ξ_old = ArrayPartition(X0[N, :point], X0[N, :vector])
 
     set_iterate!(s_exact, p0)
     @test all(get_iterate(s_exact) .== p0)

--- a/test/solvers/test_ChambollePock.jl
+++ b/test/solvers/test_ChambollePock.jl
@@ -13,7 +13,7 @@ using Manopt, Manifolds, ManifoldsBase, Test
     x_hat = shortest_geodesic(M, data, reverse(data), δ)
     N = TangentBundle(M)
     fidelity(M, x) = 1 / 2 * distance(M, x, f)^2
-    Λ(M, x) = ProductRepr(x, forward_logs(M, x))
+    Λ(M, x) = ArrayPartition(x, forward_logs(M, x))
     function Λ!(M, Y, x)
         N = TangentBundle(M)
         copyto!(M, Y[N, :point], x)
@@ -24,7 +24,7 @@ using Manopt, Manifolds, ManifoldsBase, Test
     f(M, x) = (1 / α) * fidelity(M, x) + prior(M, x)
     prox_f(M, λ, x) = prox_distance(M, λ / α, data, x, 2)
     function prox_g_dual(N, n, λ, ξ)
-        return ProductRepr(
+        return ArrayPartition(
             ξ[N, :point],
             project_collaborative_TV(
                 base_manifold(N), λ, n[N, :point], ξ[N, :vector], Inf, Inf, 1.0
@@ -38,13 +38,13 @@ using Manopt, Manifolds, ManifoldsBase, Test
         )
         return η
     end
-    DΛ(M, m, X) = ProductRepr(zero_vector(M, m), differential_forward_logs(M, m, X))
+    DΛ(M, m, X) = ArrayPartition(zero_vector(M, m), differential_forward_logs(M, m, X))
     adjoint_DΛ(N, m, n, ξ) = adjoint_differential_forward_logs(N.manifold, m, ξ[N, :vector])
 
     m = fill(mid_point(pixelM, data[1], data[2]), 2)
     n = Λ(M, m)
     x0 = deepcopy(data)
-    ξ0 = ProductRepr(zero_vector(M, m), zero_vector(M, m))
+    ξ0 = ArrayPartition(zero_vector(M, m), zero_vector(M, m))
     @testset "Test Variants" begin
         callargs_linearized = [M, N, f, x0, ξ0, m, n, prox_f, prox_g_dual, adjoint_DΛ]
         o1 = ChambollePock(

--- a/test/solvers/test_alternating_gradient.jl
+++ b/test/solvers/test_alternating_gradient.jl
@@ -14,13 +14,13 @@ using Manopt, Manifolds, Test
     grad_f1!(N, X, p) = (X .= -log(N[1], p[N, 1], data[1]))
     grad_f2(N, p) = -log(N[2], p[N, 2], data[2])
     grad_f2!(N, X, p) = (X .= -log(N[2], p[N, 2], data[2]))
-    grad_f(N, p) = ProductRepr([-log(N[i], p[N, i], data[i]) for i in [1, 2]]...)
+    grad_f(N, p) = ArrayPartition([-log(N[i], p[N, i], data[i]) for i in [1, 2]]...)
     function grad_f!(N, X, p)
         log!(N[1], X[N, 1], p[N, 1], data[1])
         log!(N[2], X[N, 2], p[N, 2], data[2])
         return X .*= -1
     end
-    p = ProductRepr([0.0, 0.0, 1.0], [0.0, 0.0, 1.0])
+    p = ArrayPartition([0.0, 0.0, 1.0], [0.0, 0.0, 1.0])
 
     @testset "Test gradient access" begin
         objf = ManifoldAlternatingGradientObjective(f, grad_f)

--- a/test/solvers/test_primal_dual_semismooth_Newton.jl
+++ b/test/solvers/test_primal_dual_semismooth_Newton.jl
@@ -18,7 +18,7 @@ using Manopt, Manifolds, ManifoldsBase, Test
     x_hat = shortest_geodesic(M, data, reverse(data), δ)
     N = M
     fidelity(M, x) = 1 / 2 * distance(M, x, f)^2
-    Λ(M, x) = ProductRepr(x, forward_logs(M, x))
+    Λ(M, x) = ArrayPartition(x, forward_logs(M, x))
     prior(M, x) = norm(norm.(Ref(M.manifold), x, submanifold_component(N, Λ(x), 2)), 1)
     f(M, x) = (1 / α) * fidelity(M, x) + prior(M, x)
     prox_f(M, λ, x) = prox_distance(M, λ / α, data, x, 2)

--- a/tutorials/GeodesicRegression.qmd
+++ b/tutorials/GeodesicRegression.qmd
@@ -176,7 +176,7 @@ A = hcat(
     map(x -> get_coordinates(S, m, log(S, m, x), DefaultOrthonormalBasis()), data)...
 )
 pca1 = get_vector(S, m, svd(A).U[:, 1], DefaultOrthonormalBasis())
-x0 = ProductRepr(m, pca1)
+x0 = ArrayPartition(m, pca1)
 ```
 
 The optimal “time labels” are then just the projections $t_i = ⟨d_i,X^*⟩$, $i=1,\ldots,n$.
@@ -271,7 +271,7 @@ A2 = hcat(
     map(x -> get_coordinates(S, m, log(S, m, x), DefaultOrthonormalBasis()), data2)...
 )
 pca2 = get_vector(S, m, svd(A2).U[:, 1], DefaultOrthonormalBasis())
-x1 = ProductRepr(m, pca2)
+x1 = ArrayPartition(m, pca2)
 t2 = map(d -> inner(S, m2, pca2, log(S, m2, d)), data2)
 ```
 
@@ -440,7 +440,7 @@ end
 We can reuse the computed initial values from before, just that now we are on a product manifold
 
 ```{julia}
-x2 = ProductRepr(x1, t2)
+x2 = ArrayPartition(x1, t2)
 F3 = RegressionCost2(data2)
 gradF3_vector = [RegressionGradient2a!(data2), RegressionGradient2b!(data2)];
 ```


### PR DESCRIPTION
Adapts Manopt to the deprecation in https://github.com/JuliaManifolds/Manifolds.jl/pull/612 . @kellertuer could you regenerate the .md file for GeodesicRegression example? I'm not sure how I should run quarto to do that.