### PR TITLE
Add a `PreconditionedDirection` direction rule

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * add a `PreconditionedDirection` variant to the `direction` gradient processor
   keyword argument and its corresponding `PreconditionedDirectionRule`
+* make the preconditioner available in quasi Newton.
+* in `gradient_descent` and `conjugate_gradient_descent` the rule can be added anyways.
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* add a `PreconditionedGradient` variant to the `direction` gradient processor
-  keyword argument and its corresponding `PreconditionedGradientRule`
+* add a `PreconditionedDirection` variant to the `direction` gradient processor
+  keyword argument and its corresponding `PreconditionedDirectionRule`
 
 ### Fixed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.9] unreleased
 
+### Added
+
+* add a `PreconditionedGradient` variant to the `direction` gradient processor
+  keyword argument and its corresponding [`PreconditionedGradientRule`](@ref).
+
 ### Fixed
 
 * the links in the AD tutorial are fixed and moved to using `extref`

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * add a `PreconditionedGradient` variant to the `direction` gradient processor
-  keyword argument and its corresponding [`PreconditionedGradientRule`](@ref).
+  keyword argument and its corresponding `PreconditionedGradientRule`
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 authors = ["Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/docs/src/solvers/gradient_descent.md
+++ b/docs/src/solvers/gradient_descent.md
@@ -25,7 +25,7 @@ DirectionUpdateRule
 IdentityUpdateRule
 MomentumGradient
 Nesterov
-PreconditionedGradient
+PreconditionedDirection
 ```
 
 which internally use the [`ManifoldDefaultsFactory`](@ref) and produce the internal
@@ -36,7 +36,7 @@ Manopt.AverageGradientRule
 Manopt.ConjugateDescentCoefficientRule
 Manopt.MomentumGradientRule
 Manopt.NesterovRule
-Manopt.PreconditionedGradientRule
+Manopt.PreconditionedDirectionRule
 ```
 
 ## Debug actions

--- a/docs/src/solvers/gradient_descent.md
+++ b/docs/src/solvers/gradient_descent.md
@@ -25,6 +25,7 @@ DirectionUpdateRule
 IdentityUpdateRule
 MomentumGradient
 Nesterov
+PreconditionedGradient
 ```
 
 which internally use the [`ManifoldDefaultsFactory`](@ref) and produce the internal
@@ -35,6 +36,7 @@ Manopt.AverageGradientRule
 Manopt.ConjugateDescentCoefficientRule
 Manopt.MomentumGradientRule
 Manopt.NesterovRule
+Manopt.PreconditionedGradientRule
 ```
 
 ## Debug actions

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -438,7 +438,8 @@ export AbstractMeshSearchFunction, DefaultMeshAdaptiveDirectSearch
 #
 # Direction Update Rules
 export DirectionUpdateRule
-export Gradient, StochasticGradient, AverageGradient, MomentumGradient, Nesterov
+export Gradient, StochasticGradient
+export AverageGradient, MomentumGradient, Nesterov, PreconditionedGradient
 export SteepestDescentCoefficient,
     HestenesStiefelCoefficient,
     FletcherReevesCoefficient,

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -439,7 +439,7 @@ export AbstractMeshSearchFunction, DefaultMeshAdaptiveDirectSearch
 # Direction Update Rules
 export DirectionUpdateRule
 export Gradient, StochasticGradient
-export AverageGradient, MomentumGradient, Nesterov, PreconditionedGradient
+export AverageGradient, MomentumGradient, Nesterov, PreconditionedDirection
 export SteepestDescentCoefficient,
     HestenesStiefelCoefficient,
     FletcherReevesCoefficient,

--- a/src/plans/gradient_plan.jl
+++ b/src/plans/gradient_plan.jl
@@ -587,9 +587,9 @@ function Nesterov(args...; kwargs...)
 end
 
 """
-    PreconditionedGradientRule{E<:AbstractEvaluationType} <: DirectionUpdateRule
+    PreconditionedDirectionRule{E<:AbstractEvaluationType} <: DirectionUpdateRule
 
-Add a preconditioning as gradient processor, see [`PreconditionedGradient`](@ref)
+Add a preconditioning as gradient processor, see [`PreconditionedDirection`](@ref)
 for more mathematical background.
 
 # Fields
@@ -599,7 +599,7 @@ for more mathematical background.
 
 # Constructors
 
-    PreconditionedGradientRule(
+    PreconditionedDirectionRule(
         M::AbstractManifold,
         preconditioner;
         direction::Union{<:DirectionUpdateRule,ManifoldDefaultsFactory}=IdentityUpdateRule(),
@@ -618,22 +618,22 @@ $(_var(:Argument, :M; type=true))
 $(_var(:Keyword, :evaluation))
 * `direction=`[`IdentityUpdateRule`](@ref) internal [`DirectionUpdateRule`](@ref) to determine the gradients to store or a [`ManifoldDefaultsFactory`](@ref) generating one
 """
-mutable struct PreconditionedGradientRule{
+mutable struct PreconditionedDirectionRule{
     E<:AbstractEvaluationType,D<:DirectionUpdateRule,F
 } <: DirectionUpdateRule
     preconditioner::F
     direction::D
 end
-function PreconditionedGradientRule(
+function PreconditionedDirectionRule(
     M::AbstractManifold,
     preconditioner::F;
     direction::Union{<:DirectionUpdateRule,ManifoldDefaultsFactory}=Gradient(),
     evaluation::E=AllocatingEvaluation(),
 ) where {E<:AbstractEvaluationType,F}
     dir = _produce_type(direction, M)
-    return PreconditionedGradientRule{E,typeof(dir),F}(preconditioner, dir)
+    return PreconditionedDirectionRule{E,typeof(dir),F}(preconditioner, dir)
 end
-function (pg::PreconditionedGradientRule{AllocatingEvaluation})(
+function (pg::PreconditionedDirectionRule{AllocatingEvaluation})(
     mp::AbstractManoptProblem, s::AbstractGradientSolverState, k
 )
     M = get_manifold(mp)
@@ -642,7 +642,7 @@ function (pg::PreconditionedGradientRule{AllocatingEvaluation})(
     step, dir = pg.direction(mp, s, k)
     return step, pg.preconditioner(M, p, dir)
 end
-function (pg::PreconditionedGradientRule{InplaceEvaluation})(
+function (pg::PreconditionedDirectionRule{InplaceEvaluation})(
     mp::AbstractManoptProblem, s::AbstractGradientSolverState, k
 )
     M = get_manifold(mp)
@@ -653,8 +653,8 @@ function (pg::PreconditionedGradientRule{InplaceEvaluation})(
 end
 
 """
-    PreconditionedGradient(preconditioner; kwargs...)
-    PreconditionedGradient(M::AbstractManifold, preconditioner; kwargs...)
+    PreconditionedDirection(preconditioner; kwargs...)
+    PreconditionedDirection(M::AbstractManifold, preconditioner; kwargs...)
 
 Add a preconditioner to a gradient processor following the [motivation for optimization](https://en.wikipedia.org/wiki/Preconditioner#Preconditioning_in_optimization),
 as a linear invertible map ``P: $(_math(:TpM)) → $(_math(:TpM))`` that usually should be
@@ -678,10 +678,10 @@ $(_var(:Argument, :M; type=true)) (optional)
 * `direction=`[`IdentityUpdateRule`](@ref) internal [`DirectionUpdateRule`](@ref) to determine the gradients to store or a [`ManifoldDefaultsFactory`](@ref) generating one
 $(_var(:Keyword, :evaluation))
 
-$(_note(:ManifoldDefaultFactory, "PreconditionedGradientRule"))
+$(_note(:ManifoldDefaultFactory, "PreconditionedDirectionRule"))
 """
-PreconditionedGradient(args...; kwargs...) =
-    ManifoldDefaultsFactory(Manopt.PreconditionedGradientRule, args...; kwargs...)
+PreconditionedDirection(args...; kwargs...) =
+    ManifoldDefaultsFactory(Manopt.PreconditionedDirectionRule, args...; kwargs...)
 
 @doc raw"""
     DebugGradient <: DebugAction

--- a/src/plans/gradient_plan.jl
+++ b/src/plans/gradient_plan.jl
@@ -640,7 +640,9 @@ function (pg::PreconditionedDirectionRule{AllocatingEvaluation})(
     p = get_iterate(s)
     # get inner direction and step size
     step, dir = pg.direction(mp, s, k)
-    return step, pg.preconditioner(M, p, dir)
+    # precondition and set as gradient
+    set_gradient!(s, M, p, pg.preconditioner(M, p, dir))
+    return step, get_gradient(s)
 end
 function (pg::PreconditionedDirectionRule{InplaceEvaluation})(
     mp::AbstractManoptProblem, s::AbstractGradientSolverState, k

--- a/src/plans/gradient_plan.jl
+++ b/src/plans/gradient_plan.jl
@@ -603,7 +603,7 @@ for more mathematical background.
         M::AbstractManifold,
         preconditioner;
         direction::Union{<:DirectionUpdateRule,ManifoldDefaultsFactory}=IdentityUpdateRule(),
-        evaluation::AbstractEvaluationType=AllocatingEvaluation()        n::Int=10
+        evaluation::AbstractEvaluationType=AllocatingEvaluation()
     )
 
 Add preconditioning to a gradient problem.

--- a/src/plans/gradient_plan.jl
+++ b/src/plans/gradient_plan.jl
@@ -665,6 +665,9 @@ as a linear invertible map ``P: $(_math(:TpM)) → $(_math(:TpM))`` that usually
 The gradient is then preconditioned as ``P(X)``, where ``X`` is either the
 gradient of the objective or the result of a previous (internally stored) gradient processor.
 
+For example if you provide as the preconditioner the inverse of the Hessian ``$(_tex(:Hess))^{-1} f``,
+you turn a gradient descent into a Newton method.
+
 # Arguments
 
 $(_var(:Argument, :M; type=true)) (optional)

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -74,7 +74,9 @@ function GradientDescentState(
         p, X, direction, stepsize, stopping_criterion, retraction_method
     )
 end
-function (r::IdentityUpdateRule)(mp::AbstractManoptProblem, s::GradientDescentState, k)
+function (r::IdentityUpdateRule)(
+    mp::AbstractManoptProblem, s::AbstractGradientSolverState, k
+)
     return get_stepsize(mp, s, k), get_gradient!(mp, s.X, s.p)
 end
 function default_stepsize(

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -229,7 +229,7 @@ $(_var(:Keyword, :evaluation; add=:GradientExample))
   * the default `nothing` does not activate a preconditioning
   * a function of the form `(M, p, X) -> Y` or mutating `(M, Y, p, X) -> Y` depending on the `evaluation`
   * a [`PreconditionedDirection`](@ref). See also their docs for mor details on the preconditioner.
-  Note that the preconditioner is applied to the gradient, i.e. the right hand side _before_ solving the linear systen
+  Note that the preconditioner is applied to the gradient, i.e. the right hand side _before_ solving the linear system.
 * `project!=copyto!`: for numerical stability it is possible to project onto the tangent space after every iteration.
   the function has to work inplace of `Y`, that is `(M, Y, p, X) -> Y`, where `X` and `Y` can be the same memory.
 $(_var(:Keyword, :retraction_method))

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -229,6 +229,7 @@ $(_var(:Keyword, :evaluation; add=:GradientExample))
   * the default `nothing` does not activate a preconditioning
   * a function of the form `(M, p, X) -> Y` or mutating `(M, Y, p, X) -> Y` depending on the `evaluation`
   * a [`PreconditionedDirection`](@ref). See also their docs for mor details on the preconditioner.
+  Note that the preconditioner is applied to the gradient, i.e. the right hand side _before_ solving the linear systen
 * `project!=copyto!`: for numerical stability it is possible to project onto the tangent space after every iteration.
   the function has to work inplace of `Y`, that is `(M, Y, p, X) -> Y`, where `X` and `Y` can be the same memory.
 $(_var(:Keyword, :retraction_method))

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -107,9 +107,31 @@ using ManifoldDiff: grad_distance
             grad_f,
             data[1];
             stopping_criterion=StopAfterIteration(1000) | StopWhenChangeLess(M, 1e-16),
-            direction=Nesterov(M; p=copy(M, data[1])),
+            direction=Nesterov(; p=copy(M, data[1])),
         )
         @test isapprox(M, p, p6; atol=1e-13)
+        # Precon in simple scale down by 2
+        p7 = gradient_descent(
+            M,
+            f,
+            grad_f,
+            data[1];
+            stopping_criterion=StopAfterIteration(1000) | StopWhenChangeLess(M, 1e-16),
+            direction=PreconditionedGradient((M, p, X) -> 0.5 .* X),
+        )
+        @test isapprox(M, p, p7; atol=1e-13)
+        # Precon in simple scale down by 2 – inplace
+        p8 = gradient_descent(
+            M,
+            f,
+            grad_f,
+            data[1];
+            stopping_criterion=StopAfterIteration(1000) | StopWhenChangeLess(M, 1e-16),
+            direction=PreconditionedGradient(
+                (M, Y, p, X) -> (Y .= 0.5 .* X); evaluation=InplaceEvaluation()
+            ),
+        )
+        @test isapprox(M, p, p8; atol=1e-13)
         M2 = Euclidean()
         @test_logs (
             :warn,

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -117,7 +117,7 @@ using ManifoldDiff: grad_distance
             grad_f,
             data[1];
             stopping_criterion=StopAfterIteration(1000) | StopWhenChangeLess(M, 1e-16),
-            direction=PreconditionedGradient((M, p, X) -> 0.5 .* X),
+            direction=PreconditionedDirection((M, p, X) -> 0.5 .* X),
         )
         @test isapprox(M, p, p7; atol=1e-13)
         # Precon in simple scale down by 2 – inplace
@@ -127,7 +127,7 @@ using ManifoldDiff: grad_distance
             grad_f,
             data[1];
             stopping_criterion=StopAfterIteration(1000) | StopWhenChangeLess(M, 1e-16),
-            direction=PreconditionedGradient(
+            direction=PreconditionedDirection(
                 (M, Y, p, X) -> (Y .= 0.5 .* X); evaluation=InplaceEvaluation()
             ),
         )

--- a/test/solvers/test_quasi_Newton.jl
+++ b/test/solvers/test_quasi_Newton.jl
@@ -188,6 +188,12 @@ end
         )
         @test isapprox(M, x_lrbfgs2, x_lrbfgs)
 
+        # A simple precon
+        x_lrbfgs = quasi_Newton(
+            M, f, grad_f, x; memory_size=-1, preconditioner=(M, p, X) -> 0.5 .* X
+        )
+        @test isapprox(M, x_lrbfgs, x_solution; atol=rayleigh_atol)
+
         x_clrbfgs = quasi_Newton(M, f, grad_f, x; cautious_update=true)
         @test isapprox(M, x_clrbfgs, x_solution; atol=rayleigh_atol)
 
@@ -401,7 +407,8 @@ end
         M = Euclidean(2)
         p = [0.0, 1.0]
         f(M, p) = sum(p .^ 2)
-        grad_f(M, p) = 2 * sum(p)
+        # A wrong gradient
+        grad_f(M, p) = -2 .* p
         gmp = ManifoldGradientObjective(f, grad_f)
         mp = DefaultManoptProblem(M, gmp)
         qns = QuasiNewtonState(


### PR DESCRIPTION
This new gradient rule allows to easily precondition the gradient as (preconditioning by 0.5):

```
gradient_descent(M, f, grad_f, p0;
    direction=PreconditionedDirection((M, p, X) -> 0.5 .* X),
)
```

or similarly in-place

```
gradient_descent(M, f, grad_f, p0;
    direction = PreconditionedDirection(
        (M, Y, p, X) -> (Y .= 0.5 .* X);
        evaluation=InplaceEvaluation()
    ),
)
```

# 📋
* [x] add this also as a `preconditioner=`keyword to quasi newton (`conjugate_gradient` accepts that as an input already)