### PR TITLE
Introduce differentials parallel to gradients

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,24 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.19] unreleased
+
+### Added
+
+* a function `get_differential` and `get_differential_function` for first order objectives.
+* a `ParentEvaluationType` for backwards compatibility, then an internal function
+  inhertis its evaluation type from the parent objective. This is the default when
+  passing a function to `GradientFunction` or `DifferenitalFunction`.
+* introduce a new `AllocatingAndInplaceEvaluationType` that is used for the
+  functions that offer both variants.
+
+### Changed
+
+* the `ManifoldGradientObjective` is renamed to `ManifoldFirstOrderObjective`, since the
+ second function might now also represent a differential.
+* the `AbstractManifoldGradientObjective` is renamed to `AbstractManifoldFirstOrderObjective`, since the
+ second function might now also represent a differential.
+
 ## [0.5.18] June 18, 2025
 
 ### Added
@@ -396,7 +414,7 @@ In general this introduces a few factories, that avoid having to pass the manifo
 * Tests use `Aqua.jl` to spot problems in the code
 * introduce a feature-based list of solvers and reduce the details in the alphabetical list
 * adds a `PolyakStepsize`
-* added a `get_subgradient` for `AbstractManifoldGradientObjectives` since their gradient is a special case of a subgradient.
+* added a `get_subgradient` for `AbstractManifoldFirstOrderObjectives` since their gradient is a special case of a subgradient.
 
 ### Fixed
 

--- a/docs/src/plans/objective.md
+++ b/docs/src/plans/objective.md
@@ -11,7 +11,7 @@ AbstractManifoldObjective
 AbstractDecoratedManifoldObjective
 ```
 
-Which has two main different possibilities for its containing functions concerning the evaluation mode, not necessarily the cost, but for example gradient in an [`AbstractManifoldGradientObjective`](@ref).
+Which has two main different possibilities for its containing functions concerning the evaluation mode, not necessarily the cost, but for example gradient in an [`AbstractManifoldFirstOrderObjective`](@ref).
 
 ```@docs
 AbstractEvaluationType
@@ -109,8 +109,8 @@ get_cost_function
 ### Gradient objectives
 
 ```@docs
-AbstractManifoldGradientObjective
-ManifoldGradientObjective
+AbstractManifoldFirstOrderObjective
+ManifoldFirstOrderObjective
 ManifoldAlternatingGradientObjective
 ManifoldStochasticGradientObjective
 NonlinearLeastSquaresObjective

--- a/ext/ManoptJuMPExt.jl
+++ b/ext/ManoptJuMPExt.jl
@@ -332,7 +332,7 @@ function MOI.set(
         return ManifoldDiff.riemannian_gradient(model.manifold, X, reshaped_grad_f)
     end
     objective = RiemannianFunction(
-        Manopt.ManifoldGradientObjective(eval_f_cb, eval_grad_f_cb)
+        Manopt.ManifoldFirstOrderObjective(eval_f_cb, eval_grad_f_cb)
     )
     MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
     return nothing
@@ -361,7 +361,7 @@ function MOI.optimize!(model::Optimizer)
     ]
     objective = model.objective
     if model.sense == MOI.FEASIBILITY_SENSE
-        objective = Manopt.ManifoldGradientObjective(
+        objective = Manopt.ManifoldFirstOrderObjective(
             (_, _) -> 0.0, ManifoldsBase.zero_vector
         )
     elseif model.sense == MOI.MAX_SENSE

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -293,7 +293,7 @@ export DefaultManoptProblem, TwoManifoldProblem, ConstrainedManoptProblem
 #
 # Objectives
 export AbstractDecoratedManifoldObjective,
-    AbstractManifoldGradientObjective,
+    AbstractManifoldFirstOrderObjective,
     AbstractManifoldCostObjective,
     AbstractManifoldObjective,
     AbstractManifoldSubObjective,
@@ -309,7 +309,7 @@ export AbstractDecoratedManifoldObjective,
     ManifoldCostObjective,
     ManifoldDifferenceOfConvexObjective,
     ManifoldDifferenceOfConvexProximalObjective,
-    ManifoldGradientObjective,
+    ManifoldFirstOrderObjective,
     ManifoldHessianObjective,
     ManifoldProximalGradientObjective,
     ManifoldProximalMapObjective,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,3 @@
 
+Base.@deprecate_binding ManifoldGradientObjective ManifoldFirstOrderObjective
+Base.Base.@deprecate_binding AbstractManifoldGradientObjective AbstractManifoldFirstOrderObjective

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -210,7 +210,7 @@ define!(
     :GradientObjective,
     (; objective="gradient_objective", f="f", grad_f="grad_f") -> """
 Alternatively to `$f` and `$grad_f` you can provide
-the corresponding [`AbstractManifoldGradientObjective`](@ref) `$objective` directly.
+the corresponding [`AbstractManifoldFirstOrderObjective`](@ref) `$objective` directly.
 """,
 )
 define!(

--- a/src/plans/alternating_gradient_plan.jl
+++ b/src/plans/alternating_gradient_plan.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    ManifoldAlternatingGradientObjective{E<:AbstractEvaluationType,TCost,TGradient} <: AbstractManifoldGradientObjective{E}
+    ManifoldAlternatingGradientObjective{E<:AbstractEvaluationType,TCost,TGradient} <: AbstractManifoldFirstOrderObjective{E}
 
 An alternating gradient objective consists of
 
@@ -26,7 +26,7 @@ Create a alternating gradient problem with an optional `cost` and the gradient e
 function (returning an array) or a vector of functions.
 """
 struct ManifoldAlternatingGradientObjective{E<:AbstractEvaluationType,TCost,TGradient} <:
-       AbstractManifoldGradientObjective{E,TCost,TGradient}
+       AbstractManifoldFirstOrderObjective{E,TCost,TGradient}
     cost::TCost
     gradient!!::TGradient
 end

--- a/src/plans/cache.jl
+++ b/src/plans/cache.jl
@@ -2,16 +2,16 @@
 # A Simple Cache for Objectives
 #
 @doc """
-     SimpleManifoldCachedObjective{O<:AbstractManifoldGradientObjective{E,TC,TG}, P, T,C} <: AbstractManifoldGradientObjective{E,TC,TG}
+     SimpleManifoldCachedObjective{O<:AbstractManifoldFirstOrderObjective{E,TC,TG}, P, T,C} <: AbstractManifoldFirstOrderObjective{E,TC,TG}
 
-Provide a simple cache for an [`AbstractManifoldGradientObjective`](@ref) that is for a given point `p` this cache
+Provide a simple cache for an [`AbstractManifoldFirstOrderObjective`](@ref) that is for a given point `p` this cache
 stores a point `p` and a gradient ``$(_tex(:grad)) f(p)`` in `X` as well as a cost value ``f(p)`` in `c`.
 
 Both `X` and `c` are accompanied by booleans to keep track of their validity.
 
 # Constructor
 
-    SimpleManifoldCachedObjective(M::AbstractManifold, obj::AbstractManifoldGradientObjective; kwargs...)
+    SimpleManifoldCachedObjective(M::AbstractManifold, obj::AbstractManifoldFirstOrderObjective; kwargs...)
 
 ## Keyword arguments
 

--- a/src/plans/constrained_plan.jl
+++ b/src/plans/constrained_plan.jl
@@ -185,7 +185,7 @@ function ConstrainedManifoldObjective(
     kwargs...,
 )
     if isnothing(hess_f)
-        objective = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+        objective = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     else
         objective = ManifoldHessianObjective(f, grad_f, hess_f; evaluation=evaluation)
     end

--- a/src/plans/constrained_set_plan.jl
+++ b/src/plans/constrained_set_plan.jl
@@ -39,7 +39,7 @@ end
 function ManifoldConstrainedSetObjective(
     f, grad_f, project!!::PF; evaluation::E=AllocatingEvaluation(), indicator=nothing
 ) where {PF,E<:AbstractEvaluationType}
-    obj = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+    obj = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     if isnothing(indicator)
         if evaluation isa AllocatingEvaluation
             ind(M, p) = (distance(M, p, project!!(M, p)) ≈ 0 ? 0 : Inf)

--- a/src/plans/difference_of_convex_plan.jl
+++ b/src/plans/difference_of_convex_plan.jl
@@ -25,7 +25,7 @@ Note that the subdifferential might be given in two possible signatures
 * `∂h!(M, X, p)` which does an [`InplaceEvaluation`](@ref) in place of `X`.
 """
 struct ManifoldDifferenceOfConvexObjective{E,TCost,TGrad,TSubGrad} <:
-       AbstractManifoldGradientObjective{E,TCost,TGrad}
+       AbstractManifoldFirstOrderObjective{E,TCost,TGrad}
     cost::TCost
     gradient!!::TGrad
     ∂h!!::TSubGrad
@@ -241,7 +241,7 @@ just for eventual debug or stopping criteria.
 """
 struct ManifoldDifferenceOfConvexProximalObjective{
     E<:AbstractEvaluationType,THGrad,TCost,TGrad
-} <: AbstractManifoldGradientObjective{E,TCost,TGrad}
+} <: AbstractManifoldFirstOrderObjective{E,TCost,TGrad}
     cost::TCost
     gradient!!::TGrad
     grad_h!!::THGrad

--- a/src/plans/differential_plan.jl
+++ b/src/plans/differential_plan.jl
@@ -1,0 +1,48 @@
+@doc """
+    DifferentialFunction{D} <: AbstractFirstOrderFunction
+
+A wrapper for a function representing the differential ``Df: $(_math(:TM)) → ℝ``,
+or in other words is is a map ``Df(p)[X] ∈ ℝ``.
+Compared to a usual function or functor, this type is meant to distinguish
+the differential from the gradient of a function, since both have similar
+signatures that would only be distinguishable if we require types points and vectors.
+
+# Fields
+* `diff_f!!::D`: a function or functor for the gradient
+
+# Constructor
+
+    DifferentialFunction(diff_f::D)
+
+Create a differential function `diff_f`
+"""
+struct DifferentialFunction{D} <: AbstractFirstOrderFunction
+    diff_f!!::D
+end
+# TODO: get_gradient for this struct?
+
+#
+# Access the differential
+# -----------------------------
+@doc """
+    get_differential(amgo::AbstractManifoldFirstOrderObjective, M, p, X)
+
+return the differential of an [`AbstractManifoldFirstOrderObjective`](@ref) `amgo`
+on the [`AbstractManifold`](@extref) `M` at the point `p` and with tangent vector `X`.
+"""
+get_differential(amgo::AbstractManifoldFirstOrderObjective, M::AbstractManifold, p, X)
+
+function get_differential(
+    amfoo::AbstractManifoldFirstOrderObjective{E,F,DifferentialFunction},
+    M::AbstractManifold,
+    p,
+    X;
+) where {E,F}
+    return amfoo.firsy_order!!(M, p, X)
+end
+# Default – functions, funtors as well as GradientFunctions
+function get_differential(
+    amfoo::AbstractManifoldFirstOrderObjective, M::AbstractManifold, p, X;
+)
+    return inner(M, p, get_gradient(amfoo, M, p, X), X)
+end

--- a/src/plans/hessian_plan.jl
+++ b/src/plans/hessian_plan.jl
@@ -7,13 +7,13 @@ These options are assumed to have a field (`gradient`) to store the current grad
 abstract type AbstractHessianSolverState <: AbstractGradientSolverState end
 
 """
-    AbstractManifoldHessianObjective{T<:AbstractEvaluationType,TC,TG,TH} <: AbstractManifoldGradientObjective{T,TC,TG}
+    AbstractManifoldHessianObjective{T<:AbstractEvaluationType,TC,TG,TH} <: AbstractManifoldFirstOrderObjective{T,TC,TG}
 
 An abstract type for all objectives that provide a (full) Hessian, where
 `T` is a [`AbstractEvaluationType`](@ref) for the gradient and Hessian functions.
 """
 abstract type AbstractManifoldHessianObjective{E<:AbstractEvaluationType,TC,TG,TH} <:
-              AbstractManifoldGradientObjective{E,TC,TG} end
+              AbstractManifoldFirstOrderObjective{E,TC,TG} end
 
 @doc raw"""
     ManifoldHessianObjective{T<:AbstractEvaluationType,C,G,H,Pre} <: AbstractManifoldHessianObjective{T,C,G,H}
@@ -116,7 +116,7 @@ function get_hessian!(
 end
 
 @doc raw"""
-    get_gradient_function(amgo::AbstractManifoldGradientObjective{E<:AbstractEvaluationType})
+    get_gradient_function(amgo::AbstractManifoldFirstOrderObjective{E<:AbstractEvaluationType})
 
 return the function to evaluate (just) the Hessian ``\operatorname{Hess} f(p)``.
 Depending on the [`AbstractEvaluationType`](@ref) `E` this is a function

--- a/src/plans/interior_point_Newton_plan.jl
+++ b/src/plans/interior_point_Newton_plan.jl
@@ -87,7 +87,7 @@ $(_var(:Keyword, :p; add=:as_Initial))
 * `σ=`[`calculate_σ`](@ref)`(M, cmo, p, μ, λ, s)`
 $(_var(:Keyword, :stopping_criterion; default="[`StopAfterIteration`](@ref)`(200)`[` | `](@ref StopWhenAny)[`StopWhenChangeLess`](@ref)`(1e-8)`"))
 $(_var(:Keyword, :retraction_method))
-* `step_objective=`[`ManifoldGradientObjective`](@ref)`(`[`KKTVectorFieldNormSq`](@ref)`(cmo)`, [`KKTVectorFieldNormSqGradient`](@ref)`(cmo)`; evaluation=[`InplaceEvaluation`](@ref)`())`
+* `step_objective=`[`ManifoldFirstOrderObjective`](@ref)`(`[`KKTVectorFieldNormSq`](@ref)`(cmo)`, [`KKTVectorFieldNormSqGradient`](@ref)`(cmo)`; evaluation=[`InplaceEvaluation`](@ref)`())`
 * `vector_space=`[`Rn`](@ref Manopt.Rn): a function that, given an integer, returns the manifold to be used for the vector space components ``ℝ^m,ℝ^n``
 * `step_problem`: wrap the manifold ``$(_math(:M)) × ℝ^m × ℝ^n × ℝ^m``
 * `step_state`: the [`StepsizeState`](@ref) with point and search direction
@@ -143,7 +143,7 @@ mutable struct InteriorPointNewtonState{
         σ::R=calculate_σ(M, cmo, p, μ, λ, s),
         stopping_criterion::SC=StopAfterIteration(200) | StopWhenChangeLess(1e-8),
         retraction_method::RTM=default_retraction_method(M),
-        step_objective=ManifoldGradientObjective(
+        step_objective=ManifoldFirstOrderObjective(
             KKTVectorFieldNormSq(cmo),
             KKTVectorFieldNormSqGradient(cmo);
             evaluation=InplaceEvaluation(),

--- a/src/plans/nonlinear_least_squares_plan.jl
+++ b/src/plans/nonlinear_least_squares_plan.jl
@@ -47,7 +47,7 @@ $(_var(:Keyword, :evaluation))
 """
 struct NonlinearLeastSquaresObjective{
     E<:AbstractEvaluationType,F<:AbstractVectorGradientFunction{E}
-} <: AbstractManifoldGradientObjective{E,F,F}
+} <: AbstractManifoldFirstOrderObjective{E,F,F}
     objective::F
 end
 

--- a/src/plans/objective.jl
+++ b/src/plans/objective.jl
@@ -34,18 +34,36 @@ abstract type AbstractDecoratedManifoldObjective{E,O<:AbstractManifoldObjective}
 @doc raw"""
     AllocatingEvaluation <: AbstractEvaluationType
 
-A parameter for a [`AbstractManoptProblem`](@ref) indicating that the problem uses functions that
-allocate memory for their result, they work out of place.
+A parameter for a [`AbstractManoptProblem`](@ref) or a `Function` indicating that
+the problem contains or the function(s) allocate memory for their result, they work out of place.
 """
 struct AllocatingEvaluation <: AbstractEvaluationType end
 
 @doc raw"""
     InplaceEvaluation <: AbstractEvaluationType
 
-A parameter for a [`AbstractManoptProblem`](@ref) indicating that the problem uses functions that
-do not allocate memory but work on their input, in place.
+A parameter for a [`AbstractManoptProblem`](@ref) or a `Function` indicating that
+the problem contains or the function(s) do not allocate memory but work on their input, in place.
 """
 struct InplaceEvaluation <: AbstractEvaluationType end
+
+@doc raw"""
+    ParentEvaluationType <: AbstractEvaluationType
+
+A parameter for a [`AbstractManoptProblem`](@ref) or a `Function` indicating that
+the problem contains or the function(s) do inherit their property from a parent
+[`AbstractManoptProblem`](@ref) or function.
+"""
+struct ParentEvaluationType <: AbstractEvaluationType end
+
+@doc raw"""
+    AllocatingAndInplaceEvaluation <: AbstractEvaluationType
+
+A parameter for a [`AbstractManoptProblem`](@ref) or a `Function` indicating that
+the problem contains or the function(s) that provides both an allocating variant and one,
+that does not allocate memory but work on their input, in place.
+"""
+struct AllocatingAndInplaceEvaluation <: AbstractEvaluationType end
 
 @doc raw"""
     ReturnManifoldObjective{E,O2,O1<:AbstractManifoldObjective{E}} <:

--- a/src/plans/plan.jl
+++ b/src/plans/plan.jl
@@ -114,6 +114,8 @@ include("stepsize.jl")
 include("bundle_plan.jl")
 include("cost_plan.jl")
 include("gradient_plan.jl")
+# Requires the definitions from first order ideas from the plan.
+include("differential_plan.jl")
 include("hessian_plan.jl")
 include("proximal_plan.jl")
 include("proximal_gradient_plan.jl")

--- a/src/plans/stochastic_gradient_plan.jl
+++ b/src/plans/stochastic_gradient_plan.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    ManifoldStochasticGradientObjective{T<:AbstractEvaluationType} <: AbstractManifoldGradientObjective{T}
+    ManifoldStochasticGradientObjective{T<:AbstractEvaluationType} <: AbstractManifoldFirstOrderObjective{T}
 
 A stochastic gradient objective consists of
 
@@ -37,7 +37,7 @@ Note that this can also be used with a [`gradient_descent`](@ref), since the (co
 is just the sums of the single gradients.
 """
 struct ManifoldStochasticGradientObjective{T<:AbstractEvaluationType,TCost,TGradient} <:
-       AbstractManifoldGradientObjective{T,TCost,TGradient}
+       AbstractManifoldFirstOrderObjective{T,TCost,TGradient}
     cost::TCost
     gradient!!::TGradient
 end

--- a/src/solvers/FrankWolfe.jl
+++ b/src/solvers/FrankWolfe.jl
@@ -203,7 +203,7 @@ $(_var(:Keyword, :stopping_criterion; default="[`StopAfterIteration`](@ref)`(500
   the gradient of the Frank-Wolfe sub problem. $(_note(:KeywordUsedIn, "sub_objective"))
 $(_var(:Keyword, :sub_kwargs))
 
-* `sub_objective=`[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_gradient)`:
+* `sub_objective=`[`ManifoldFirstOrderObjective`](@ref)`(sub_cost, sub_gradient)`:
   the objective for the Frank-Wolfe sub problem. $(_note(:KeywordUsedIn, "sub_problem"))
 
 $(_var(:Keyword, :sub_problem; default="[`DefaultManoptProblem`](@ref)`(M, sub_objective)`"))
@@ -216,7 +216,7 @@ $(_var(:Keyword, :X; add=:as_Gradient))
 
 $(_note(:OtherKeywords))
 
-If you provide the [`ManifoldGradientObjective`](@ref) directly, the `evaluation=` keyword is ignored.
+If you provide the [`ManifoldFirstOrderObjective`](@ref) directly, the `evaluation=` keyword is ignored.
 The decorations are still applied to the objective.
 
 # Output
@@ -237,13 +237,13 @@ function Frank_Wolfe_method(
     p_ = _ensure_mutating_variable(p)
     f_ = _ensure_mutating_cost(f, p)
     grad_f_ = _ensure_mutating_gradient(grad_f, p, evaluation)
-    mgo = ManifoldGradientObjective(f_, grad_f_; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f_, grad_f_; evaluation=evaluation)
     rs = Frank_Wolfe_method(M, mgo, p_; evaluation=evaluation, kwargs...)
     return _ensure_matching_output(p, rs)
 end
 function Frank_Wolfe_method(
     M::AbstractManifold, mgo::O, p=rand(M); kwargs...
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     q = copy(M, p)
     return Frank_Wolfe_method!(M, mgo, q; kwargs...)
 end
@@ -258,7 +258,7 @@ function Frank_Wolfe_method!(
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     kwargs...,
 )
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     return Frank_Wolfe_method!(M, mgo, p; evaluation=evaluation, kwargs...)
 end
 function Frank_Wolfe_method!(
@@ -276,7 +276,7 @@ function Frank_Wolfe_method!(
     sub_cost=FrankWolfeCost(p, X),
     sub_grad=FrankWolfeGradient(p, X),
     sub_kwargs=(;),
-    sub_objective=ManifoldGradientObjective(sub_cost, sub_grad),
+    sub_objective=ManifoldFirstOrderObjective(sub_cost, sub_grad),
     sub_problem=DefaultManoptProblem(
         M,
         decorate_objective!(M, sub_objective; objective_type=objective_type, sub_kwargs...),
@@ -303,7 +303,7 @@ function Frank_Wolfe_method!(
     kwargs...,
 ) where {
     TStop<:StoppingCriterion,
-    O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective},
+    O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective},
 }
     dmgo = decorate_objective!(M, mgo; objective_type=objective_type, kwargs...)
     dmp = DefaultManoptProblem(M, dmgo)

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -249,7 +249,7 @@ $(_var(:Keyword, :sub_problem; default="[`DefaultManoptProblem`](@ref)`(M, sub_o
 
 $(_note(:OtherKeywords))
 
-If you provide the [`ManifoldGradientObjective`](@ref) directly, the `evaluation=` keyword is ignored.
+If you provide the [`ManifoldFirstOrderObjective`](@ref) directly, the `evaluation=` keyword is ignored.
 The decorations are still applied to the objective.
 
 $(_note(:TutorialMode))

--- a/src/solvers/augmented_Lagrangian_method.jl
+++ b/src/solvers/augmented_Lagrangian_method.jl
@@ -474,7 +474,7 @@ function augmented_Lagrangian_method!(
         # pass down objective type to sub solvers
         decorate_objective!(
             M,
-            ManifoldGradientObjective(sub_cost, sub_grad; evaluation=evaluation);
+            ManifoldFirstOrderObjective(sub_cost, sub_grad; evaluation=evaluation);
             objective_type=objective_type,
             sub_kwargs...,
         ),

--- a/src/solvers/conjugate_gradient_descent.jl
+++ b/src/solvers/conjugate_gradient_descent.jl
@@ -57,7 +57,7 @@ the last direction ``δ_{k-1}`` and both gradients ``$(_tex(:grad))f(x_k)``,``$(
 The [`Stepsize`](@ref) ``s_k`` may be determined by a [`Linesearch`](@ref).
 
 Alternatively to `f` and `grad_f` you can provide
-the [`AbstractManifoldGradientObjective`](@ref) `gradient_objective` directly.
+the [`AbstractManifoldFirstOrderObjective`](@ref) `gradient_objective` directly.
 
 Available update rules are [`SteepestDescentCoefficientRule`](@ref), which yields a [`gradient_descent`](@ref),
 [`ConjugateDescentCoefficient`](@ref) (the default), [`DaiYuanCoefficientRule`](@ref), [`FletcherReevesCoefficient`](@ref),
@@ -88,7 +88,7 @@ $(_var(:Keyword, :stepsize; default="[`ArmijoLinesearch`](@ref)`()`"))
 $(_var(:Keyword, :stopping_criterion; default="[`StopAfterIteration`](@ref)`(500)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(1e-8)`"))
 $(_var(:Keyword, :vector_transport_method))
 
-If you provide the [`ManifoldGradientObjective`](@ref) directly, the `evaluation=` keyword is ignored.
+If you provide the [`ManifoldFirstOrderObjective`](@ref) directly, the `evaluation=` keyword is ignored.
 The decorations are still applied to the objective.
 
 $(_note(:OutputSection))
@@ -105,13 +105,13 @@ function conjugate_gradient_descent(
     p_ = _ensure_mutating_variable(p)
     f_ = _ensure_mutating_cost(f, p)
     grad_f_ = _ensure_mutating_gradient(grad_f, p, evaluation)
-    mgo = ManifoldGradientObjective(f_, grad_f_; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f_, grad_f_; evaluation=evaluation)
     rs = conjugate_gradient_descent(M, mgo, p_; evaluation=evaluation, kwargs...)
     return _ensure_matching_output(p, rs)
 end
 function conjugate_gradient_descent(
     M::AbstractManifold, mgo::O, p=rand(M); kwargs...
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     q = copy(M, p)
     return conjugate_gradient_descent!(M, mgo, q; kwargs...)
 end
@@ -126,7 +126,7 @@ function conjugate_gradient_descent!(
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     kwargs...,
 ) where {TF,TDF}
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     dmgo = decorate_objective!(M, mgo; kwargs...)
     return conjugate_gradient_descent!(M, dmgo, p; kwargs...)
 end
@@ -144,7 +144,7 @@ function conjugate_gradient_descent!(
     vector_transport_method=default_vector_transport_method(M, typeof(p)),
     initial_gradient=zero_vector(M, p),
     kwargs...,
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     dmgo = decorate_objective!(M, mgo; kwargs...)
     dmp = DefaultManoptProblem(M, dmgo)
     cgs = ConjugateGradientDescentState(

--- a/src/solvers/difference-of-convex-proximal-point.jl
+++ b/src/solvers/difference-of-convex-proximal-point.jl
@@ -328,7 +328,7 @@ function difference_of_convex_proximal_point!(
         decorate_objective!(
             M,
             if isnothing(sub_hess)
-                ManifoldGradientObjective(sub_cost, sub_grad; evaluation=evaluation)
+                ManifoldFirstOrderObjective(sub_cost, sub_grad; evaluation=evaluation)
             else
                 ManifoldHessianObjective(
                     sub_cost, sub_grad, sub_hess; evaluation=evaluation

--- a/src/solvers/difference_of_convex_algorithm.jl
+++ b/src/solvers/difference_of_convex_algorithm.jl
@@ -262,7 +262,7 @@ function difference_of_convex_algorithm!(
         decorate_objective!(
             M,
             if isnothing(sub_hess)
-                ManifoldGradientObjective(sub_cost, sub_grad; evaluation=evaluation)
+                ManifoldFirstOrderObjective(sub_cost, sub_grad; evaluation=evaluation)
             else
                 ManifoldHessianObjective(
                     sub_cost, sub_grad, sub_hess; evaluation=evaluation

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -255,7 +255,7 @@ Otherwise the problem is not constrained and a better solver would be for exampl
 $(_var(:Keyword, :sub_kwargs))
 * `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping cirterion for the sub solver
   $(_note(:KeywordUsedIn, "sub_state"))
-$(_var(:Keyword, :sub_state; default="[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
+$(_var(:Keyword, :sub_state; default="[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldFirstOrderObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
 $(_var(:Keyword, :sub_state; default="[`QuasiNewtonState`](@ref)", add=" where [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used"))
 $(_var(:Keyword, :stopping_criterion; default="[`StopAfterIteration`](@ref)`(300)`$(_sc(:Any))` ( `[`StopWhenSmallerOrEqual`](@ref)`(ϵ, ϵ_min)`$(_sc(:All))[`StopWhenChangeLess`](@ref)`(1e-10) )`"))
 
@@ -396,7 +396,7 @@ function exact_penalty_method!(
         M,
         decorate_objective!(
             M,
-            ManifoldGradientObjective(sub_cost, sub_grad; evaluation=evaluation);
+            ManifoldFirstOrderObjective(sub_cost, sub_grad; evaluation=evaluation);
             objective_type=objective_type,
             sub_kwargs...,
         ),

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -155,7 +155,7 @@ $(_var(:Keyword, :X; add=:as_Gradient))
 
 $(_note(:OtherKeywords))
 
-If you provide the [`ManifoldGradientObjective`](@ref) directly, the `evaluation=` keyword is ignored.
+If you provide the [`ManifoldFirstOrderObjective`](@ref) directly, the `evaluation=` keyword is ignored.
 The decorations are still applied to the objective.
 
 $(_note(:TutorialMode))
@@ -177,13 +177,13 @@ function gradient_descent(
     p_ = _ensure_mutating_variable(p)
     f_ = _ensure_mutating_cost(f, p)
     grad_f_ = _ensure_mutating_gradient(grad_f, p, evaluation)
-    mgo = ManifoldGradientObjective(f_, grad_f_; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f_, grad_f_; evaluation=evaluation)
     rs = gradient_descent(M, mgo, p_; kwargs...)
     return _ensure_matching_output(p, rs)
 end
 function gradient_descent(
     M::AbstractManifold, mgo::O, p=rand(M); kwargs...
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     q = copy(M, p)
     return gradient_descent!(M, mgo, q; kwargs...)
 end
@@ -198,7 +198,7 @@ function gradient_descent!(
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     kwargs...,
 )
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     return gradient_descent!(M, mgo, p; kwargs...)
 end
 function gradient_descent!(
@@ -224,7 +224,7 @@ function gradient_descent!(
     direction=Gradient(),
     X=zero_vector(M, p),
     kwargs..., #collect rest
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     dmgo = decorate_objective!(M, mgo; kwargs...)
     dmp = DefaultManoptProblem(M, dmgo)
     s = GradientDescentState(

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -71,7 +71,7 @@ $(_var(:Keyword, :retraction_method))
 * `ρ=μ's / length(μ)`:  store the orthogonality `μ's/m` to compute the barrier parameter `β` in the sub problem.
 * `s=copy(μ)`: initial value for the slack variables
 * `σ=`[`calculate_σ`](@ref)`(M, cmo, p, μ, λ, s)`:  scaling factor for the barrier parameter `β` in the sub problem, which is updated during the iterations
-* `step_objective`: a [`ManifoldGradientObjective`](@ref) of the norm of the KKT vector field [`KKTVectorFieldNormSq`](@ref) and its gradient [`KKTVectorFieldNormSqGradient`](@ref)
+* `step_objective`: a [`ManifoldFirstOrderObjective`](@ref) of the norm of the KKT vector field [`KKTVectorFieldNormSq`](@ref) and its gradient [`KKTVectorFieldNormSqGradient`](@ref)
 * `step_problem`: the manifold ``$(_math(:M)) × ℝ^m × ℝ^n × ℝ^m`` together with the `step_objective`
   as the problem the linesearch `stepsize=` employs for determining a step size
 * `step_state`: the [`StepsizeState`](@ref) with point and search direction
@@ -213,7 +213,7 @@ function interior_point_Newton!(
     vector_space=Rn,
     #γ=0.9,
     centrality_condition=missing, #InteriorPointCentralityCondition(cmo, γ, zero(γ), zero(γ)),
-    step_objective=ManifoldGradientObjective(
+    step_objective=ManifoldFirstOrderObjective(
         KKTVectorFieldNormSq(cmo), KKTVectorFieldNormSqGradient(cmo); evaluation=evaluation
     ),
     _step_M::AbstractManifold=M × vector_space(length(μ)) × vector_space(length(λ)) ×

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -266,13 +266,13 @@ function quasi_Newton(
     p_ = _ensure_mutating_variable(p)
     f_ = _ensure_mutating_cost(f, p)
     grad_f_ = _ensure_mutating_gradient(grad_f, p, evaluation)
-    mgo = ManifoldGradientObjective(f_, grad_f_; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f_, grad_f_; evaluation=evaluation)
     rs = quasi_Newton(M, mgo, p_; kwargs...)
     return _ensure_matching_output(p, rs)
 end
 function quasi_Newton(
     M::AbstractManifold, mgo::O, p; kwargs...
-) where {O<:Union{AbstractManifoldGradientObjective,AbstractDecoratedManifoldObjective}}
+) where {O<:Union{AbstractManifoldFirstOrderObjective,AbstractDecoratedManifoldObjective}}
     q = copy(M, p)
     return quasi_Newton!(M, mgo, q; kwargs...)
 end
@@ -287,7 +287,7 @@ function quasi_Newton!(
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     kwargs...,
 ) where {TF,TDF}
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation=evaluation)
+    mgo = ManifoldFirstOrderObjective(f, grad_f; evaluation=evaluation)
     return quasi_Newton!(M, mgo, p; kwargs...)
 end
 function quasi_Newton!(
@@ -325,7 +325,7 @@ function quasi_Newton!(
     kwargs...,
 ) where {
     E<:AbstractEvaluationType,
-    O<:Union{AbstractManifoldGradientObjective{E},AbstractDecoratedManifoldObjective{E}},
+    O<:Union{AbstractManifoldFirstOrderObjective{E},AbstractDecoratedManifoldObjective{E}},
 }
     if memory_size >= 0
         local_dir_upd = QuasiNewtonLimitedMemoryDirectionUpdate(

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -31,7 +31,7 @@ function test_sphere()
         return Manopt.riemannian_gradient(M, X, grad_f)
     end
 
-    objective = Manopt.ManifoldGradientObjective(eval_sum_cb, eval_grad_sum_cb)
+    objective = Manopt.ManifoldFirstOrderObjective(eval_sum_cb, eval_grad_sum_cb)
 
     @testset "$obj_sense" for (obj_sense, obj_sign) in
                               [(MOI.MIN_SENSE, -1), (MOI.MAX_SENSE, 1)]

--- a/test/helpers/test_linesearches.jl
+++ b/test/helpers/test_linesearches.jl
@@ -42,7 +42,7 @@ using Test
     @test startswith(sprint(show, ls_hz), "LineSearchesStepsize(HagerZhang")
 
     # make sure get_last_stepsize works
-    mgo = ManifoldGradientObjective(
+    mgo = ManifoldFirstOrderObjective(
         rosenbrock, rosenbrock_grad!; evaluation=InplaceEvaluation()
     )
     mp = DefaultManoptProblem(M, mgo)
@@ -55,7 +55,7 @@ using Test
     function rosenbrock_throw(::AbstractManifold, x)
         return error("test exception")
     end
-    mgo_throw = ManifoldGradientObjective(
+    mgo_throw = ManifoldFirstOrderObjective(
         rosenbrock_throw, rosenbrock_grad!; evaluation=InplaceEvaluation()
     )
     mp_throw = DefaultManoptProblem(M, mgo_throw)

--- a/test/plans/test_cache.jl
+++ b/test/plans/test_cache.jl
@@ -43,7 +43,7 @@ end
     @testset "Test Factory" begin
         M = Euclidean(3)
         # allocating
-        mgoa = ManifoldGradientObjective(TestCostCount(0), TestGradCount(0))
+        mgoa = ManifoldFirstOrderObjective(TestCostCount(0), TestGradCount(0))
         s1 = objective_cache_factory(M, mgoa, :Simple)
         @test s1 isa SimpleManifoldCachedObjective
         @test objective_cache_factory(M, mgoa, :none) == mgoa
@@ -67,8 +67,8 @@ end
         s = 3 * ones(3)
         X = zero_vector(M, p)
         # allocating
-        mgoa = ManifoldGradientObjective(TestCostCount(0), TestGradCount(0))
-        mcgoa = ManifoldGradientObjective(TestCostCount(0), TestGradCount(0))
+        mgoa = ManifoldFirstOrderObjective(TestCostCount(0), TestGradCount(0))
+        mcgoa = ManifoldFirstOrderObjective(TestCostCount(0), TestGradCount(0))
         sco1 = Manopt.SimpleManifoldCachedObjective(M, mgoa; p=p)
         @test repr(sco1) == "SimpleManifoldCachedObjective{AllocatingEvaluation,$(mgoa)}"
         @test startswith(
@@ -107,7 +107,7 @@ A `SimpleManifoldCachedObjective`""",
         @test Manopt.get_cost_function(sco1) != Manopt.get_cost_function(mgoa)
         @test Manopt.get_gradient_function(sco1) != Manopt.get_gradient_function(mgoa)
 
-        mgoi = ManifoldGradientObjective(
+        mgoi = ManifoldFirstOrderObjective(
             TestCostCount(0), TestGradCount(0); evaluation=InplaceEvaluation()
         )
         sco2 = Manopt.SimpleManifoldCachedObjective(M, mgoi; p=p, initialized=false)
@@ -188,7 +188,7 @@ A `SimpleManifoldCachedObjective`""",
         A = [2.0 1.0 0.0; 1.0 2.0 1.0; 0.0 1.0 2.0]
         f(M, p) = p' * A * p
         grad_f(M, p) = 2 * A * p
-        o = ManifoldGradientObjective(f, grad_f)
+        o = ManifoldFirstOrderObjective(f, grad_f)
         co = ManifoldCountObjective(M, o, [:Cost, :Gradient])
         lco = objective_cache_factory(M, co, (:LRU, [:Cost, :Gradient]))
         @test startswith(repr(lco), "## Cache\n  * ")
@@ -329,7 +329,7 @@ A `SimpleManifoldCachedObjective`""",
         @test Hess_f1!(M, Y, p, X) == Hess_f!(M, Z, p, X)
         #
         # Simple
-        obj_g = ManifoldGradientObjective(f, grad_f)
+        obj_g = ManifoldFirstOrderObjective(f, grad_f)
         s_obj = Manopt.SimpleManifoldCachedObjective(M, obj_g; p=similar(p), X=similar(X))
         # undecorated / recursive cost -> exactly f
         @test Manopt.get_cost_function(obj_g) === Manopt.get_cost_function(s_obj, true)
@@ -344,7 +344,7 @@ A `SimpleManifoldCachedObjective`""",
         @test grad_f1 != grad_f
         @test grad_f1(M, p) == grad_f(M, p)
         # Simple Mutating
-        obj_g_i = ManifoldGradientObjective(f, grad_f!; evaluation=InplaceEvaluation())
+        obj_g_i = ManifoldFirstOrderObjective(f, grad_f!; evaluation=InplaceEvaluation())
         s_obj_i = Manopt.SimpleManifoldCachedObjective(
             M, obj_g_i; p=similar(p), X=similar(X)
         )

--- a/test/plans/test_conjugate_gradient_plan.jl
+++ b/test/plans/test_conjugate_gradient_plan.jl
@@ -14,7 +14,7 @@ Manopt.update_rule_storage_vectors(::DummyCGCoeff) = Tuple{}
         f(M, p) = norm(M, p)^2
         grad_f(M, p) = p
         p0 = [1.0, 0.0]
-        pr = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        pr = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         cgs2 = ConjugateGradientDescentState(
             M;
             p=p0,

--- a/test/plans/test_constrained_plan.jl
+++ b/test/plans/test_constrained_plan.jl
@@ -135,7 +135,7 @@ using LRUCache, Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, Recursi
         @test inequality_constraints_length(cofE) == 0
     end
 
-    @test Manopt.get_unconstrained_objective(cofa) isa ManifoldGradientObjective
+    @test Manopt.get_unconstrained_objective(cofa) isa ManifoldFirstOrderObjective
     cofha = ConstrainedManifoldObjective(
         f,
         grad_f,

--- a/test/plans/test_counts.jl
+++ b/test/plans/test_counts.jl
@@ -11,7 +11,7 @@ using LinearAlgebra: Symmetric
         A = [2.0 1.0 0.0; 1.0 2.0 1.0; 0.0 1.0 2.0]
         f(M, p) = p' * A * p
         grad_f(M, p) = project(M, p, 2 * A * p)
-        obj = ManifoldGradientObjective(f, grad_f)
+        obj = ManifoldFirstOrderObjective(f, grad_f)
         c_obj = ManifoldCountObjective(M, obj, [:Cost, :Gradient])
         # function access functions are different since the right is still counting.
         @test get_cost_function(obj) != get_cost_function(c_obj)

--- a/test/plans/test_debug.jl
+++ b/test/plans/test_debug.jl
@@ -36,7 +36,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         grad_f(M, q) = -2 * log(M, q, p)
         # summary fallback to show
         @test Manopt.status_summary(TestDebugAction()) === "TestDebugAction()"
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         a1 = DebugDivider("|"; io=io)
         @test Manopt.dispatch_state_decorator(DebugSolverState(st, a1)) === Val{true}()
         # constructors
@@ -261,7 +261,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         )
         f(M, y) = Inf
         grad_f(M, y) = Inf .* ones(2)
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
 
         w1 = DebugWarnIfCostNotFinite()
         @test repr(w1) == "DebugWarnIfCostNotFinite()"
@@ -280,7 +280,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         @test_logs (:warn,) w5(mp, st, 1)
 
         M2 = Sphere(2)
-        mp2 = DefaultManoptProblem(M2, ManifoldGradientObjective(f, grad_f))
+        mp2 = DefaultManoptProblem(M2, ManifoldFirstOrderObjective(f, grad_f))
         w6 = DebugWarnIfGradientNormTooLarge(1.0, :Once)
         @test repr(w6) == "DebugWarnIfGradientNormTooLarge(1.0, :Once)"
         st.X .= [4.0, 0.0] # > π in norm
@@ -309,7 +309,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         )
         f(M, q) = distance(M, q, p) .^ 2
         grad_f(M, q) = -2 * log(M, q, p)
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         d1 = DebugTime(; start=true, io=io)
         @test d1.last_time != Nanosecond(0)
         d2 = DebugTime(; io=io)
@@ -396,7 +396,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         )
         f(M, y) = Inf
         grad_f(M, y) = Inf .* ones(2)
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
 
         die1 = DebugIfEntry(:p, p -> p[1] > 0.0; type=:warn, message="test1")
         @test startswith(repr(die1), "DebugIfEntry(:p, ")
@@ -421,7 +421,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         )
         f(M, q) = distance(M, q, p) .^ 2
         grad_f(M, q) = -2 * log(M, q, p)
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         dD = DebugDivider(" | "; io=io)
         dA = DebugWhenActive(dD, false)
         @test !dA.active
@@ -466,7 +466,7 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
             )
             f(M, q) = distance(M, q, p) .^ 2
             grad_f(M, q) = -2 * log(M, q, p)
-            mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+            mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
             n = 0
             cb() = (n += 1)
             dst = decorate_state!(st; callback=cb)

--- a/test/plans/test_gradient_plan.jl
+++ b/test/plans/test_gradient_plan.jl
@@ -19,7 +19,7 @@ using ManifoldsBase, Manopt, ManoptTestSuite, Test
     @test isapprox(M, p, get_gradient(gst), [1.0, 0.0])
     f(M, q) = distance(M, q, p) .^ 2
     grad_f(M, q) = -2 * log(M, q, p)
-    mgo = ManifoldGradientObjective(f, grad_f)
+    mgo = ManifoldFirstOrderObjective(f, grad_f)
     mp = DefaultManoptProblem(M, mgo)
     @test get_initial_stepsize(mp, gst) == 1.0
     @test get_stepsize(mp, gst, 1) == 1.0

--- a/test/plans/test_problem.jl
+++ b/test/plans/test_problem.jl
@@ -5,12 +5,12 @@ using Manopt, Manifolds, Test
         M = Euclidean(3)
         f(M, p) = norm(p)^2
         grad_f(M, p) = 2 * p
-        moa = ManifoldGradientObjective(f, grad_f)
+        moa = ManifoldFirstOrderObjective(f, grad_f)
         cpa = DefaultManoptProblem(M, moa)
         @test Manopt.evaluation_type(cpa) === AllocatingEvaluation
 
         grad_f!(M, X, p) = (X .= 2 * p)
-        moi = ManifoldGradientObjective(f, grad_f!; evaluation=InplaceEvaluation())
+        moi = ManifoldFirstOrderObjective(f, grad_f!; evaluation=InplaceEvaluation())
         cpi = DefaultManoptProblem(M, moi)
         @test Manopt.evaluation_type(cpi) === InplaceEvaluation
     end

--- a/test/plans/test_record.jl
+++ b/test/plans/test_record.jl
@@ -21,7 +21,7 @@ Manopt.get_parameter(d::TestRecordParameterState, ::Val{:value}) = d.value
     )
     f(M, q) = distance(M, q, p) .^ 2
     grad_f(M, q) = -2 * log(M, q, p)
-    dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+    dmp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
     a = RecordIteration()
     @test repr(a) == "RecordIteration()"
     @test Manopt.status_summary(a) == ":Iteration"

--- a/test/plans/test_stepsize.jl
+++ b/test/plans/test_stepsize.jl
@@ -76,7 +76,7 @@ using ManoptTestSuite
         grad_f(M, p) = [0.0, 0.75, 0.0] # valid, since only north pole used
         M = Sphere(2)
         p = [1.0, 0.0, 0.0]
-        mgo = ManifoldGradientObjective(f, grad_f)
+        mgo = ManifoldFirstOrderObjective(f, grad_f)
         mp = DefaultManoptProblem(M, mgo)
         s = AdaptiveWNGradient(; gradient_reduction=0.5, count_threshold=2)(M)
         gds = GradientDescentState(M; p=p)
@@ -102,7 +102,7 @@ using ManoptTestSuite
         grad_f(M, p) = [0.0, 0.75, 0.0] # valid, since only north pole used
         M = Sphere(2)
         p = [1.0, 0.0, 0.0]
-        mgo = ManifoldGradientObjective(f, grad_f)
+        mgo = ManifoldFirstOrderObjective(f, grad_f)
         mp = DefaultManoptProblem(M, mgo)
         gds = GradientDescentState(M; p=p)
         abs_dec_step = Manopt.DecreasingStepsize(
@@ -119,7 +119,7 @@ using ManoptTestSuite
         M = Euclidean(2)
         f(M, p) = sum(p .^ 2)
         grad_f(M, p) = sum(2 .* p)
-        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        dmp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         p = [2.0, 2.0]
         X = grad_f(M, p)
         sgs = SubGradientMethodState(M; p=p)

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -23,7 +23,7 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
 
         s3 = StopWhenCostLess(0.1)
         p = DefaultManoptProblem(
-            Euclidean(), ManifoldGradientObjective((M, x) -> x^2, x -> 2x)
+            Euclidean(), ManifoldFirstOrderObjective((M, x) -> x^2, x -> 2x)
         )
         s = GradientDescentState(Euclidean(); p=1.0)
         @test !s3(p, s, 1)
@@ -133,7 +133,7 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
         @test repr(g) == "StopWhenCostLess(0.0001)\n    $(Manopt.status_summary(g))"
         gf(M, p) = norm(p)
         grad_gf(M, p) = p
-        gp = DefaultManoptProblem(Euclidean(2), ManifoldGradientObjective(gf, grad_gf))
+        gp = DefaultManoptProblem(Euclidean(2), ManifoldFirstOrderObjective(gf, grad_gf))
         gs = GradientDescentState(Euclidean(2))
         Manopt.set_iterate!(gs, Euclidean(2), [0.0, 1e-2])
         g(gp, gs, 0) # reset
@@ -196,7 +196,7 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
     end
 
     @testset "Stop with step size" begin
-        mgo = ManifoldGradientObjective((M, x) -> x^2, x -> 2x)
+        mgo = ManifoldFirstOrderObjective((M, x) -> x^2, x -> 2x)
         dmp = DefaultManoptProblem(Euclidean(), mgo)
         gds = GradientDescentState(
             Euclidean();
@@ -217,7 +217,7 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
     end
 
     @testset "Test further setters" begin
-        mgo = ManifoldGradientObjective((M, x) -> x^2, x -> 2x)
+        mgo = ManifoldFirstOrderObjective((M, x) -> x^2, x -> 2x)
         dmp = DefaultManoptProblem(Euclidean(), mgo)
         gds = GradientDescentState(
             Euclidean();

--- a/test/plans/test_storage.jl
+++ b/test/plans/test_storage.jl
@@ -17,7 +17,7 @@ using Test, Manopt, ManifoldsBase, Manifolds
         )
         f(M, q) = distance(M, q, p) .^ 2
         grad_f(M, q) = -2 * log(M, q, p)
-        mp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        mp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
 
         a = StoreStateAction(M; store_fields=[:p, :X])
 

--- a/test/solvers/test_Frank_Wolfe.jl
+++ b/test/solvers/test_Frank_Wolfe.jl
@@ -37,7 +37,7 @@ using ManifoldsBase, Manopt, Random, Test, LinearAlgebra
         @test startswith(repr(s), "# Solver state for `Manopt.jl`s Frank Wolfe Method\n")
         set_iterate!(s, 2 .* p)
         @test get_iterate(s) == 2 .* p
-        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(FC, FG))
+        dmp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(FC, FG))
         gds = GradientDescentState(M)
         s2 = FrankWolfeState(M, dmp, gds; p=p)
         @test Manopt.get_message(s2) == ""

--- a/test/solvers/test_conjugate_gradient.jl
+++ b/test/solvers/test_conjugate_gradient.jl
@@ -9,7 +9,7 @@ using LinearAlgebra: Diagonal, dot, eigvals, eigvecs
         M = Euclidean(2)
         f(M, x) = norm(x)^2
         grad_f(::Euclidean, x) = 2 * x
-        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        dmp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         x0 = [0.0, 1.0]
         sC = StopAfterIteration(1)
         s = Manopt.ConstantStepsize(M)

--- a/test/solvers/test_difference_of_convex.jl
+++ b/test/solvers/test_difference_of_convex.jl
@@ -34,7 +34,7 @@ import Manifolds: inner
         X3 = similar(X2)
         dca_sub_grad(M, X3, p0)
         @test X2 == X3
-        dca_sub_objective = ManifoldGradientObjective(dca_sub_cost, dca_sub_grad)
+        dca_sub_objective = ManifoldFirstOrderObjective(dca_sub_cost, dca_sub_grad)
         dca_sub_problem = DefaultManoptProblem(M, dca_sub_objective)
         dca_sub_state = GradientDescentState(M; p=copy(M, p0))
 
@@ -60,7 +60,7 @@ import Manifolds: inner
         dcppa_sub_grad(M, Y2, p0)
         @test Y1 == Y2
 
-        dcppa_sub_objective = ManifoldGradientObjective(dcppa_sub_cost, dcppa_sub_grad)
+        dcppa_sub_objective = ManifoldFirstOrderObjective(dcppa_sub_cost, dcppa_sub_grad)
         dcppa_sub_problem = DefaultManoptProblem(M, dcppa_sub_objective)
         dcppa_sub_state = GradientDescentState(M; p=copy(M, p0))
 

--- a/test/solvers/test_quasi_Newton.jl
+++ b/test/solvers/test_quasi_Newton.jl
@@ -66,7 +66,7 @@ end
             debug=[],
         )
         # Verify that Newton update direction works also allocating
-        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        dmp = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
         p_star = get_solver_result(lrbfgs_s)
         D = zero_vector(M, p_star)
         lrbfgs_s.direction_update(D, dmp, lrbfgs_s)
@@ -402,7 +402,7 @@ end
         p = [0.0, 0.0]
         f(M, p) = sum(p .^ 2)
         grad_f(M, p) = 2 * sum(p)
-        gmp = ManifoldGradientObjective(f, grad_f)
+        gmp = ManifoldFirstOrderObjective(f, grad_f)
         mp = DefaultManoptProblem(M, gmp)
         qns = QuasiNewtonState(M; p=p)
         # push zeros to memory
@@ -422,7 +422,7 @@ end
         f(M, p) = sum(p .^ 2)
         # A wrong gradient
         grad_f(M, p) = -2 .* p
-        gmp = ManifoldGradientObjective(f, grad_f)
+        gmp = ManifoldFirstOrderObjective(f, grad_f)
         mp = DefaultManoptProblem(M, gmp)
         qns = QuasiNewtonState(
             M;

--- a/tutorials/HowToRecord.qmd
+++ b/tutorials/HowToRecord.qmd
@@ -121,7 +121,7 @@ To illustrate a complicated example let's record:
 We first generate the problem and the state, to also illustrate the low-level works when not using the high-level interface [`gradient_descent`](https://manoptjl.org/stable/solvers/gradient_descent.html).
 
 ```{julia}
-p = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+p = DefaultManoptProblem(M, ManifoldFirstOrderObjective(f, grad_f))
 s = GradientDescentState(
     M;
     p=copy(data[1]),


### PR DESCRIPTION
This aims to resolve #482.

both @mateuszbaran and @jonas-pueschel:
does this read like an approach that sounds reasonable?

The general idea is that instead of a gradient a “first-order-thingy” can also store a differential (indicated by being wrapped in a type `DifferentialFunction`). I feel this is a good approach but want to check back before I spent more time reworking the rest, see below for questions and remaining roadmap.

# ？
* introduce a `ManifoldCostDifferentialObjective` (or rework the `ManifoldCostGradObjective`?) for a function that can compute both as in `f, df = cost_diff(M; p, X)`?
* introduce something where we have `diff` and `grad` in parallel as first order information?

For now the tests fail, since I had to remove a default especially for the `get_gradient_function` that always fell back to just return ing a field (which now can be the differential, see third todo)

# 🛣️🗺️
* [ ] introduce `get_gradient` for the differential case? Should be doable with a basis 
* [ ] introduce `get_differential_function`
* [ ] rework the `get_gradient_function` which lost a detail and needs a rework
* [ ] test coverage 📈
* [ ] check documentation and introduce a section for the differential 📚