### PR TITLE
max_stepsize improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.67] – unreleased
+## [0.4.67] – July 25, 2024
 
 ### Added
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * a few typos in the documentation
-* `WolfePowellLinesearch` do longer uses `max_stepsize` with invalid point by default.
+* `WolfePowellLinesearch` no longer uses `max_stepsize` with invalid point by default.
 
 ## [0.4.66] June 27, 2024
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.67] – unreleased
 
+### Added
+
+* `max_stepsize` methods for `Hyperrectangle`.
+
 ### Fixed
 
 * a few typos in the documentation
+* `WolfePowellLinesearch` do longer uses `max_stepsize` with invalid point by default.
 
 ## [0.4.66] June 27, 2024
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.4.66"
+version = "0.4.67"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -56,9 +56,10 @@ Manopt.LineSearchesStepsize
 Loading `Manifolds.jl` introduces the following additional functions
 
 ```@docs
-mid_point
-Manopt.max_stepsize(::TangentBundle, ::Any)
 Manopt.max_stepsize(::FixedRankMatrices, ::Any)
+Manopt.max_stepsize(::Hyperrectangle, ::Any)
+Manopt.max_stepsize(::TangentBundle, ::Any)
+mid_point
 ```
 
 ## JuMP.jl

--- a/docs/src/plans/stepsize.md
+++ b/docs/src/plans/stepsize.md
@@ -26,9 +26,15 @@ Order = [:type,:function]
 Filter = t -> t != Stepsize
 ```
 
+Some step sizes use [`max_stepsize`](@ref) function as a rough upper estimate for the trust region size.
+It is by default equal to injectivity radius of the exponential map but in some cases a different value is used.
+For the `FixedRankMatrices` manifold an estimate from Manopt is used.
+Tangent bundle with the Sasaki metric has 0 injectivity radius, so the maximum stepsize of the underlying manifold is used instead.
+`Hyperrectangle` also has 0 injectivity radius and an estimate based on maximum of dimensions along each index is used instead.
+For manifolds with corners, however, a line search capable of handling break points along the projected search direction should be used, and such algorithms do not call `max_stepsize`.
+
 ## Literature
 
 ```@bibliography
 Pages = ["stepsize.md"]
 Canonical=false
-```

--- a/docs/src/plans/stepsize.md
+++ b/docs/src/plans/stepsize.md
@@ -38,3 +38,4 @@ For manifolds with corners, however, a line search capable of handling break poi
 ```@bibliography
 Pages = ["stepsize.md"]
 Canonical=false
+```

--- a/ext/ManoptManifoldsExt/manifold_functions.jl
+++ b/ext/ManoptManifoldsExt/manifold_functions.jl
@@ -22,6 +22,12 @@ function max_stepsize(M::FixedRankMatrices, p)
 end
 max_stepsize(M::FixedRankMatrices) = manifold_dimension(M)
 
+"""
+    max_stepsize(M::Hyperrectangle, p)
+
+The default maximum stepsize for `Hyperrectangle` manifold with corners is maximum
+of distances from `p` to each boundary.
+"""
 function max_stepsize(M::Hyperrectangle, p)
     ms = 0.0
     for i in eachindex(M.lb, p)

--- a/ext/ManoptManifoldsExt/manifold_functions.jl
+++ b/ext/ManoptManifoldsExt/manifold_functions.jl
@@ -22,13 +22,26 @@ function max_stepsize(M::FixedRankMatrices, p)
 end
 max_stepsize(M::FixedRankMatrices) = manifold_dimension(M)
 
-max_stepsize(M::Hyperrectangle, p) = max_stepsize(M)
+function max_stepsize(M::Hyperrectangle, p)
+    ms = 0.0
+    for i in eachindex(M.lb, p)
+        dist_ub = M.ub[i] - p[i]
+        if dist_ub > 0
+            ms = max(ms, dist_ub)
+        end
+        dist_lb = p[i] - M.lb[i]
+        if dist_lb > 0
+            ms = max(ms, dist_lb)
+        end
+    end
+    return ms
+end
 function max_stepsize(M::Hyperrectangle)
     ms = 0.0
     for i in eachindex(M.lb, M.ub)
-        ms += (M.ub[i] - M.lb[i])^2
+        ms = max(ms, M.ub[i] - M.lb[i])
     end
-    return sqrt(ms)
+    return ms
 end
 
 """

--- a/ext/ManoptManifoldsExt/manifold_functions.jl
+++ b/ext/ManoptManifoldsExt/manifold_functions.jl
@@ -18,7 +18,17 @@ the choice of typical distance in Matlab Manopt, the dimension of `M`. See
 [this note](https://github.com/NicolasBoumal/manopt/blob/97b6eb6b185334ab7b3991585ed2c044d69ee905/manopt/manifolds/fixedrank/fixedrankembeddedfactory.m#L76-L78)
 """
 function max_stepsize(M::FixedRankMatrices, p)
-    return manifold_dimension(M)
+    return max_stepsize(M)
+end
+max_stepsize(M::FixedRankMatrices) = manifold_dimension(M)
+
+max_stepsize(M::Hyperrectangle, p) = max_stepsize(M)
+function max_stepsize(M::Hyperrectangle)
+    ms = 0.0
+    for i in eachindex(M.lb, M.ub)
+        ms += (M.ub[i] - M.lb[i])^2
+    end
+    return sqrt(ms)
 end
 
 """

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -909,7 +909,6 @@ function (a::WolfePowellLinesearch)(
     X = get_gradient(ams)
     l = real(inner(M, p, η, X))
     grad_norm = norm(M, p, η)
-    println("a.max_stepsize: ", a.max_stepsize)
     max_step_increase = ifelse(
         isfinite(a.max_stepsize), min(1e9, a.max_stepsize / grad_norm), 1e9
     )

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -872,7 +872,7 @@ mutable struct WolfePowellLinesearch{
         candidate_point::P=allocate_result(M, rand),
         candidate_tangent::T=allocate_result(M, zero_vector, candidate_point),
         candidate_direction::T=allocate_result(M, zero_vector, candidate_point),
-        max_stepsize::Real=max_stepsize(M, candidate_point),
+        max_stepsize::Real=max_stepsize(M),
         retraction_method::TRM=default_retraction_method(M),
         vector_transport_method::VTM=default_vector_transport_method(M),
         linesearch_stopsize::Float64=0.0,            # deprecated remove on next breaking change
@@ -909,6 +909,7 @@ function (a::WolfePowellLinesearch)(
     X = get_gradient(ams)
     l = real(inner(M, p, η, X))
     grad_norm = norm(M, p, η)
+    println("a.max_stepsize: ", a.max_stepsize)
     max_step_increase = ifelse(
         isfinite(a.max_stepsize), min(1e9, a.max_stepsize / grad_norm), 1e9
     )

--- a/test/helpers/test_manifold_extra_functions.jl
+++ b/test/helpers/test_manifold_extra_functions.jl
@@ -98,5 +98,8 @@ Random.seed!(42)
             ],
         )
         @test Manopt.max_stepsize(Mfr, pfr) == manifold_dimension(Mfr)
+
+        M = Hyperrectangle([-3, -1.5], [3, 1.5])
+        @test Manopt.max_stepsize(M) ≈ 6.708203932499369
     end
 end

--- a/test/helpers/test_manifold_extra_functions.jl
+++ b/test/helpers/test_manifold_extra_functions.jl
@@ -100,6 +100,7 @@ Random.seed!(42)
         @test Manopt.max_stepsize(Mfr, pfr) == manifold_dimension(Mfr)
 
         M = Hyperrectangle([-3, -1.5], [3, 1.5])
-        @test Manopt.max_stepsize(M) ≈ 6.708203932499369
+        @test Manopt.max_stepsize(M) ≈ 6.0
+        @test Manopt.max_stepsize(M, [-1, 0.5]) ≈ 4.0
     end
 end


### PR DESCRIPTION
I've been debugging some issues with optimization on Hyperrectangle and noticed it lacks `max_stepsize`. Also, `WolfePowellLinesearch` by default tries calling `max_stepsize` with an invalid point. If it tries to get the global maximum stepsize, it should not provide the point, and if it wants local maximum stepsize (which would make some sense), it should call `max_stepsize` before each search separately.