### PR TITLE
Generalize Douglas Rachford's internal reflection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.36"
+version = "0.4.37"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/functions/manifold_functions.jl
+++ b/src/functions/manifold_functions.jl
@@ -29,7 +29,7 @@ Reflect the point `x` from the manifold `M` at point `p`, i.e.
 ````
 
 where $\operatorname{retr}$ and $\operatorname{iretr}$ denote a retraction and an inverse
-retraction, respecivelu.
+retraction, respectively.
 This can also be done in place of `q`.
 
 ## Keyword arguments

--- a/src/functions/manifold_functions.jl
+++ b/src/functions/manifold_functions.jl
@@ -31,3 +31,10 @@ This can also be done in place of `q`.
 """
 reflect(M::AbstractManifold, p, x) = exp(M, p, -log(M, p, x))
 reflect!(M::AbstractManifold, q, p, x) = exp!(M, q, p, -log(M, p, x))
+
+function reflect(M::AbstractManifold, p, x;
+    rectraction_method=default_retract_method(M),
+    inverse_retraction_method=default_inverse_retraction_method(M)
+)
+    return retract(M, p, -inverse_retract(M, p, x, inverse_retraction_method), rectraction_method)
+end

--- a/src/functions/manifold_functions.jl
+++ b/src/functions/manifold_functions.jl
@@ -25,10 +25,10 @@ end
 Reflect the point `x` from the manifold `M` at point `p`, i.e.
 
 ````math
-    \operatorname{refl}_p(x) = \operatorname{retr}_p(-\operatorname{iretr}_p x).
+    \operatorname{refl}_p(x) = \operatorname{retr}_p(-\operatorname{retr}^{-1}_p x).
 ````
 
-where $\operatorname{retr}$ and $\operatorname{iretr}$ denote a retraction and an inverse
+where $\operatorname{retr}$ and $\operatorname{retr}^{-1}$ denote a retraction and an inverse
 retraction, respectively.
 This can also be done in place of `q`.
 

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -231,7 +231,13 @@ function DouglasRachford!(
     p;
     λ::Tλ=(iter) -> 1.0,
     α::Tα=(iter) -> 0.9,
-    R::TR=Manopt.reflect,
+    retraction_method::AbstractRetractionMethod=default_retraction_method(M, typeof(p)),
+    inverse_retraction_method::AbstractInverseRetractionMethod=default_inverse_retraction_method(M, typeof(p)),
+    # Adapt to evaluation type
+    R::TR=(M,p,q) -> Manopt.reflect(M, p, q;
+        retraction_method=retraction_method,
+        inverse_retraction_method=inverse_retraction_method
+    ),
     parallel::Int=0,
     stopping_criterion::StoppingCriterion=StopWhenAny(
         StopAfterIteration(200), StopWhenChangeLess(10.0^-5)

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -365,5 +365,8 @@ function step_solver!(amp::AbstractManoptProblem, drs::DouglasRachfordState, i)
 end
 get_solver_result(drs::DouglasRachfordState) = drs.parallel ? drs.p[1] : drs.p
 
-_reflect!(M, r, p, x, R, ::AllocatingEvaluation) = (r = R(M, p, x))
-_reflect!(M, r, p, x, R, ::InplaceEvaluation) = (R(M, r, p, x))
+function _reflect!(M, r, p, x, R, ::AllocatingEvaluation)
+    copyto!(M, r, R(M, p, x))
+    return r
+end
+_reflect!(M, r, p, x, R, ::InplaceEvaluation) = R(M, r, p, x)

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -27,7 +27,7 @@ Generate the options for a Manifold `M` and an initial point `p`, where the foll
 * `α` – (`(iter)->0.9`) relaxation of the step from old to new iterate, i.e.
   ``x^{(k+1)} = g(α(k); x^{(k)}, t^{(k)})``, where ``t^{(k)}`` is the result
   of the double reflection involved in the DR algorithm
-* `R` – ([`reflect`](@ref) or [`reflect!`](@ref)) method employed in the iteration to perform the reflection of `x` at
+* `R` – ([`reflect`](@ref) or `reflect!`) method employed in the iteration to perform the reflection of `x` at
   the prox `p`, which function is used depends on `reflection_evaluation`.
 * reflection_evaluation – ([`AllocatingEvaluation`](@ref)`()`) specify whether the reflection works inplace or allocating (default)
 * `stopping_criterion` – ([`StopAfterIteration`](@ref)`(300)`) a [`StoppingCriterion`](@ref)
@@ -137,9 +137,9 @@ If you provide a [`ManifoldProximalMapObjective`](@ref) `mpo` instead, the proxi
   of the double reflection involved in the DR algorithm
 * `inverse_retraction_method` - (`default_inverse_retraction_method(M, typeof(p))`) the inverse retraction to use within the reflection (ignored, if you set `R` directly)
 * `R` – method employed in the iteration to perform the reflection of `x` at the prox `p`.
-  This uses by default [`reflect!`](@ref) or [`reflect!`](@ref) depending on `reflection_evaluation` and
+  This uses by default `reflect`](@ref) or `reflect!` depending on `reflection_evaluation` and
   the retraction and inverse retraction specified by `retraction_method` and `inverse_retraction_method`, respectively.
-* `reflection_evaluation` – ([`AllocatingEvaluation`](@ef) whether `R` works inplace or allocating
+* `reflection_evaluation` – ([`AllocatingEvaluation`](@ref) whether `R` works inplace or allocating
 * `retraction_method` - (`default_retration_metiod(M, typeof(p))`) the retraction to use in the reflection (ignored, if you set `R` directly)
 * `stopping_criterion` – ([`StopWhenAny`](@ref)`(`[`StopAfterIteration`](@ref)`(200),`[`StopWhenChangeLess`](@ref)`(10.0^-5))`) a [`StoppingCriterion`](@ref).
 * `parallel` – (`false`) clarify that we are doing a parallel DR, i.e. on a

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -12,7 +12,7 @@ Store all options required for the DouglasRachford algorithm,
   ``x^{(k+1)} = g(α(k); x^{(k)}, t^{(k)})``, where ``t^{(k)}`` is the result
   of the double reflection involved in the DR algorithm
 * `R` – method employed in the iteration to perform the reflection of `x` at the prox `p`.
-* `reflection_evaluation` – whether `R` works inplace or allocating`
+* `reflection_evaluation` – whether `R` works inplace or allocating
 * `stop` – a [`StoppingCriterion`](@ref)
 * `parallel` – indicate whether we are running a parallel Douglas-Rachford or not.
 

--- a/test/solvers/test_Douglas_Rachford.jl
+++ b/test/solvers/test_Douglas_Rachford.jl
@@ -11,13 +11,17 @@ using Manifolds, Manopt, Test
     prox1a = (M, η, p) -> prox_distance(M, η, d1, p)
     prox2a = (M, η, p) -> prox_distance(M, η, d2, p)
     @test_throws ErrorException DouglasRachford(M, f, Array{Function,1}([prox1a]), p) # we need more than one prox
-    q1 = DouglasRachford(M, f, [prox1a, prox2a], p)
-    @test isapprox(M, q1, p_star; atol=1e-14)
+    q1a = DouglasRachford(M, f, [prox1a, prox2a], p)
+    @test isapprox(M, q1a, p_star; atol=1e-14)
+    q1i = DouglasRachford(
+        M, f, [prox1a, prox2a], p; reflection_evaluation=InplaceEvaluation()
+    )
+    @test isapprox(M, q1i, p_star; atol=1e-14)
     prox1i = (M, q, η, p) -> prox_distance!(M, q, η, d1, p)
     prox2i = (M, q, η, p) -> prox_distance!(M, q, η, d2, p)
     q2 = copy(M, p)
     DouglasRachford!(M, f, [prox1i, prox2i], q2; evaluation=InplaceEvaluation())
-    @test isapprox(M, q1, q2)
+    @test isapprox(M, q1a, q2)
     # but we can also compute the riemannian center of mass (locally) on Sn
     # though also this is not that useful, but easy to test that DR works
     F2(M, p) = distance(M, p, d1)^2 + distance(M, p, d2)^2 + distance(M, p, d3)^2


### PR DESCRIPTION
From a discussion today this PR generalises the `R` keyword and the `reflect` operation of `DouglasRachford` in two senses

* `reflect` now uses the default retraction and default inverse retraction (with keywords) instead of exp and log
* `R` passes `retraction_method` and `inverse_retraction_method` (new keywords of DR) to the reflection it calls
* `reflection_evaluation` can now be set to `InplaceEvaluation` in case `R` works in place.