### PR TITLE
Fix extra allocations in get_gradient!'s jacobian

### DIFF
--- a/src/plans/nonlinear_least_squares_plan.jl
+++ b/src/plans/nonlinear_least_squares_plan.jl
@@ -99,11 +99,11 @@ function get_gradient!(
 end
 
 function get_gradient!(
-    M::AbstractManifold, 
+    M::AbstractManifold,
     X,
     nlso::NonlinearLeastSquaresObjective{InplaceEvaluation},
     p,
-    Jval = zeros(nlso.num_components, manifold_dimension(M))
+    Jval=zeros(nlso.num_components, manifold_dimension(M)),
 )
     basis_p = _maybe_get_basis(M, p, nlso.jacobian_tangent_basis)
     nlso.jacobian!!(M, Jval, p; basis_domain=basis_p)

--- a/src/plans/nonlinear_least_squares_plan.jl
+++ b/src/plans/nonlinear_least_squares_plan.jl
@@ -99,10 +99,13 @@ function get_gradient!(
 end
 
 function get_gradient!(
-    M::AbstractManifold, X, nlso::NonlinearLeastSquaresObjective{InplaceEvaluation}, p
+    M::AbstractManifold, 
+    X,
+    nlso::NonlinearLeastSquaresObjective{InplaceEvaluation},
+    p,
+    Jval = zeros(nlso.num_components, manifold_dimension(M))
 )
     basis_p = _maybe_get_basis(M, p, nlso.jacobian_tangent_basis)
-    Jval = zeros(nlso.num_components, manifold_dimension(M))
     nlso.jacobian!!(M, Jval, p; basis_domain=basis_p)
     residual_values = zeros(nlso.num_components)
     nlso.f(M, residual_values, p)

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -207,7 +207,7 @@ function initialize_solver!(
     lms::LevenbergMarquardtState,
 ) where {mT<:AbstractManifold}
     get_objective(dmp).f(get_manifold(dmp), lms.residual_values, lms.p)
-    lms.X = get_gradient(dmp, lms.p)
+    get_gradient!(dmp, lms.X, lms.p, lms.jacF)
     return lms
 end
 


### PR DESCRIPTION
I'm not sure of the correct way to fix this, but here is the cause of the extra allocations in my example from: https://github.com/JuliaRobotics/IncrementalInference.jl/issues/1546#issuecomment-1750536933

With this fix it shaves off 15 seconds of a 30-second solve.