### PR TITLE
Allocation-free cost and gradient callback for JuMP interface

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.16] TBD
+
+### Fixed
+
+* Fixed allocations in the callbacks of the JuMP interface so that the solver can query the cost and gradient without allocating.
+
 ## [0.5.15] 2025-05-06
 
 ### Fixed

--- a/ext/ManoptJuMPExt.jl
+++ b/ext/ManoptJuMPExt.jl
@@ -68,10 +68,6 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     problem::Union{Nothing,Manopt.AbstractManoptProblem}
     # State of the optimizer
     state::Union{Nothing,Manopt.AbstractManoptSolverState}
-    # Used to store the vectorized point
-    vectorized_point::Vector{Float64}
-    # Used to store the vectorized tangent
-    vectorized_tangent::Vector{Float64}
     # Starting value for each variable
     variable_primal_start::Vector{Union{Nothing,Float64}}
     # Sense of the optimization, that is whether it is for example min, max or no objective
@@ -85,8 +81,6 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             nothing,
             nothing,
             nothing,
-            Float64[],
-            Float64[],
             Union{Nothing,Float64}[],
             MOI.FEASIBILITY_SENSE,
             nothing,
@@ -315,13 +309,40 @@ already been set.
 """
 MOI.get(model::Optimizer, ::MOI.ObjectiveSense) = model.sense
 
+# We could have it be a subtype of `AbstractManifoldGradientObjective{E,TC,TG}`
+# but I wouldn't know what to do with `TC` and `TG` in this case.
+# But we still implement an API similar to `get_cost` and `get_gradient!`
+# so for consistency.
+struct _EmbeddingObjective{E<:MOI.AbstractNLPEvaluator,T}
+    evaluator::E
+    # Used to store the vectorized point
+    vectorized_point::Vector{Float64}
+    # Used to store the vectorized tangent
+    vectorized_tangent::Vector{Float64}
+    # Used to store the tangent in the embedding space
+    embedding_tangent::T
+end
+
+function _get_cost(M, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    return MOI.eval_objective(objective.evaluator, objective.vectorized_point)
+end
+
+# We put all arguments
+function _get_gradient!(M, gradient, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    MOI.eval_objective_gradient(objective.evaluator, objective.vectorized_tangent, objective.vectorized_point)
+    _reshape_vector!(objective.embedding_tangent, objective.vectorized_tangent, _tangent_shape(M))
+    return ManifoldDiff.riemannian_gradient!(M, gradient, p, objective.embedding_tangent)
+end
+
 """
     MOI.set(model::Optimizer, ::MOI.ObjectiveFunction{F}, func::F) where {F}
 
 Set the objective function as `func` for `model`.
 """
 function MOI.set(
-    model::Optimizer, attr::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
+    model::Optimizer, ::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
 )
     backend = MOI.Nonlinear.SparseReverseMode()
     vars = [MOI.VariableIndex(i) for i in eachindex(model.variable_primal_start)]
@@ -330,21 +351,24 @@ function MOI.set(
     MOI.Nonlinear.set_objective(nlp_model, nl)
     evaluator = MOI.Nonlinear.Evaluator(nlp_model, backend, vars)
     MOI.initialize(evaluator, [:Grad])
-    resize!(model.vectorized_point, length(_point_shape(model.manifold)))
-    resize!(model.vectorized_tangent, length(_tangent_shape(model.manifold)))
-    function eval_f_cb(M, X)
-        _vectorize!(model.vectorized_point, X, _point_shape(M))
-        return MOI.eval_objective(evaluator, model.vectorized_point)
+    objective = let
+        # To avoid creating a closure capturing the `embedding_obj` object,
+        # we use the `let` block trick detailed in:
+        # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
+        embedding_obj = _EmbeddingObjective(
+            evaluator,
+            zeros(length(_point_shape(model.manifold))),
+            zeros(length(_tangent_shape(model.manifold))),
+            _zero(_tangent_shape(model.manifold)),
+        )
+        RiemannianFunction(
+            Manopt.ManifoldGradientObjective(
+                (M, x) -> _get_cost(M, embedding_obj, x),
+                (M, g, x) -> _get_gradient!(M, g, embedding_obj, x),
+                evaluation = Manopt.InplaceEvaluation(),
+            )
+        )
     end
-    function eval_grad_f_cb(M, X)
-        _vectorize!(model.vectorized_point, X, _point_shape(M))
-        MOI.eval_objective_gradient(evaluator, model.vectorized_tangent, model.vectorized_point)
-        reshaped_grad_f = JuMP.reshape_vector(model.vectorized_tangent, _tangent_shape(model.manifold))
-        return ManifoldDiff.riemannian_gradient(model.manifold, X, reshaped_grad_f)
-    end
-    objective = RiemannianFunction(
-        Manopt.ManifoldGradientObjective(eval_f_cb, eval_grad_f_cb)
-    )
     MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
     return nothing
 end
@@ -410,15 +434,31 @@ Return the length of the vectors in the vectorized representation.
 Base.length(shape::ArrayShape) = prod(shape.size)
 
 """
-    _vectorize!(res::Vector{T}, array::Array{T,N}, shape::ArrayShape{M}) where {T,N,M}
+    _vectorize!(res::Vector{T}, array::Array{T,N}, shape::ArrayShape{N}) where {T,N}
 
 Inplace version of `res = JuMP.vectorize(array, shape)`.
 """
-function _vectorize!(res::Vector{T}, array::Array{T,N}, ::ArrayShape{M}) where {T,N,M}
+function _vectorize!(res::Vector{T}, array::Array{T,N}, ::ArrayShape{N}) where {T,N,M}
     copyto!(res, array)
 end
 
-function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{M}) where {T,N,M}
+"""
+    _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+
+Inplace version of `res = JuMP.reshape_vector(vec, shape)`.
+"""
+function _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+    copyto!(res, vec)
+end
+
+"""
+    _zero(shape::ArrayShape)
+
+Return a zero element of the shape `shape`.
+"""
+_zero(shape::ArrayShape{N}) where {N} = zeros(shape.size)
+
+function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{N}) where {T,N}
     return vec(array)
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -42,17 +42,17 @@ function test_sphere()
         # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
         grad_f = ones(3)
 
-        function eval_sum_cb(M, x)
+        function _get_cost(M, x)
             return sum(x)
         end
 
-        function eval_grad_sum_cb(M, g, X)
+        function _get_gradient!(M, g, X)
             return Manopt.riemannian_gradient!(M, g, X, grad_f)
         end
 
         Manopt.ManifoldGradientObjective(
-            eval_sum_cb,
-            eval_grad_sum_cb,
+            _get_cost,
+            _get_gradient!,
             evaluation=Manopt.InplaceEvaluation(),
         )
     end


### PR DESCRIPTION
I wanted to have `_EmbeddingObjective <: AbstractManifoldGradientObjective` so that I don't even have to create a `ManifoldGradientObjective` as the `_EmbeddingObjective` would serve as the objective but I saw that I needed to specify `TC` and `TG` which are the types of the cost and gradient function which didn't really apply if I just wanted to implement `get_cost` and `get_gradient!` directly without creating closures.
So instead, I created (allocation-free !) closures that I gave to `ManifoldGradientObjective` which I think is fine but I left a comment to explain the design choice.
This also moves some code out of the `MOI.set` method which makes it easier to parse both for us and for the compilers :)
I also added tests to make sure it stays allocation-free.