### PR TITLE
Fix a typo in a decorator call.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ManifoldsBase.jl` now is running on Documenter 1.3, `Manopt.jl` documentation now uses [DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl) to refer to sections and functions from `ManifoldsBase.jl`
 
+### Fixed
+
+* fixes a type that when passing `sub_kwargs` to `trust_regions` caused an error in the decoration of the sub objective.
+
 ## [0.4.56] March 4, 2024
 
 ### Added

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -495,7 +495,7 @@ function trust_regions!(
     augmentation_threshold::R=0.75,
     augmentation_factor::R=2.0,
     sub_kwargs=(;),
-    sub_objective=decorate_objective!(M, TrustRegionModelObjective(mho), sub_kwargs...),
+    sub_objective=decorate_objective!(M, TrustRegionModelObjective(mho); sub_kwargs...),
     sub_problem=DefaultManoptProblem(TangentSpace(M, p), sub_objective),
     sub_stopping_criterion::StoppingCriterion=StopAfterIteration(manifold_dimension(M)) |
                                               StopWhenResidualIsReducedByFactorOrPower(;
@@ -513,8 +513,8 @@ function trust_regions!(
             trust_region_radius,
             randomize=randomize,
             (project!)=project!,
-            sub_kwargs...,
             stopping_criterion=sub_stopping_criterion,
+            sub_kwargs...,
         );
         sub_kwargs...,
     ),

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -638,7 +638,7 @@ function step_solver!(mp::AbstractManoptProblem, trs::TrustRegionsState, i)
     if ρ < trs.reduction_threshold || !model_decreased || isnan(ρ)
         trs.trust_region_radius *= trs.reduction_factor
     elseif ρ > trs.augmentation_threshold &&
-        get_manopt_parameter(trs.sub_state, :TrustRegionExceeded)
+        get_manopt_parameter(get_state(trs.sub_state), :TrustRegionExceeded)
         # (b) performed great and exceed/reach the trust region boundary -> increase radius
         trs.trust_region_radius = min(
             trs.augmentation_factor * trs.trust_region_radius, trs.max_trust_region_radius


### PR DESCRIPTION
This caused an error when sub_kwargs was not empty – and a hard to spot typo. We should probably include this in the next release as well.