### PR TITLE
Absolute and relative constant and decreasing stepsizes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.33] - 24/08/2023
+
+### Added
+
+* `ConstantStepsize` and `DecreasingStepsize` now have an additional field `type::Symbol` to assess whether the
+  step-size should be relatively (to the gradient norm) or absolutely constant.
+
 ## [0.4.32] - 23/08/2023
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.32"
+version = "0.4.33"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -45,13 +45,14 @@ end
 A functor that always returns a fixed step size.
 
 # Fields
-* `length` – constant value for the step size.
+* `length` – constant value for the step size
+* `type` - a symbol that indicates whether the stepsize is relatively (to the gradient norm) or absolutely constant
 
 # Constructors
 
-    ConstantStepsize(s::Real)
+    ConstantStepsize(s::Real, t::Symbol)
 
-initialize the stepsize to a constant `s`.
+initialize the stepsize to a constant `s` of type `t`.
 
     ConstantStepsize(M::AbstractManifold=DefaultManifold(2); stepsize=injectivity_radius(M)/2)
 
@@ -60,20 +61,32 @@ radius, unless the radius is infinity, then the default step size is `1`.
 """
 mutable struct ConstantStepsize{T} <: Stepsize
     length::T
+    type::Symbol
 end
 function ConstantStepsize(
     M::AbstractManifold=DefaultManifold(2);
     stepsize=isinf(injectivity_radius(M)) ? 1.0 : injectivity_radius(M) / 2,
+    type=:relative,
 )
-    return ConstantStepsize{typeof(stepsize)}(stepsize)
+    return ConstantStepsize{typeof(stepsize)}(stepsize, type)
+end
+function ConstantStepsize(stepsize::T) where {T<:Number}
+    return ConstantStepsize{T}(stepsize, :relative)
 end
 function (cs::ConstantStepsize)(
-    ::AbstractManoptProblem, ::AbstractManoptSolverState, ::Any, args...; kwargs...
+    amp::AbstractManoptProblem, ams::AbstractManoptSolverState, ::Any, args...; kwargs...
 )
-    return cs.length
+    s = cs.length
+    if cs.type == :absolute
+        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        if ns > eps(eltype(s))
+            s /= ns
+        end
+    end
+    return s
 end
 get_initial_stepsize(s::ConstantStepsize) = s.length
-show(io::IO, cs::ConstantStepsize) = print(io, "ConstantStepsize($(cs.length))")
+show(io::IO, cs::ConstantStepsize) = print(io, "ConstantStepsize($(cs.length), $(cs.type))")
 
 @doc raw"""
     DecreasingStepsize()
@@ -87,6 +100,7 @@ A functor that represents several decreasing step sizes
 * `exponent` – (`1`) a value ``e`` the current iteration numbers ``e``th exponential
   is taken of
 * `shift` – (`0`) shift the denominator iterator ``i`` by ``s```.
+* `type` - a symbol that indicates whether the stepsize is relatively (to the gradient norm) or absolutely constant
 
 In total the complete formulae reads for the ``i``th iterate as
 
@@ -98,7 +112,7 @@ and hence the default simplifies to just ``s_i = \frac{l}{i}``
 
 # Constructor
 
-    DecreasingStepsize(l=1,f=1,a=0,e=1,s=0)
+    DecreasingStepsize(l=1,f=1,a=0,e=1,s=0,type=:relative)
 
 Alternatively one can also use the following keyword.
 
@@ -115,8 +129,11 @@ mutable struct DecreasingStepsize <: Stepsize
     subtrahend::Float64
     exponent::Float64
     shift::Int
-    function DecreasingStepsize(l::Real, f::Real=1.0, a::Real=0.0, e::Real=1.0, s::Int=0)
-        return new(l, f, a, e, s)
+    type::Symbol
+    function DecreasingStepsize(
+        l::Real, f::Real=1.0, a::Real=0.0, e::Real=1.0, s::Int=0, type::Symbol=:relative
+    )
+        return new(l, f, a, e, s, type)
     end
 end
 function DecreasingStepsize(
@@ -126,13 +143,21 @@ function DecreasingStepsize(
     subtrahend=0.0,
     exponent=1.0,
     shift=0,
+    type::Symbol=:relative,
 )
-    return DecreasingStepsize(length, factor, subtrahend, exponent, shift)
+    return DecreasingStepsize(length, factor, subtrahend, exponent, shift, type)
 end
 function (s::DecreasingStepsize)(
-    ::P, ::O, i::Int, args...; kwargs...
+    amp::P, ams::O, i::Int, args...; kwargs...
 ) where {P<:AbstractManoptProblem,O<:AbstractManoptSolverState}
-    return (s.length - i * s.subtrahend) * (s.factor^i) / ((i + s.shift)^(s.exponent))
+    ds = (s.length - i * s.subtrahend) * (s.factor^i) / ((i + s.shift)^(s.exponent))
+    if s.type == :absolute
+        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        if ns > eps(eltype(ds))
+            ds /= ns
+        end
+    end
+    return ds
 end
 get_initial_stepsize(s::DecreasingStepsize) = s.length
 function show(io::IO, s::DecreasingStepsize)

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -78,7 +78,7 @@ function (cs::ConstantStepsize)(
 )
     s = cs.length
     if cs.type == :absolute
-        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        ns = norm(get_manifold(amp), get_iterate(ams), get_gradient(ams))
         if ns > eps(eltype(s))
             s /= ns
         end
@@ -152,7 +152,7 @@ function (s::DecreasingStepsize)(
 ) where {P<:AbstractManoptProblem,O<:AbstractManoptSolverState}
     ds = (s.length - i * s.subtrahend) * (s.factor^i) / ((i + s.shift)^(s.exponent))
     if s.type == :absolute
-        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        ns = norm(get_manifold(amp), get_iterate(ams), get_gradient(ams))
         if ns > eps(eltype(ds))
             ds /= ns
         end

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -46,15 +46,18 @@ A functor that always returns a fixed step size.
 
 # Fields
 * `length` – constant value for the step size
-* `type` - a symbol that indicates whether the stepsize is relatively (to the gradient norm) or absolutely constant
+* `type` - a symbol that indicates whether the stepsize is relatively (:relative),
+    with respect to the gradient norm, or absolutely (:absolute) constant.
 
 # Constructors
 
-    ConstantStepsize(s::Real, t::Symbol)
+    ConstantStepsize(s::Real, t::Symbol=:relative)
 
 initialize the stepsize to a constant `s` of type `t`.
 
-    ConstantStepsize(M::AbstractManifold=DefaultManifold(2); stepsize=injectivity_radius(M)/2)
+    ConstantStepsize(M::AbstractManifold=DefaultManifold(2); 
+        stepsize=injectivity_radius(M)/2, type::Symbol=:relative
+    )
 
 initialize the stepsize to a constant `stepsize`, which by default is half the injectivity
 radius, unless the radius is infinity, then the default step size is `1`.
@@ -100,7 +103,8 @@ A functor that represents several decreasing step sizes
 * `exponent` – (`1`) a value ``e`` the current iteration numbers ``e``th exponential
   is taken of
 * `shift` – (`0`) shift the denominator iterator ``i`` by ``s```.
-* `type` - a symbol that indicates whether the stepsize is relatively (to the gradient norm) or absolutely constant
+* `type` - a symbol that indicates whether the stepsize is relatively (:relative),
+    with respect to the gradient norm, or absolutely (:absolute) constant.
 
 In total the complete formulae reads for the ``i``th iterate as
 
@@ -118,9 +122,11 @@ Alternatively one can also use the following keyword.
 
     DecreasingStepsize(
         M::AbstractManifold=DefaultManifold(3);
-        length=injectivity_radius(M)/2, multiplier=1.0, subtrahend=0.0, exponent=1.0, shift=0)
+        length=injectivity_radius(M)/2, multiplier=1.0, subtrahend=0.0, 
+        exponent=1.0, shift=0, type=:relative
+    )
 
-initialiszes all fields above, where none of them is mandatory and the length is set to
+initializes all fields above, where none of them is mandatory and the length is set to
 half and to $1$ if the injectivity radius is infinite.
 """
 mutable struct DecreasingStepsize <: Stepsize

--- a/src/solvers/subgradient.jl
+++ b/src/solvers/subgradient.jl
@@ -1,15 +1,16 @@
 """
     SubGradientMethodState <: AbstractManoptSolverState
 
-stories option values for a [`subgradient_method`](@ref) solver
+stores option values for a [`subgradient_method`](@ref) solver
 
 # Fields
+
 * `retraction_method` – the retration to use within
 * `stepsize` – ([`ConstantStepsize`](@ref)`(M)`) a [`Stepsize`](@ref)
 * `stop` – ([`StopAfterIteration`](@ref)`(5000)``)a [`StoppingCriterion`](@ref)
 * `p` – (initial or current) value the algorithm is at
 * `p_star` – optimal value (initialized to a copy of `p`.)
-* `X` (`zero_vector(M, p)`) the current element from the possible subgradients at
+* `X` - (`zero_vector(M, p)`) the current element from the possible subgradients at
    `p` that was last evaluated.
 
 # Constructor
@@ -93,8 +94,8 @@ not necessarily deterministic.
 
 * `M` – a manifold ``\mathcal M``
 * `f` – a cost function ``f:\mathcal M→ℝ`` to minimize
-* `∂f`– the (sub)gradient ``\partial f: \mathcal M→ T\mathcal M`` of F
-  restricted to always only returning one value/element from the subgradient.
+* `∂f`– the (sub)gradient ``\partial f: \mathcal M→ T\mathcal M`` of f
+  restricted to always only returning one value/element from the subdifferential.
   This function can be passed as an allocation function `(M, p) -> X` or
   a mutating function `(M, X, p) -> X`, see `evaluation`.
 * `p` – an initial value ``p_0=p ∈ \mathcal M``
@@ -105,8 +106,8 @@ alternatively to `f` and `∂f` a [`ManifoldSubgradientObjective`](@ref) `sgo` c
 # Optional
 
 * `evaluation` – ([`AllocatingEvaluation`](@ref)) specify whether the subgradient works by
-   allocation (default) form `∂F(M, y)` or [`InplaceEvaluation`](@ref) in place, i.e. is
-   of the form `∂F!(M, X, x)`.
+   allocation (default) form `∂f(M, y)` or [`InplaceEvaluation`](@ref) in place, i.e. is
+   of the form `∂f!(M, X, x)`.
 * `stepsize` – ([`ConstantStepsize`](@ref)`(M)`) specify a [`Stepsize`](@ref)
 * `retraction` – (`default_retraction_method(M, typeof(p))`) a retraction to use.
 * `stopping_criterion` – ([`StopAfterIteration`](@ref)`(5000)`)
@@ -166,7 +167,7 @@ perform a subgradient method ``p_{k+1} = \mathrm{retr}(p_k, s_k∂f(p_k))``,
 * `M` – a manifold ``\mathcal M``
 * `f` – a cost function ``f:\mathcal M→ℝ`` to minimize
 * `∂f`– the (sub)gradient ``\partial f: \mathcal M→ T\mathcal M`` of F
-  restricted to always only returning one value/element from the subgradient.
+  restricted to always only returning one value/element from the subdifferential.
   This function can be passed as an allocation function `(M, p) -> X` or
   a mutating function `(M, X, p) -> X`, see `evaluation`.
 * `p` – an initial value ``p_0=p ∈ \mathcal M``

--- a/src/solvers/subgradient.jl
+++ b/src/solvers/subgradient.jl
@@ -224,3 +224,27 @@ function step_solver!(mp::AbstractManoptProblem, sgs::SubGradientMethodState, i)
     return sgs
 end
 get_solver_result(sgs::SubGradientMethodState) = sgs.p_star
+function (cs::ConstantStepsize)(
+    amp::AbstractManoptProblem, sgs::SubGradientMethodState, ::Any, args...; kwargs...
+)
+    s = cs.length
+    if cs.type == :absolute
+        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        if ns > eps(eltype(s))
+            s /= ns
+        end
+    end
+    return s
+end
+function (s::DecreasingStepsize)(
+    amp::AbstractManoptProblem, sgs::SubGradientMethodState, i::Int, args...; kwargs...
+)
+    ds = (s.length - i * s.subtrahend) * (s.factor^i) / ((i + s.shift)^(s.exponent))
+    if s.type == :absolute
+        ns = norm(get_manifold(amp), get_iterate(sgs), get_subgradient(sgs))
+        if ns > eps(eltype(ds))
+            ds /= ns
+        end
+    end
+    return ds
+end

--- a/test/solvers/test_subgradient_method.jl
+++ b/test/solvers/test_subgradient_method.jl
@@ -11,10 +11,16 @@ include("../utils/example_tasks.jl")
         M, p0; stopping_criterion=StopAfterIteration(200), stepsize=ConstantStepsize(M)
     )
     sgs_ac = SubGradientMethodState(
-        M, q0; stopping_criterion=StopAfterIteration(200), stepsize=ConstantStepsize(1.0, :absolute)
+        M,
+        q0;
+        stopping_criterion=StopAfterIteration(200),
+        stepsize=ConstantStepsize(1.0, :absolute),
     )
     sgs_ad = SubGradientMethodState(
-        M, q0; stopping_criterion=StopAfterIteration(200), stepsize=DecreasingStepsize(1, 1, 0, 1, 0, :absolute)
+        M,
+        q0;
+        stopping_criterion=StopAfterIteration(200),
+        stepsize=DecreasingStepsize(1, 1, 0, 1, 0, :absolute),
     )
     @test startswith(repr(sgs), "# Solver state for `Manopt.jl`s Subgradient Method\n")
     @test get_iterate(sgs) == p0
@@ -41,12 +47,16 @@ include("../utils/example_tasks.jl")
         @test get_last_stepsize(mp, sgs, 1) == 1.0
         # Check absolute constant stepsize
         @test get_initial_stepsize(mp, sgs_ac) == 1.0
-        @test get_stepsize(mp, sgs_ac, 1) == 1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
-        @test get_last_stepsize(mp, sgs_ac, 1) ==  1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
+        @test get_stepsize(mp, sgs_ac, 1) ==
+            1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
+        @test get_last_stepsize(mp, sgs_ac, 1) ==
+            1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
         # Check absolute decreasing stepsize
         @test get_initial_stepsize(mp, sgs_ad) == 1.0
-        @test get_stepsize(mp, sgs_ad, 1) == 1.0 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
-        @test get_stepsize(mp, sgs_ad, 200) ==  0.005 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
+        @test get_stepsize(mp, sgs_ad, 1) ==
+            1.0 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
+        @test get_stepsize(mp, sgs_ad, 200) ==
+            0.005 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
         # Check Fallbacks of Problem
         @test get_cost(mp, p) == 0.0
         @test norm(M, p, get_subgradient(mp, p)) == 0

--- a/test/solvers/test_subgradient_method.jl
+++ b/test/solvers/test_subgradient_method.jl
@@ -6,8 +6,15 @@ include("../utils/example_tasks.jl")
     M = Euclidean(2)
     p = [4.0, 2.0]
     p0 = [5.0, 2.0]
+    q0 = [10.0, 5.0]
     sgs = SubGradientMethodState(
         M, p0; stopping_criterion=StopAfterIteration(200), stepsize=ConstantStepsize(M)
+    )
+    sgs_ac = SubGradientMethodState(
+        M, q0; stopping_criterion=StopAfterIteration(200), stepsize=ConstantStepsize(1.0, :absolute)
+    )
+    sgs_ad = SubGradientMethodState(
+        M, q0; stopping_criterion=StopAfterIteration(200), stepsize=DecreasingStepsize(1, 1, 0, 1, 0, :absolute)
     )
     @test startswith(repr(sgs), "# Solver state for `Manopt.jl`s Subgradient Method\n")
     @test get_iterate(sgs) == p0
@@ -26,11 +33,21 @@ include("../utils/example_tasks.jl")
         get_subgradient!(mp, X, p)
         @test isapprox(M, p, X, Y)
         oR = solve!(mp, sgs)
+        solve!(mp, sgs_ac)
+        solve!(mp, sgs_ad)
         q1 = get_solver_result(oR)
         @test get_initial_stepsize(mp, sgs) == 1.0
         @test get_stepsize(mp, sgs, 1) == 1.0
         @test get_last_stepsize(mp, sgs, 1) == 1.0
-        # Check Fallbacks of Problen
+        # Check absolute constant stepsize
+        @test get_initial_stepsize(mp, sgs_ac) == 1.0
+        @test get_stepsize(mp, sgs_ac, 1) == 1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
+        @test get_last_stepsize(mp, sgs_ac, 1) ==  1.0 / norm(get_manifold(mp), get_iterate(sgs_ac), get_subgradient(sgs_ac))
+        # Check absolute decreasing stepsize
+        @test get_initial_stepsize(mp, sgs_ad) == 1.0
+        @test get_stepsize(mp, sgs_ad, 1) == 1.0 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
+        @test get_stepsize(mp, sgs_ad, 200) ==  0.005 / norm(get_manifold(mp), get_iterate(sgs_ad), get_subgradient(sgs_ad))
+        # Check Fallbacks of Problem
         @test get_cost(mp, p) == 0.0
         @test norm(M, p, get_subgradient(mp, p)) == 0
         @test_throws MethodError get_gradient(mp, sgs.p)


### PR DESCRIPTION
`ConstantStepsize` and `DecreasingStepsize` now accept an additional symbolic argument that can be either `:relative` (default value) or `:absolute`.
The default option leaves the behavior of both stepsizes unchanged, whereas using `:absolute` triggers the division of the stepsize length by the norm of the (sub)gradient at the current iterate. 
The naming of the two symbolic options may seem counterintuitive at first, but stepsizes are used in retractions where they show up as a multiplicative factor for the (sub)gradient at the current iterate.
This means that the actual step computed by the algorithm with an `:absolute` stepsize won't be scaled by the length of the (sub)gradient but will only go in its direction, whence the name.

Additionally, `ConstantStepsize` and `DecreasingStepsize` have also been implemented for subgradient-based objectives.