### PR TITLE
Alloc stiefel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.16] TBD
+
+### Fixed
+
+* Fixed allocations in the callbacks of the JuMP interface so that the solver can query the cost and gradient without allocating.
+
 ## [0.5.15] 2025-05-06
 
 ### Fixed

--- a/ext/ManoptJuMPExt.jl
+++ b/ext/ManoptJuMPExt.jl
@@ -68,10 +68,6 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     problem::Union{Nothing,Manopt.AbstractManoptProblem}
     # State of the optimizer
     state::Union{Nothing,Manopt.AbstractManoptSolverState}
-    # Used to store the vectorized point
-    vectorized_point::Vector{Float64}
-    # Used to store the vectorized tangent
-    vectorized_tangent::Vector{Float64}
     # Starting value for each variable
     variable_primal_start::Vector{Union{Nothing,Float64}}
     # Sense of the optimization, that is whether it is for example min, max or no objective
@@ -85,8 +81,6 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             nothing,
             nothing,
             nothing,
-            Float64[],
-            Float64[],
             Union{Nothing,Float64}[],
             MOI.FEASIBILITY_SENSE,
             nothing,
@@ -315,13 +309,40 @@ already been set.
 """
 MOI.get(model::Optimizer, ::MOI.ObjectiveSense) = model.sense
 
+# We could have it be a subtype of `AbstractManifoldGradientObjective{E,TC,TG}`
+# but I wouldn't know what to do with `TC` and `TG` in this case.
+# But we still implement an API similar to `get_cost` and `get_gradient!`
+# so for consistency.
+struct _EmbeddingObjective{E<:MOI.AbstractNLPEvaluator,T}
+    evaluator::E
+    # Used to store the vectorized point
+    vectorized_point::Vector{Float64}
+    # Used to store the vectorized tangent
+    vectorized_tangent::Vector{Float64}
+    # Used to store the tangent in the embedding space
+    embedding_tangent::T
+end
+
+function _get_cost(M, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    return MOI.eval_objective(objective.evaluator, objective.vectorized_point)
+end
+
+# We put all arguments
+function _get_gradient!(M, gradient, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    MOI.eval_objective_gradient(objective.evaluator, objective.vectorized_tangent, objective.vectorized_point)
+    _reshape_vector!(objective.embedding_tangent, objective.vectorized_tangent, _tangent_shape(M))
+    return ManifoldDiff.riemannian_gradient!(M, gradient, p, objective.embedding_tangent)
+end
+
 """
     MOI.set(model::Optimizer, ::MOI.ObjectiveFunction{F}, func::F) where {F}
 
 Set the objective function as `func` for `model`.
 """
 function MOI.set(
-    model::Optimizer, attr::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
+    model::Optimizer, ::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
 )
     backend = MOI.Nonlinear.SparseReverseMode()
     vars = [MOI.VariableIndex(i) for i in eachindex(model.variable_primal_start)]
@@ -330,21 +351,24 @@ function MOI.set(
     MOI.Nonlinear.set_objective(nlp_model, nl)
     evaluator = MOI.Nonlinear.Evaluator(nlp_model, backend, vars)
     MOI.initialize(evaluator, [:Grad])
-    resize!(model.vectorized_point, length(_point_shape(model.manifold)))
-    resize!(model.vectorized_tangent, length(_tangent_shape(model.manifold)))
-    function eval_f_cb(M, X)
-        _vectorize!(model.vectorized_point, X, _point_shape(M))
-        return MOI.eval_objective(evaluator, model.vectorized_point)
+    objective = let
+        # To avoid creating a closure capturing the `embedding_obj` object,
+        # we use the `let` block trick detailed in:
+        # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
+        embedding_obj = _EmbeddingObjective(
+            evaluator,
+            zeros(length(_point_shape(model.manifold))),
+            zeros(length(_tangent_shape(model.manifold))),
+            _zero(_tangent_shape(model.manifold)),
+        )
+        RiemannianFunction(
+            Manopt.ManifoldGradientObjective(
+                (M, x) -> _get_cost(M, embedding_obj, x),
+                (M, g, x) -> _get_gradient!(M, g, embedding_obj, x),
+                evaluation = Manopt.InplaceEvaluation(),
+            )
+        )
     end
-    function eval_grad_f_cb(M, X)
-        _vectorize!(model.vectorized_point, X, _point_shape(M))
-        MOI.eval_objective_gradient(evaluator, model.vectorized_tangent, model.vectorized_point)
-        reshaped_grad_f = JuMP.reshape_vector(model.vectorized_tangent, _tangent_shape(model.manifold))
-        return ManifoldDiff.riemannian_gradient(model.manifold, X, reshaped_grad_f)
-    end
-    objective = RiemannianFunction(
-        Manopt.ManifoldGradientObjective(eval_f_cb, eval_grad_f_cb)
-    )
     MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
     return nothing
 end
@@ -410,15 +434,31 @@ Return the length of the vectors in the vectorized representation.
 Base.length(shape::ArrayShape) = prod(shape.size)
 
 """
-    _vectorize!(res::Vector{T}, array::Array{T,N}, shape::ArrayShape{M}) where {T,N,M}
+    _vectorize!(res::Vector{T}, array::Array{T,N}, shape::ArrayShape{N}) where {T,N}
 
 Inplace version of `res = JuMP.vectorize(array, shape)`.
 """
-function _vectorize!(res::Vector{T}, array::Array{T,N}, ::ArrayShape{M}) where {T,N,M}
+function _vectorize!(res::Vector{T}, array::Array{T,N}, ::ArrayShape{N}) where {T,N,M}
     copyto!(res, array)
 end
 
-function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{M}) where {T,N,M}
+"""
+    _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+
+Inplace version of `res = JuMP.reshape_vector(vec, shape)`.
+"""
+function _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+    copyto!(res, vec)
+end
+
+"""
+    _zero(shape::ArrayShape)
+
+Return a zero element of the shape `shape`.
+"""
+_zero(shape::ArrayShape{N}) where {N} = zeros(shape.size)
+
+function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{N}) where {T,N}
     return vec(array)
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -117,6 +117,7 @@ function _test_stiefel(solver)
     optimize!(model)
     @test objective_value(model) ≈ 2
     @test value.(U) ≈ [1 0; 0 1]
+    _test_allocs(unsafe_backend(model), zeros(2, 2), zeros(2, 2))
     return nothing
 end
 


### PR DESCRIPTION
I wanted to test allocations in the Stiefel example as well but it is allocating.
The allocation does not come from the JuMP extension but form the Manopt part. here is a pure-Manopt reproducer:
```julia
using Manifolds, ManifoldDiff
function alloc()
    M = Stiefel(2, 2)
    embedding_tangent = [-2.0 2.0; 2.0 -2.0]
    gradient = [-2.0 2.0; 2.0 -2.0]
    p = [0.0 0.0; 0.0 0.0]
    ManifoldDiff.riemannian_gradient!(M, gradient, p, embedding_tangent)
    @time ManifoldDiff.riemannian_gradient!(M, gradient, p, embedding_tangent)
end
alloc()
```
This gives
```
  0.000001 seconds (4 allocations: 224 bytes)
2×2 Matrix{Float64}:
 -2.0   2.0
  2.0  -2.0
```