### PR TITLE
Introduce support of subsolver records.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: x64

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: 1
       - name: Install JuliaFormatter and format

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,20 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.59] - May 7, 2024
+## [0.4.60] – unreleased (April, 3024)
+
+### Added
+
+* `RecordWhenActive` to allow records to be deactivated during runtime, symbol `:WhenActive`
+* `RecordSubsolver` to record the result of a subsolver recording in the main solver, symbol `:Subsolver`
+* `RecordStoppingCriterion` to record the reason a solver stopped
+* made the `RecordFactory` more flexible and quite similar to `DebugFactory`, such that it is now also easy to specify recordings at the end of solver runs. This can especially be used to record final states of sub solvers.
+
+### Fixed
+
+* The name `:Subsolver` to generate `DebugWhenActive` was misleading, it is now called `:WhenActive` – referring to “print debug only when set active, e.g. by the parent (main) solver”.
+
+## [0.4.59] - April 7, 2024
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,14 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * made the `RecordFactory` more flexible and quite similar to `DebugFactory`, such that it is now also easy to specify recordings at the end of solver runs. This can especially be used to record final states of sub solvers.
 
 ### Changed
+
 * being a bit more strict with internal tools and made the factories for record non-exported, so this is the same as for debug.
 
 ### Fixed
 
 * The name `:Subsolver` to generate `DebugWhenActive` was misleading, it is now called `:WhenActive` – referring to “print debug only when set active, e.g. by the parent (main) solver”.
-* the old version of specifying `Symbol => RecordAction` for later access was ambigous, since
+* the old version of specifying `Symbol => RecordAction` for later access was ambiguous, since
 it could also mean to store the action in the dictionary under that symbol. Hence the order for access
-was switched to `RecordAction => Sumbol` to resolve that ambiguity.
+was switched to `RecordAction => Symbol` to resolve that ambiguity.
 
 ## [0.4.59] - April 7, 2024
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `RecordWhenActive` to allow records to be deactivated during runtime, symbol `:WhenActive`
 * `RecordSubsolver` to record the result of a subsolver recording in the main solver, symbol `:Subsolver`
-* `RecordStoppingCriterion` to record the reason a solver stopped
+* `RecordStoppingReason` to record the reason a solver stopped
 * made the `RecordFactory` more flexible and quite similar to `DebugFactory`, such that it is now also easy to specify recordings at the end of solver runs. This can especially be used to record final states of sub solvers.
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.60] – unreleased (April, 3024)
+## [0.4.60] – April 10, 2024
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,9 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `RecordStoppingReason` to record the reason a solver stopped
 * made the `RecordFactory` more flexible and quite similar to `DebugFactory`, such that it is now also easy to specify recordings at the end of solver runs. This can especially be used to record final states of sub solvers.
 
+### Changed
+* being a bit more strict with internal tools and made the factories for record non-exported, so this is the same as for debug.
+
 ### Fixed
 
 * The name `:Subsolver` to generate `DebugWhenActive` was misleading, it is now called `:WhenActive` – referring to “print debug only when set active, e.g. by the parent (main) solver”.
+* the old version of specifying `Symbol => RecordAction` for later access was ambigous, since
+it could also mean to store the action in the dictionary under that symbol. Hence the order for access
+was switched to `RecordAction => Sumbol` to resolve that ambiguity.
 
 ## [0.4.59] - April 7, 2024
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.59"
+version = "0.4.60"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ In Julia you can get started by just typing
 using Pkg; Pkg.add("Manopt");
 ```
 
-and then checkout the [Get started: optimize!](https://manoptjl.org/v0.4/tutorials/Optimize/) tutorial.
+and then checkout the [Get started: optimize!](https://manoptjl.org/stable/tutorials/Optimize/) tutorial.
 
 ## Related packages
 

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ In Julia you can get started by just typing
 using Pkg; Pkg.add("Manopt");
 ```
 
-and then checkout the [Get started: optimize!](https://manoptjl.org/stable/tutorials/Optimize!/) tutorial.
+and then checkout the [Get started: optimize!](https://manoptjl.org/v0.4/tutorials/Optimize/) tutorial.
 
 ## Related packages
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -116,7 +116,8 @@ tutorials_menu =
 # (e) finally make docs
 bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style=:alpha)
 links = InterLinks(
-    "ManifoldsBase" => ("https://juliamanifolds.github.io/ManifoldsBase.jl/stable/")
+    "ManifoldsBase" => ("https://juliamanifolds.github.io/ManifoldsBase.jl/stable/"),
+    "Manifolds" => ("https://juliamanifolds.github.io/Manifolds.jl/stable/"),
 )
 makedocs(;
     format=Documenter.HTML(;

--- a/docs/src/plans/record.md
+++ b/docs/src/plans/record.md
@@ -7,19 +7,33 @@ CurrentModule = Manopt
 To record values during the iterations of a solver run, there are in general two possibilities.
 On the one hand, the high-level interfaces provide a `record=` keyword, that accepts several different inputs. For more details see [How to record](../tutorials/HowToRecord.md).
 
-For example recording the gradient from the [`GradientDescentState`](@ref) is
-automatically available, as explained in the [`gradient_descent`](@ref) solver.
-
-## [Record solver states](@id subsec-record-states)
+## [Record Actions & the solver state decorator](@id subsec-record-states)
 
 ```@autodocs
 Modules = [Manopt]
 Pages = ["plans/record.jl"]
-Order = [:type, :function]
-Private = true
+Order = [:type]
 ```
 
-see [recording values](@ref sec-record) for details on the decorated solver.
+## Access functions
+
+```@autodocs
+Modules = [Manopt]
+Pages = ["plans/record.jl"]
+Order = [:function]
+Public = true
+Private = false
+```
+
+## Internal factory functions
+
+```@autodocs
+Modules = [Manopt]
+Pages = ["plans/record.jl"]
+Order = [:function]
+Public = false
+Private = true
+```
 
 Further specific [`RecordAction`](@ref)s can be found when specific types of [`AbstractManoptSolverState`](@ref) define them on their corresponding site.
 

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -543,7 +543,7 @@ export DebugWarnIfLagrangeMultiplierIncreases
 export DebugWarnIfGradientNormTooLarge, DebugMessages
 #
 # Records - and access functions
-export get_record, get_record_state, get_record_action, has_record
+export get_record, get_record_state, get_record_action, has_record, getindex
 export RecordAction
 export RecordGroup, RecordEvery
 export RecordChange, RecordCost, RecordIterate, RecordIteration

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -550,6 +550,7 @@ export RecordGroup, RecordEvery
 export RecordChange, RecordCost, RecordIterate, RecordIteration
 export RecordEntry, RecordEntryChange, RecordTime
 export RecordGradient, RecordGradientNorm, RecordStepsize
+export RecordSubsolver, RecordWhenActive, RecordStoppingReason
 export RecordPrimalBaseChange,
     RecordPrimalBaseIterate, RecordPrimalChange, RecordPrimalIterate
 export RecordDualBaseChange, RecordDualBaseIterate, RecordDualChange, RecordDualIterate

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -545,7 +545,6 @@ export DebugWarnIfGradientNormTooLarge, DebugMessages
 # Records - and access functions
 export get_record, get_record_state, get_record_action, has_record
 export RecordAction
-export RecordActionFactory, RecordFactory
 export RecordGroup, RecordEvery
 export RecordChange, RecordCost, RecordIterate, RecordIteration
 export RecordEntry, RecordEntryChange, RecordTime

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -1175,7 +1175,7 @@ making it deactivatable by its parent solver.
 """
 function DebugGroupFactory(a::Vector; activation_offset=1)
     group = DebugAction[]
-    for d in filter(x -> !isa(x, Int) && (x ∉ [:WhenActive]), a) # filter Ints, &Sub
+    for d in filter(x -> !isa(x, Int) && (x ∉ [:WhenActive]), a) # filter Ints, &Active
         push!(group, DebugActionFactory(d))
     end
     l = length(group)

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -748,7 +748,7 @@ mutable struct DebugWhenActive{D<:DebugAction} <: DebugAction
     always_update::Bool
     function DebugWhenActive(
         d::D, active::Bool=true, always_update::Bool=true
-    ) where {D<:Manopt.DebugAction}
+    ) where {D<:DebugAction}
         return new{D}(d, active, always_update)
     end
 end

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -755,7 +755,7 @@ end
 function (dwa::DebugWhenActive)(p::AbstractManoptProblem, st::AbstractManoptSolverState, i)
     if dwa.active
         dwa.debug(p, st, i)
-    elseif (dwa.always_update) && (i <= 0)
+    elseif (i <= 0) && (dwa.always_update)
         dwa.debug(p, st, i)
     end
 end

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -1068,7 +1068,7 @@ end
 Generate a dictionary of [`DebugAction`](@ref)s.
 
 First all `Symbol`s `String`, [`DebugAction`](@ref)s and numbers are collected,
-excluding `:Stop` and `:Subsolver`.
+excluding `:Stop` and `:WhenActive`.
 This collected vector is added to the `:Iteration => [...]` pair.
 `:Stop` is added as `:StoppingCriterion` to the `:Stop => [...]` pair.
 If necessary, these pairs are created
@@ -1076,7 +1076,7 @@ If necessary, these pairs are created
 For each `Pair` of a `Symbol` and a `Vector`, the [`DebugGroupFactory`](@ref)
 is called for the `Vector` and the result is added to the debug dictonaries entry
 with said symbold. This is wrapped into the [`DebugWhenActive`](@ref),
-when the `:Subsolver` symbol is present
+when the `:WhenActive` symbol is present
 
 # Return value
 
@@ -1116,7 +1116,7 @@ function DebugFactory(a::Vector{<:Any})
     # filter out :Iteration defaults
     # filter numbers & stop & pairs (pairs handles separately, numbers at the end)
     iter_entries = filter(
-        x -> !isa(x, Pair) && (x ∉ [:Stop, :Subsolver]) && !isa(x, Int), a
+        x -> !isa(x, Pair) && (x ∉ [:Stop, :WhenActive]) && !isa(x, Int), a
     )
     # Filter pairs
     b = filter(x -> isa(x, Pair), a)
@@ -1146,7 +1146,7 @@ function DebugFactory(a::Vector{<:Any})
     for d in b
         offset = d.first === :BeforeIteration ? 0 : 1
         dbg = DebugGroupFactory(d.second; activation_offset=offset)
-        (:Subsolver in a) && (dbg = DebugWhenActive(dbg))
+        (:WhenActive in a) && (dbg = DebugWhenActive(dbg))
         # Add DebugEvery to all but Start and Stop
         (!(d.first in [:Start, :Stop]) && (ae > 0)) && (dbg = DebugEvery(dbg, ae))
         dictionary[d.first] = dbg
@@ -1170,12 +1170,12 @@ If this results in more than one [`DebugAction`](@ref) a [`DebugGroup`](@ref) of
 If any integers are present, the last of these is used to wrap the group in a
 [`DebugEvery`](@ref)`(k)`.
 
-If `:SubSolver` is present, the resulting Action is wrappedn in [`DebugWhenActive`](@ref),
+If `:WhenActive` is present, the resulting Action is wrappedn in [`DebugWhenActive`](@ref),
 making it deactivatable by its parent solver.
 """
 function DebugGroupFactory(a::Vector; activation_offset=1)
     group = DebugAction[]
-    for d in filter(x -> !isa(x, Int) && (x ∉ [:Subsolver]), a) # filter Ints, &Sub
+    for d in filter(x -> !isa(x, Int) && (x ∉ [:WhenActive]), a) # filter Ints, &Sub
         push!(group, DebugActionFactory(d))
     end
     l = length(group)
@@ -1190,7 +1190,7 @@ function DebugGroupFactory(a::Vector; activation_offset=1)
     if length(e) > 0
         debug = DebugEvery(debug, last(e); activation_offset=activation_offset)
     end
-    (:Subsolver in a) && (debug = (DebugWhenActive(debug)))
+    (:WhenActive in a) && (debug = (DebugWhenActive(debug)))
     return debug
 end
 DebugGroupFactory(a; kwargs...) = DebugGroupFactory([a]; kwargs...)

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -749,7 +749,7 @@ mutable struct DebugWhenActive{D<:DebugAction} <: DebugAction
     function DebugWhenActive(
         d::D, active::Bool=true, always_update::Bool=true
     ) where {D<:Manopt.DebugAction}
-        return DebugWhenActive{D}(d, active, always_update)
+        return new{D}(d, active, always_update)
     end
 end
 function (dwa::DebugWhenActive)(p::AbstractManoptProblem, st::AbstractManoptSolverState, i)

--- a/src/plans/record.jl
+++ b/src/plans/record.jl
@@ -105,7 +105,6 @@ _has_record(::AbstractManoptSolverState, ::Val{false}) = false
 Set certain values specified by `args...` into the elements of the `recordDictionary`
 """
 function set_manopt_parameter!(rss::RecordSolverState, ::Val{:Record}, args...)
-    println("Fn")
     for d in values(rss.recordDictionary)
         set_manopt_parameter!(d, args...)
     end
@@ -758,7 +757,7 @@ status_summary(ri::RecordTime) = (ri.mode === :iterative ? ":IterativeTime" : ":
 
 Generate a dictionary of [`RecordAction`](@ref)s.
 
-First all `Symbol`s `String`, [`DebugAction`](@ref)s and numbers are collected,
+First all `Symbol`s `String`, [`RecordAction`](@ref)s and numbers are collected,
 excluding `:Stop` and `:WhenActive`.
 This collected vector is added to the `:Iteration => [...]` pair.
 `:Stop` is added as `:StoppingCriterion` to the `:Stop => [...]` pair.
@@ -772,7 +771,7 @@ when the `:WhenActive` symbol is present
 # Return value
 
 A dictionary for the different enrty points where debug can happen, each containing
-a [`DebugAction`](@ref) to call.
+a [`RecordAction`](@ref) to call.
 
 Note that upon the initialisation all dictionaries but the `:StartAlgorithm`
 one are called with an `i=0` for reset.
@@ -814,7 +813,7 @@ function RecordFactory(s::AbstractManoptSolverState, a::Array{<:Any,1})
     for d in b
         dbg = RecordGroupFactory(s, d.second)
         (:WhenActive in a) && (dbg = RecordWhenActive(dbg))
-        # Add DebugEvery to all but Start and Stop
+        # Add RecordEvery to all but Start and Stop
         (!(d.first in [:Start, :Stop]) && (ae > 0)) && (dbg = RecordEvery(dbg, ae))
         dictionary[d.first] = dbg
     end
@@ -826,15 +825,15 @@ RecordFactory(s::AbstractManoptSolverState, a) = RecordFactory(s, [a])
 
 Generate a [`RecordGroup`] of [`RecordAction`](@ref)s. The following rules are used
 
-1. Any `Symbol` contained in `a` is passed to [`RecordActionFactory`](@ref DebugActionFactory(::Symbol))
+1. Any `Symbol` contained in `a` is passed to [`RecordActionFactory`](@ref RecordActionFactory(s::AbstractManoptSolverState, ::Symbol))
 2. Any [`RecordAction`](@ref) is included as is.
 Any Pair of a Recordaction and a symbol, that is in order `RecordCost() => :A` is handled,
 that the corresponding record action can later be accessed as `g[:A]`, where `g`is the record group generated here.
 
-If this results in more than one [`DebugAction`](@ref) a [`DebugGroup`](@ref) of these is build.
+If this results in more than one [`RecordAction`](@ref) a [`RecordGroup`](@ref) of these is build.
 
 If any integers are present, the last of these is used to wrap the group in a
-[`DebugEvery`](@ref)`(k)`.
+[`RecordEvery`](@ref)`(k)`.
 
 If `:WhenActive` is present, the resulting Action is wrappedn in [`RecordWhenActive`](@ref), making it deactivatable by its parent solver.
 """

--- a/src/plans/record.jl
+++ b/src/plans/record.jl
@@ -6,9 +6,13 @@ The usual call is given by
 `(amp::AbstractManoptProblem, ams::AbstractManoptSolverState, i) -> s` that performs the record,
 where `i` is the current iteration.
 
-By convention `i<=0` is interpreted as "For Initialization only," so only
+By convention `i=0` is interpreted as "For Initialization only," so only
 initialize internal values, but not trigger any record, that the record is
 called from within [`stop_solver!`](@ref) which returns true afterwards.
+
+Any negative value is interpreted as a “reset”, and should hence delete all stored recordings,
+for example when reusing a `RecordAction`. The start of a solver calls the `:Iteration` and `:Stop`.
+dictionary entries with `-1`
 
 # Fields (assumed by subtypes to exist)
 
@@ -198,7 +202,7 @@ function record_or_reset!(r::RecordAction, v, i::Int)
     if i > 0
         push!(r.recorded_values, deepcopy(v))
     elseif i < 0 # reset if negative
-        r.recorded_values = similar(r.recorded_values) # Reset to empty
+        r.recorded_values = empty(r.recorded_values) # Reset to empty
     end
 end
 

--- a/src/plans/record.jl
+++ b/src/plans/record.jl
@@ -100,11 +100,12 @@ _has_record(s::AbstractManoptSolverState, ::Val{true}) = has_record(s.state)
 _has_record(::AbstractManoptSolverState, ::Val{false}) = false
 
 """
-    set_manopt_parameter!(ams::DebugSolverState, ::Val{:Debug}, args...)
+    set_manopt_parameter!(ams::REcordSolverState, ::Val{:Record}, args...)
 
-Set certain values specified by `args...` into the elements of the `debugDictionary`
+Set certain values specified by `args...` into the elements of the `recordDictionary`
 """
 function set_manopt_parameter!(rss::RecordSolverState, ::Val{:Record}, args...)
+    println("Fn")
     for d in values(rss.recordDictionary)
         set_manopt_parameter!(d, args...)
     end
@@ -765,7 +766,7 @@ If any of these two pairs does not exist, it is pairs are created when adding th
 
 For each `Pair` of a `Symbol` and a `Vector`, the [`RecordGroupFactory`](@ref)
 is called for the `Vector` and the result is added to the debug dictonaries entry
-with said symbold. This is wrapped into the [`DebugWhenActive`](@ref),
+with said symbold. This is wrapped into the [`RecordWhenActive`](@ref),
 when the `:WhenActive` symbol is present
 
 # Return value
@@ -790,6 +791,7 @@ function RecordFactory(s::AbstractManoptSolverState, a::Array{<:Any,1})
     i = findlast(x -> (isa(x, Pair)) && (x.first == :Iteration), b)
     if !isnothing(i)
         iter = popat!(b, i) #
+        println(iter, "<-")
         b = [b..., :Iteration => [iter.second..., iter_entries...]]
     else
         (length(iter_entries) > 0) && (b = [b..., :Iteration => iter_entries])
@@ -799,9 +801,9 @@ function RecordFactory(s::AbstractManoptSolverState, a::Array{<:Any,1})
         i = findlast(x -> (isa(x, Pair)) && (x.first == :Stop), b)
         if !isnothing(i)
             stop = popat!(b, i) #
-            b = [b..., :Stop => [stop.second..., RecordActionFactory(:Stop)]]
+            b = [b..., :Stop => [stop.second..., RecordActionFactory(s, :Stop)]]
         else # regenerate since we have to maybe change type of b
-            b = [b..., :Stop => [RecordActionFactory(:Stop)]]
+            b = [b..., :Stop => [RecordActionFactory(s, :Stop)]]
         end
     end
     dictionary = Dict{Symbol,RecordAction}()

--- a/src/solvers/record_solver.jl
+++ b/src/solvers/record_solver.jl
@@ -7,6 +7,9 @@ that were added to the `:Start` entry.
 function initialize_solver!(amp::AbstractManoptProblem, rss::RecordSolverState)
     initialize_solver!(amp, rss.state)
     get(rss.recordDictionary, :Start, RecordGroup())(amp, get_state(rss), 0)
+    # Reset Iteation and Stop
+    get(rss.recordDictionary, :Iteration, RecordGroup())(amp, get_state(rss), 0)
+    get(rss.recordDictionary, :Stop, RecordGroup())(amp, get_state(rss), 0)
     return rss
 end
 

--- a/src/solvers/record_solver.jl
+++ b/src/solvers/record_solver.jl
@@ -8,8 +8,8 @@ function initialize_solver!(amp::AbstractManoptProblem, rss::RecordSolverState)
     initialize_solver!(amp, rss.state)
     get(rss.recordDictionary, :Start, RecordGroup())(amp, get_state(rss), 0)
     # Reset Iteation and Stop
-    get(rss.recordDictionary, :Iteration, RecordGroup())(amp, get_state(rss), 0)
-    get(rss.recordDictionary, :Stop, RecordGroup())(amp, get_state(rss), 0)
+    get(rss.recordDictionary, :Iteration, RecordGroup())(amp, get_state(rss), -1)
+    get(rss.recordDictionary, :Stop, RecordGroup())(amp, get_state(rss), -1)
     return rss
 end
 

--- a/test/plans/test_debug.jl
+++ b/test/plans/test_debug.jl
@@ -426,8 +426,8 @@ Manopt.get_manopt_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         dG(mp, st, 2)
         @test endswith(String(take!(io)), " | ")
         # test its usage in the factory independent of position
-        @test DebugFactory([" | ", :Subsolver])[:Iteration] isa DebugWhenActive
-        @test DebugFactory([:Subsolver, " | "])[:Iteration] isa DebugWhenActive
+        @test DebugFactory([" | ", :WhenActive])[:Iteration] isa DebugWhenActive
+        @test DebugFactory([:WhenActive, " | "])[:Iteration] isa DebugWhenActive
 
         dst = DebugSolverState(st, dA)
         set_manopt_parameter!(dst, :Debug, :active, true)

--- a/test/plans/test_debug.jl
+++ b/test/plans/test_debug.jl
@@ -418,6 +418,7 @@ Manopt.get_manopt_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         dE(mp, st, 2)
         @test endswith(String(take!(io)), " | ")
         set_manopt_parameter!(dE, :active, false) # deactivate
+        dE(mp, st, -1) # rset still working
         dE(mp, st, 2)
         @test endswith(String(take!(io)), "")
         @test !dA.active

--- a/test/plans/test_record.jl
+++ b/test/plans/test_record.jl
@@ -251,7 +251,6 @@ Manopt.get_manopt_parameter(d::TestRecordParameterState, ::Val{:value}) = d.valu
         @test (:Cost in keys(rg.indexSymbols)) && (:Cost2 in keys(rg.indexSymbols))
         @test (1 in values(rg.indexSymbols)) && (2 in values(rg.indexSymbols))
     end
-    # Record Time
     @testset "RecordTime" begin
         h1 = RecordTime(; mode=:cumulative)
         @test repr(h1) == "RecordTime(; mode=:cumulative)"

--- a/test/plans/test_record.jl
+++ b/test/plans/test_record.jl
@@ -201,9 +201,12 @@ Manopt.get_manopt_parameter(d::TestRecordParameterState, ::Val{:value}) = d.valu
         rwa(dmp, gds, 1)
         set_manopt_parameter!(rwa, :active, false)
         @test !rwa.active
-        # check always update
+        # check inactive
         rwa(dmp, gds, 2)
         @test length(get_record(rwa)) == 1 # updated, but not cleared
+        # check always update
+        rwa(dmp, gds, -1)
+        @test length(get_record(rwa)) == 0 # updated, but not cleared
     end
     @testset "RecordFactory" begin
         gds.X = [0.0, 0.0]
@@ -228,10 +231,13 @@ Manopt.get_manopt_parameter(d::TestRecordParameterState, ::Val{:value}) = d.valu
                 ],
             ),
         )
+    end
+    @testset "RecordActionactory" begin
+        g = RecordCost()
         @test RecordActionFactory(gds, g) == g
         rss = RecordActionFactory(gds, :Subsolver)
         @test rss isa RecordSubsolver
-        @test rss2.record == [:Iteration]# Default
+        @test rss.record == [:Iteration]# Default
         rss2 = RecordActionFactory(gds, (:Subsolver, :Stop))
         @test rss2 isa RecordSubsolver
         @test rss2.record == [:Stop]

--- a/test/plans/test_record.jl
+++ b/test/plans/test_record.jl
@@ -48,7 +48,7 @@ Manopt.get_manopt_parameter(d::TestRecordParameterState, ::Val{:value}) = d.valu
         RecordIteration,
     )
     @test isa(RecordFactory(gds, :Iteration)[:Iteration], RecordIteration)
-    sa = :It3 => RecordIteration()
+    sa = RecordIteration() => :It3
     @test RecordActionFactory(gds, sa) === sa
     @test !has_record(gds)
     @test_throws ErrorException get_record(gds)

--- a/tutorials/HowToDebug.qmd
+++ b/tutorials/HowToDebug.qmd
@@ -125,7 +125,7 @@ p3 = exact_penalty_method(
 
 The different lengths of the dotted lines come from the fact that ---at least in the beginning--- the subsolver performs a few steps and each subsolvers step prints a dot.
 
-For this issue, there is the next symbol (similar to the `:Stop`) to indicate that a debug set is a subsolver set `:Subsolver`, which introduces a [`DebugWhenActive`](@ref) that is only activated when the outer debug is actually active, or inother words [`DebugEvery`](@ref) is active itself.
+For this issue, there is the next symbol (similar to the `:Stop`) to indicate that a debug set is a subsolver set `:WhenActive`, which introduces a [`DebugWhenActive`](@ref) that is only activated when the outer debug is actually active, or inother words [`DebugEvery`](@ref) is active itself.
 Furthermore, we want to print the iteration number _before_ printing the subsolvers steps, so we put this into a `Pair`, but we can leave the remaining ones as single
 entries.
 Finally we also prefix `:Stop` with `" | "` and print the iteration number at the time we stop. We get
@@ -150,7 +150,7 @@ p4 = exact_penalty_method(
             :Iteration,
             :Cost,
             "\n",
-            :Subsolver,
+            :WhenActive,
             :Stop => [(:Stop, " | "), " | stopped after iteration ", :Iteration, "\n"],
         ],
     ],

--- a/tutorials/HowToRecord.qmd
+++ b/tutorials/HowToRecord.qmd
@@ -143,6 +143,7 @@ rI = RecordEvery(
 ```
 
 where the notation as a pair with the symbol can be read as “Is accessible by”.
+The `record=` keyword with the symbol `:Iteration` is actually the same as we specified here for the first group entry.
 For recording the final iteration number
 
 ```{julia}
@@ -151,7 +152,8 @@ sI = RecordIteration()
 
 We now combine both into the [`RecordSolverState`](https://manoptjl.org/stable/plans/record/#Manopt.RecordSolverState) decorator. It acts completely the same as any [`AbstractManoptSolverState`](https://manoptjl.org/stable/plans/state/#Manopt.AbstractManoptSolverState) but records something in every iteration additionally. This is stored in a dictionary of [`RecordAction`](https://manoptjl.org/stable/plans/record/#Manopt.RecordAction)s, where `:Iteration` is the action (here the only every sixth iteration group) and the `sI` which is executed at stop.
 
-Note that the keyword `record=` in the high level interface `gradient_descent` only would fill the `:Iteration` symbol of said dictionary.
+Note that the keyword `record=` in the high level interface `gradient_descent` only would fill the `:Iteration` symbol of said dictionary, but we could also pass pairs like in the following,
+that is in the form `Symbol => RecordAction` into that keyword to obtain the same as in
 
 ```{julia}
 r = RecordSolverState(s, Dict(:Iteration => rI, :Stop => sI))

--- a/tutorials/HowToRecord.qmd
+++ b/tutorials/HowToRecord.qmd
@@ -134,15 +134,16 @@ We now first build a  [`RecordGroup`](https://manoptjl.org/stable/plans/record/#
 ```{julia}
 rI = RecordEvery(
     RecordGroup([
-        (:Iteration, RecordIteration()),
-        (:Cost, RecordCost()),
-        (:Gradient, RecordEntry(similar(data[1]), :X)),
+        RecordIteration() => :Iteration,
+        RecordCost() => :Cost,
+        RecordEntry(similar(data[1]), :X) => :Gradient,
     ]),
     6,
 )
 ```
 
-and for recording the final iteration number
+where the notation as a pair with the symbol can be read as “Is accessible by”.
+For recording the final iteration number
 
 ```{julia}
 sI = RecordIteration()
@@ -173,6 +174,9 @@ and the other values during the iterations are
 ```{julia}
 get_record(res, :Iteration, (:Iteration, :Cost))
 ```
+
+where the last tuple contains the names from the pairs when we generated the record group.
+So similarly we can use `:Gradient` as specified before to access the recorded gradient.
 
 ## Recording from a Subsolver
 
@@ -325,7 +329,7 @@ R3 = gradient_descent(
     data[1];
     record=[:Iteration => [
         :Iteration,
-        (:Count, RecordCount()),
+        RecordCount() => :Count,
         :Cost],
     ],
     stepsize = ConstantStepsize(1.0),
@@ -335,7 +339,7 @@ R3 = gradient_descent(
 )
 ```
 
-For `:Cost` we already learned how to access them, the `:Count =>` introduces the following action to obtain the `:Count`. We can again access the whole sets of records
+For `:Cost` we already learned how to access them, the ` => :Count` introduces preceeding action to obtain the `:Count` symbol as its access. We can again access the whole sets of records
 
 ```{julia}
 get_record(R3)


### PR DESCRIPTION
This is a PR to resolve #371.

* generalise the record factories to work more modular (similar to debug), this allows to easier add elements to `:Stop`
* add a `RecordStoppingReason` action to record the stopping reason (dah!)
* add a `RecordWhenActive` (analogue to debug), though not 100% necessary, might be nice to reduce allocations when only requiring every $n$-th subsolver run to actually be recorded
* add a `RecordSubsolverRecords` action that stores the sub solvers record (or parts of it) in the parents record entry for that iteration

# ToDo
* [x] verify and check that the idea works
* [x] extend docuemntation
* [x] write tests
* [x] extend tutorial
* [x] check test coverage

# Open Points

Currently the symbol `:Subsolver` is used _in_ subsolvers to declare them beding dependent (of the parent), while it might be breaking `:WhenActive` might be a nicer symbol. The `:Subsolver` could be used to indicate subsolver recordings. I have to think about this a bit and whether this is seriously breaking, since for now `:Subsolver`.  On the other hand it is not breaking code to the extend it does now work, just that since the last release to this then some might get a bit more subsolver debug.


