### PR TITLE
Fix links and move them to extref in the AD tutorial.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -139,6 +139,7 @@ end
 # (e) finally make docs
 bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style=:alpha)
 links = InterLinks(
+    "ManifoldDiff" => ("https://juliamanifolds.github.io/ManifoldDiff.jl/stable/"),
     "ManifoldsBase" => ("https://juliamanifolds.github.io/ManifoldsBase.jl/stable/"),
     "Manifolds" => ("https://juliamanifolds.github.io/Manifolds.jl/stable/"),
 )

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -204,7 +204,7 @@ $(_var(:Field, :last_change))
 $(_var(:Field, :inverse_retraction_method))
 $(_var(:Field, :storage))
 * `at_iteration::Int`: indicate at which iteration this stopping criterion was last active.
-* `inverse_retraction`: An [`AbstractInverseRetractionMethod`](@ref) that can be passed
+* `inverse_retraction`: An [`AbstractInverseRetractionMethod`](@extref `ManifoldsBase.AbstractInverseRetractionMethod`) that can be passed
   to approximate the distance by this inverse retraction and a norm on the tangent space.
   This can be used if neither the distance nor the logarithmic map are availannle on `M`.
 * `last_change`: store the last change

--- a/tutorials/AutomaticDifferentiation.qmd
+++ b/tutorials/AutomaticDifferentiation.qmd
@@ -141,7 +141,7 @@ More generally take a change of the metric into account as
 = Df(p)[X] = g_p(\operatorname{grad}f(p), X)
 ```
 
-or in words: we have to change the Riesz representer of the (restricted/projected) differential of $f$ ($\tilde f$) to the one with respect to the Riemannian metric. This is done using [`change_representer`](https://juliamanifolds.github.io/Manifolds.jl/latest/manifolds/metric.html#Manifolds.change_representer-Tuple{AbstractManifold,%20AbstractMetric,%20Any,%20Any}).
+or in words: we have to change the Riesz representer of the (restricted/projected) differential of $f$ ($\tilde f$) to the one with respect to the Riemannian metric. This is done using ``[`change_representer`](@extref `ManifoldsBase.change_representer-Tuple{AbstractManifold, ManifoldsBase.AbstractMetric, Any, Any}`)``{=commonmark}.
 
 ### A continued example
 
@@ -187,7 +187,7 @@ This can be computed for symmetric positive definite matrices by summing the squ
 G(q) = sum(log.(eigvals(Symmetric(q))) .^ 2) / 2
 ```
 
-We can also interpret this as a function on the space of matrices and apply the Euclidean finite differences machinery; in this way we can easily derive the Euclidean gradient. But when computing the Riemannian gradient, we have to change the representer (see again [`change_representer`](https://juliamanifolds.github.io/Manifolds.jl/latest/manifolds/metric.html#Manifolds.change_representer-Tuple{AbstractManifold,%20AbstractMetric,%20Any,%20Any})) after projecting onto the tangent space $T_p\mathcal P(n)$ at $p$.
+We can also interpret this as a function on the space of matrices and apply the Euclidean finite differences machinery; in this way we can easily derive the Euclidean gradient. But when computing the Riemannian gradient, we have to change the representer (see again ``[`change_representer`](@extref `ManifoldsBase.change_representer-Tuple{AbstractManifold, ManifoldsBase.AbstractMetric, Any, Any}`)``{=commonmark}) after projecting onto the tangent space $T_p\mathcal P(n)$ at $p$.
 
 Let's first define a point and the manifold $N=\mathcal P(3)$.
 
@@ -204,7 +204,7 @@ We could first just compute the gradient using `FiniteDifferences.jl`, but this 
 FiniteDifferences.grad(central_fdm(5, 1), G, q)
 ```
 
-Instead, we use the [`RiemannianProjectedBackend`](https://juliamanifolds.github.io/Manifolds.jl/latest/features/differentiation.html#Manifolds.RiemannianProjectionBackend) of `Manifolds.jl`, which in this case internally uses `FiniteDifferences.jl` to compute a Euclidean gradient but then uses the conversion explained before to derive the Riemannian gradient.
+Instead, we use the ``[`RiemannianProjectedBackend`](@extref `ManifoldDiff.RiemannianProjectionBackend`)``{=commonmark} of ``[`Manifolds.jl`](@extref Manifolds :std:doc:`index`)``{=commonmark}, which in this case internally uses `FiniteDifferences.jl` to compute a Euclidean gradient but then uses the conversion explained before to derive the Riemannian gradient.
 
 We define this here again as a function `grad_G_FD` that could be used in the `Manopt.jl` framework within a gradient based optimization.
 
@@ -220,7 +220,7 @@ end
 G1 = grad_G_FD(N, q)
 ```
 
-Now, we can again compare this to the (known) solution of the gradient, namely the gradient of (half of) the distance squared $G(q) = \frac{1}{2}d^2_{\mathcal P(3)}(q,I_3)$ is given by $\operatorname{grad} G(q) = -\operatorname{log}_q I_3$, where $\operatorname{log}$ is the [logarithmic map](https://juliamanifolds.github.io/Manifolds.jl/latest/manifolds/symmetricpositivedefinite.html#Base.log-Tuple{SymmetricPositiveDefinite,%20Vararg{Any,%20N}%20where%20N}) on the manifold.
+Now, we can again compare this to the (known) solution of the gradient, namely the gradient of (half of) the distance squared $G(q) = \frac{1}{2}d^2_{\mathcal P(3)}(q,I_3)$ is given by $\operatorname{grad} G(q) = -\operatorname{log}_q I_3$, where $\operatorname{log}$ is th ``[logarithmic map](@extref Manifolds :jl:method:`Base.log-Tuple{SymmetricPositiveDefinite, Vararg{Any}}`)``{=commonmark} on the manifold.
 
 ```{julia}
 G2 = -log(N, q, Matrix{Float64}(I, 3, 3))


### PR DESCRIPTION
Fix #442 by replacing the remaining hard coded links actually with `extref`s.