### PR TITLE
Change PSO SC to a more efficient way of computing.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.58]
+
+### Changed
+
+* introduce a `StopWhenSwarmVelocityLess` stopping criterion for `particle_swarm` replacing
+  the current default of the swarm change, since this is a bit more effective to compute
+
 ## [0.4.57] March 15, 2024
 
 ### Changed

--- a/docs/src/solvers/convex_bundle_method.md
+++ b/docs/src/solvers/convex_bundle_method.md
@@ -16,6 +16,7 @@ ConvexBundleMethodState
 ```
 
 ## Stopping Criteria
+
 ```@docs
 StopWhenLagrangeMultiplierLess
 ```

--- a/docs/src/solvers/particle_swarm.md
+++ b/docs/src/solvers/particle_swarm.md
@@ -15,6 +15,12 @@ CurrentModule = Manopt
 ParticleSwarmState
 ```
 
+## Stopping Criteria
+
+```@docs
+StopWhenSwarmVelocityLess
+```
+
 ## [Technical details](@id sec-arc-technical-details)
 
 The [`particle_swarm`](@ref) solver requires the following functions of a manifold to be available

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -492,6 +492,7 @@ export StopAfter,
     StopWhenSmallerOrEqual,
     StopWhenStepsizeLess,
     StopWhenSubgradientNormLess,
+    StopWhenSwarmVelocityLess,
     StopWhenTrustRegionIsExceeded
 export get_active_stopping_criteria,
     get_stopping_criteria, get_reason, get_stopping_criterion

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -183,11 +183,24 @@ struct DummyStoppingCriterion <: StoppingCriterion end
     end
 
     @testset "Test further setters" begin
-        swecl = StopWhenEntryChangeLess(:dummy, (p, s, v, w) -> norm(w - v), 1e-5)
+        mgo = ManifoldGradientObjective((M, x) -> x^2, x -> 2x)
+        dmp = DefaultManoptProblem(Euclidean(), mgo)
+        gds = GradientDescentState(
+            Euclidean(),
+            1.0;
+            stopping_criterion=StopAfterIteration(100),
+            stepsize=ConstantStepsize(Euclidean()),
+        )
+        swecl = StopWhenEntryChangeLess(:p, (p, s, v, w) -> norm(w - v), 1e-5)
         @test startswith(repr(swecl), "StopWhenEntryChangeLess\n")
-        update_stopping_criterion!(swecl, :Threshold, 1e-1)
-        @test swecl.threshold == 1e-1
+        update_stopping_criterion!(swecl, :Threshold, 1e-4)
+        @test swecl.threshold == 1e-4
+        @test !swecl(dmp, gds, 1) #First call stores
+        @test swecl(dmp, gds, 2) #Second triggers (no change)
+        swecl(dmp, gds, 0) # reset
+        @test length(swecl.reason) == 0
     end
+
     @testset "Subgradient Norm Stopping Criterion" begin
         M = Euclidean(2)
         p = [1.0, 2.0]
@@ -215,6 +228,7 @@ struct DummyStoppingCriterion <: StoppingCriterion end
         update_stopping_criterion!(c2, :MinSubgradNorm, 1e-8)
         @test c2.threshold == 1e-8
     end
+
     @testset "StopWhenCostNaN & StopWhenIterateNaN" begin
         sc1 = StopWhenCostNaN()
         f(M, p) = NaN

--- a/test/solvers/test_particle_swarm.jl
+++ b/test/solvers/test_particle_swarm.jl
@@ -67,7 +67,7 @@ using Random
         s = particle_swarm(M, f, swarm)
         @test s ≈ 0.0
     end
-    @testset "Specific Stoping criteria" begin
+    @testset "Specific Stopping criteria" begin
         sc = StopWhenSwarmVelocityLess(1.0)
         @test startswith(repr(sc), "StopWhenSwarmVelocityLess")
     end

--- a/test/solvers/test_particle_swarm.jl
+++ b/test/solvers/test_particle_swarm.jl
@@ -67,4 +67,8 @@ using Random
         s = particle_swarm(M, f, swarm)
         @test s ≈ 0.0
     end
+    @testset "Specific Stoping criteria" begin
+        sc = StopWhenSwarmVelocityLess(1.0)
+        @test startswith(repr(sc), "StopWhenSwarmVelocityLess")
+    end
 end


### PR DESCRIPTION
I thought a bit about #347. The velocities are actually equivalent to the change (the same if the steps are computed with exp). So this PR changes the stopping criterion of SC to this – a bit nicer – form.

Still to check

* [x] documentation
* [x] test coverage
* [x] changelog 