### PR TITLE
Riemannian Levenberg-Marquardt initial residual and jacobian as kwargs

### DIFF
--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -168,7 +168,7 @@ function LevenbergMarquardt!(
     debug=[DebugWarnIfCostIncreases()],
     expect_zero_residual::Bool=false,
     initial_residual_values=similar(p, get_objective(nlso).num_components),
-    initial_jacF=similar(p, get_objective(nlso).num_components, manifold_dimension(M)),
+    initial_jacobian_f=similar(p, get_objective(nlso).num_components, manifold_dimension(M)),
     kwargs..., #collect rest
 ) where {O<:Union{NonlinearLeastSquaresObjective,AbstractDecoratedManifoldObjective}}
     i_nlso = get_objective(nlso) # undeecorate – for safety

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -178,7 +178,7 @@ function LevenbergMarquardt!(
         M,
         p,
         initial_residual_values,
-        initial_jacF;
+        initial_jacobian_f;
         stopping_criterion=stopping_criterion,
         retraction_method=retraction_method,
         expect_zero_residual=expect_zero_residual,

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -35,6 +35,8 @@ then the keyword `jacobian_tangent_basis` below is ignored
   a functor inheriting from [`StoppingCriterion`](@ref) indicating when to stop.
 * `expect_zero_residual` – (`false`) whether or not the algorithm might expect that the value of
   residual (objective) at mimimum is equal to 0.
+* `initial_residual_values` – the initial residual vector of the cost function `f`.
+* `initial_jacobian_f` – the initial Jacobian of the cost function `f`.
 
 All other keyword arguments are passed to [`decorate_state!`](@ref) for decorators or
 [`decorate_objective!`](@ref), respectively.

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -167,6 +167,8 @@ function LevenbergMarquardt!(
                                           StopWhenStepsizeLess(1e-12),
     debug=[DebugWarnIfCostIncreases()],
     expect_zero_residual::Bool=false,
+    initial_residual_values=similar(p, get_objective(nlso).num_components),
+    initial_jacF=similar(p, get_objective(nlso).num_components, manifold_dimension(M)),
     kwargs..., #collect rest
 ) where {O<:Union{NonlinearLeastSquaresObjective,AbstractDecoratedManifoldObjective}}
     i_nlso = get_objective(nlso) # undeecorate – for safety
@@ -175,8 +177,8 @@ function LevenbergMarquardt!(
     lms = LevenbergMarquardtState(
         M,
         p,
-        similar(p, i_nlso.num_components),
-        similar(p, i_nlso.num_components, manifold_dimension(M));
+        initial_residual_values,
+        initial_jacF;
         stopping_criterion=stopping_criterion,
         retraction_method=retraction_method,
         expect_zero_residual=expect_zero_residual,

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -170,7 +170,9 @@ function LevenbergMarquardt!(
     debug=[DebugWarnIfCostIncreases()],
     expect_zero_residual::Bool=false,
     initial_residual_values=similar(p, get_objective(nlso).num_components),
-    initial_jacobian_f=similar(p, get_objective(nlso).num_components, manifold_dimension(M)),
+    initial_jacobian_f=similar(
+        p, get_objective(nlso).num_components, manifold_dimension(M)
+    ),
     kwargs..., #collect rest
 ) where {O<:Union{NonlinearLeastSquaresObjective,AbstractDecoratedManifoldObjective}}
     i_nlso = get_objective(nlso) # undeecorate – for safety


### PR DESCRIPTION
Hi, I wanted to test using Levenberg Marquardt in https://github.com/JuliaRobotics/IncrementalInference.jl/pull/1724 but came across 2 issues that I fixed in this PR.

1. `initial_residual_values = similar(p,  get_objective(nlso).num_components)`
Didn't work for me on SE(n) with p an ArrayPartion of (SVector,SMatrix)

2. `initial_jacF = similar(p,  get_objective(nlso).num_components, manifold_dimension(M)` 
I wanted to use a sparse Jacobian so I had to supply the initial jacobian myself.

I'm open to suggestions of other ways to do it, but thought I'd rather open a PR than an issue.

PS. I almost have Riemannian Levenberg-Marquardt working as one of our solvers, but I'm not getting the correct results yet, and still need to figure out some performance issues. But thanks for another great addition to julia manifolds.