### PR TITLE
Improve performance of IPM

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.69] – unreleased
+
+### Changed
+
+* Improved performance of Interior Point Newton Method.
+
 ## [0.4.68] – August 2, 2024
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ All notable Changes to the Julia package `Manopt.jl` will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.69] – unreleased
+## [0.4.69] – August 3, 2024
 
 ### Changed
 


### PR DESCRIPTION
This significantly improves performance of interior point Newton method. Together with some light improvements to ManifoldsBase, I got from 9ms to below 3ms on the problem from the test suite. The two biggest issues were:
1. Accessing product manifold components like `Y[N, 1]` is really slow. I recommend using things like `Y1, Y2 = submanifold_components(N, Y)` in performance-sensitive code. Maybe it would be possible to speed up `Y[N, 1]` but it would require tinkering with compiler heuristics which is quite difficult and depends on the version of Julia.
2. Broadcasting. It can eliminate vast majority of intermediate arrays.

Not that many potential gains remain as those 3ms are dominated by calls to Hessian and gradient of `g`.