### PR TITLE
Kellertuer/fix storages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,14 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.52]
+## [0.4.53] February 13, 2024
+
+### Fixed
+
+* fixes two storage action defaults, that accidentally still tried to initialize a `:Population` (as modified back to `:Iterate` 0.4.49).
+* fix a few typos in the documentation and add a reference for the subgradient menthod.
+
+## [0.4.52] February 5, 2024
 
 ### Added
 

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -313,6 +313,26 @@
 % --- F
 %
 %
+@article{FerreiraOliveira:1998,
+    AUTHOR       = {Ferreira, Orizon and Oliveira, Paulo Roberto},
+    DOI          = {10.1023/A:1022675100677},
+    JOURNAL      = {Journal of Optimization Theory and Applications},
+    NUMBER       = {1},
+    PAGES        = {93--104},
+    TITLE        = {Subgradient algorithm on Riemannian manifolds},
+    VOLUME       = {97},
+    YEAR         = {1998}
+}
+@article{FerreiraOliveira:2002,
+    AUTHOR       = {Ferreira, Orizon and Oliveira, Paulo Roberto},
+    DOI          = {10.1080/02331930290019413},
+    JOURNAL      = {Optimization. A Journal of Mathematical Programming and Operations Research},
+    NUMBER       = {2},
+    PAGES        = {257--270},
+    TITLE        = {Proximal point algorithm on Riemannian manifolds},
+    VOLUME       = {51},
+    YEAR         = {2002}
+}
 @book{Fletcher:1987,
     AUTHOR    = {Fletcher, R.},
     EDITION   = {2},

--- a/docs/src/solvers/subgradient.md
+++ b/docs/src/solvers/subgradient.md
@@ -21,3 +21,10 @@ actions.
 The [`subgradient_method`](@ref) solver requires the following functions of a manifold to be available
 
 * A [`retract!`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/)`(M, q, p, X)`; it is recommended to set the [`default_retraction_method`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/#ManifoldsBase.default_retraction_method-Tuple{AbstractManifold}) to a favourite retraction. If this default is set, a `retraction_method=` does not have to be specified.
+
+## Literature
+
+```@bibliography
+Pages = ["subgradient.md"]
+Canonical=false
+```

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -206,7 +206,7 @@ end
 function StopWhenChangeLess(
     M::AbstractManifold,
     ε::Float64;
-    storage::StoreStateAction=StoreStateAction(M; store_points=Tuple{:Iterate,:Population}),
+    storage::StoreStateAction=StoreStateAction(M; store_points=Tuple{:Iterate}),
     inverse_retraction_method::IRT=default_inverse_retraction_method(M),
 ) where {IRT<:AbstractInverseRetractionMethod}
     return StopWhenChangeLess{IRT,typeof(storage)}(
@@ -215,7 +215,7 @@ function StopWhenChangeLess(
 end
 function StopWhenChangeLess(
     ε::Float64;
-    storage::StoreStateAction=StoreStateAction([:Iterate, :Population]),
+    storage::StoreStateAction=StoreStateAction([:Iterate]),
     manifold::AbstractManifold=DefaultManifold(),
     inverse_retraction_method::IRT=default_inverse_retraction_method(manifold),
 ) where {IRT<:AbstractInverseRetractionMethod}

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -77,6 +77,7 @@ function QuasiNewtonState(
         retraction_method=retraction_method,
         vector_transport_method=vector_transport_method,
     ),
+    kwargs... #ignore others, for example `debug=`.
 ) where {
     P,
     T,

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -77,7 +77,7 @@ function QuasiNewtonState(
         retraction_method=retraction_method,
         vector_transport_method=vector_transport_method,
     ),
-    kwargs... #ignore others, for example `debug=`.
+    kwargs..., #ignore others, for example `debug=`.
 ) where {
     P,
     T,

--- a/src/solvers/subgradient.jl
+++ b/src/solvers/subgradient.jl
@@ -80,7 +80,7 @@ end
 
 @doc raw"""
     subgradient_method(M, f, ∂f, p; kwargs...)
-    subgradient_method(M; sgo, p; kwargs...)
+    subgradient_method(M, sgo, p; kwargs...)
 
 perform a subgradient method ``p_{k+1} = \mathrm{retr}(p_k, s_k∂f(p_k))``,
 
@@ -89,6 +89,7 @@ where ``\mathrm{retr}`` is a retraction, ``s_k`` is a step size, usually the
 Though the subgradient might be set valued,
 the argument `∂f` should always return _one_ element from the subgradient, but
 not necessarily deterministic.
+For more detils see [FerreiraOliveira:1998](@cite).
 
 # Input
 
@@ -98,7 +99,7 @@ not necessarily deterministic.
   restricted to always only returning one value/element from the subdifferential.
   This function can be passed as an allocation function `(M, p) -> X` or
   a mutating function `(M, X, p) -> X`, see `evaluation`.
-* `p` – an initial value ``p_0=p ∈ \mathcal M``
+* `p` – (`rand(M)`) an initial value ``p_0=p ∈ \mathcal M``
 
 alternatively to `f` and `∂f` a [`ManifoldSubgradientObjective`](@ref) `sgo` can be provided.
 


### PR DESCRIPTION
A small bugfix on storages that sometimes assumed `:Population` to exist, which usually does not.