### PR TITLE
Checking for non-descent direction in qN

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.55] unreleased
+
+### Added
+
+* Option `nondescent_direction_behavior` for quasi-Newton solvers. By default it checks for non-descent direction which may not be handled well by some stepsize selection algorithms.
+
 ## [0.4.54] February 28, 2024
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.54"
+version = "0.4.55"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"


### PR DESCRIPTION
A slightly generalized check originally proposed in #339 . Ideally we would also have an option that purges the memory but that's fairly difficult to do in Manopt. This change may be a little difficult to test.