### PR TITLE
Add jacobian_tangent_basis to docstring

### DIFF
--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -40,6 +40,7 @@ then the keyword `jacobian_tangent_basis` below is ignored
 * `β` – parameter by which the damping term is multiplied when the current new point is rejected
 * `initial_residual_values` – the initial residual vector of the cost function `f`.
 * `initial_jacobian_f` – the initial Jacobian of the cost function `f`.
+* `jacobian_tangent_basis` - [`AbstractBasis`](@ref) specify the basis of the tangent space for `jacobian_f`.
 
 All other keyword arguments are passed to [`decorate_state!`](@ref) for decorators or
 [`decorate_objective!`](@ref), respectively.

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -40,7 +40,7 @@ then the keyword `jacobian_tangent_basis` below is ignored
 * `β` – parameter by which the damping term is multiplied when the current new point is rejected
 * `initial_residual_values` – the initial residual vector of the cost function `f`.
 * `initial_jacobian_f` – the initial Jacobian of the cost function `f`.
-* `jacobian_tangent_basis` - [`AbstractBasis`](@ref) specify the basis of the tangent space for `jacobian_f`.
+* `jacobian_tangent_basis` - [`AbstractBasis`](@ref https://juliamanifolds.github.io/ManifoldsBase.jl/stable/bases/#ManifoldsBase.AbstractBasis) specify the basis of the tangent space for `jacobian_f`.
 
 All other keyword arguments are passed to [`decorate_state!`](@ref) for decorators or
 [`decorate_objective!`](@ref), respectively.

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -40,7 +40,7 @@ then the keyword `jacobian_tangent_basis` below is ignored
 * `β` – parameter by which the damping term is multiplied when the current new point is rejected
 * `initial_residual_values` – the initial residual vector of the cost function `f`.
 * `initial_jacobian_f` – the initial Jacobian of the cost function `f`.
-* `jacobian_tangent_basis` - [`AbstractBasis`](@ref https://juliamanifolds.github.io/ManifoldsBase.jl/stable/bases/#ManifoldsBase.AbstractBasis) specify the basis of the tangent space for `jacobian_f`.
+* `jacobian_tangent_basis` - [`AbstractBasis`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/bases/#ManifoldsBase.AbstractBasis) specify the basis of the tangent space for `jacobian_f`.
 
 All other keyword arguments are passed to [`decorate_state!`](@ref) for decorators or
 [`decorate_objective!`](@ref), respectively.


### PR DESCRIPTION
I was confused when reading

> then the keyword `jacobian_tangent_basis` below is ignored

since there was no such keyword below.