### PR TITLE
Do not scale the cost function twice.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow setting `AbstractManifoldObjective` through JuMP
 
+### Fixed
+
+* a scaling error that appeared only when calling `get_cost_function` on the new `ScaledManifoldObjective`.
+
 ## [0.5.12] April 13, 2025
 
 ### Added

--- a/src/plans/scaled_objective.jl
+++ b/src/plans/scaled_objective.jl
@@ -64,7 +64,7 @@ end
 
 function get_cost_function(scaled_objective::ScaledManifoldObjective, recursive::Bool=false)
     recursive && (return get_cost_function(scaled_objective.objective, recursive))
-    return (M, p) -> scaled_objective.scale * get_cost(M, scaled_objective, p)
+    return (M, p) -> get_cost(M, scaled_objective, p)
 end
 @doc """
     get_gradient(M::AbstractManifold, scaled_objective::ScaledManifoldObjective, p)

--- a/test/plans/test_scaled_objective.jl
+++ b/test/plans/test_scaled_objective.jl
@@ -41,7 +41,7 @@ using LinearAlgebra, Manifolds, Manopt, Test, Random
         @test Manopt.get_cost_function(o) === Manopt.get_cost_function(s, true)
         f2 = Manopt.get_cost_function(s)
         @test f2 != f
-        @test f2(M, p) == f(M, p)
+        @test f2(M, p) == -f(M, p)
         # The same for gradient
         @test Manopt.get_gradient_function(o) === Manopt.get_gradient_function(s, true)
     end


### PR DESCRIPTION
fixes #456. Should allow #453 to work again.

I accidentally multiplied the scaling twice for the case where someone requested the cost function. One of the few occasions this is asked for (instead of a point evaluation) is line searches.