### PR TITLE
Allow `d.msg` in DebugIfEntry to contain an identifier to print the field

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+* Allow the `message=` of the `DebugIfEntry` debug action to contain a format element to print the field in the message as well.
+
 ## [0.4.50] January 26, 2024
 
 ### Fixed

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -370,7 +370,11 @@ end
 @doc raw"""
     DebugIfEntry <: DebugAction
 
-Issue a warning, info or error if a certain field does _not_ pass a check
+Issue a warning, info or error if a certain field does _not_ pass a check.
+
+The `message` is printed in this case. If it contains a `@printf` argument identifier,
+that one will be filled with the value of the `field`.
+That way you can print the vaule in this case as well.
 
 # Fields
 
@@ -400,10 +404,13 @@ mutable struct DebugIfEntry{F} <: DebugAction
 end
 function (d::DebugIfEntry)(::AbstractManoptProblem, st::AbstractManoptSolverState, i)
     if (i >= 0) && (!d.check(getfield(st, d.field)))
-        d.type === :warn && (@warn "$(d.msg)")
-        d.type === :info && (@info "$(d.msg)")
-        d.type === :error && error(d.msg)
-        d.type === :print && print(d.io, d.msg)
+        format = Printf.Format(d.msg)
+        l = format.numarguments
+        msg = l == 0 ? d.msg : Printf.format(format, getfield(st, d.field))
+        d.type === :warn && (@warn "$(msg)")
+        d.type === :info && (@info "$(msg)")
+        d.type === :error && error(msg)
+        d.type === :print && print(d.io, msg)
     end
     return nothing
 end

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -405,8 +405,7 @@ end
 function (d::DebugIfEntry)(::AbstractManoptProblem, st::AbstractManoptSolverState, i)
     if (i >= 0) && (!d.check(getfield(st, d.field)))
         format = Printf.Format(d.msg)
-        l = format.numarguments
-        msg = l == 0 ? d.msg : Printf.format(format, getfield(st, d.field))
+        msg = !('%' ∈ d.msg) ? d.msg : Printf.format(format, getfield(st, d.field))
         d.type === :warn && (@warn "$(msg)")
         d.type === :info && (@info "$(msg)")
         d.type === :error && error(msg)


### PR DESCRIPTION
This is just a very small PR, will not be a complete new version but if tests pass be on master for a while until we have a new version.