### PR TITLE
Debug warning for RPG backtracking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.20] unreleased
 
+### Added
+
+* a `DebugWarnIfBacktrackingNotConverged` DebugAction and a related `:WarnBacktracking` symbol for the debug dictionary. This is to be used in conjunction with the `ProximalGradientMethodBacktracking` stepsize to warn if the backtracking procedure of the `proximal_gradient_method` hit the stepsize length threshold without converging.
+
 ### Fixed
 
 * Fixed a few typos in the docs.

--- a/docs/src/solvers/proximal_gradient_method.md
+++ b/docs/src/solvers/proximal_gradient_method.md
@@ -35,6 +35,12 @@ ProximalGradientMethodBacktracking
 Manopt.ProximalGradientMethodBacktrackingStepsize
 ```
 
+## Debug functions
+
+```@docs
+DebugWarnIfBacktrackingNotConverged
+```
+
 ## Internal functions
 
 ```@docs

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -610,7 +610,7 @@ export DebugProximalParameter, DebugWarnIfCostIncreases
 export DebugGradient, DebugGradientNorm, DebugStepsize
 export DebugWhenActive, DebugWarnIfFieldNotFinite, DebugIfEntry
 export DebugWarnIfCostNotFinite, DebugWarnIfFieldNotFinite
-export DebugWarnIfLagrangeMultiplierIncreases
+export DebugWarnIfLagrangeMultiplierIncreases, DebugWarnIfBacktrackingNotConverged
 export DebugWarnIfGradientNormTooLarge, DebugMessages
 #
 # Records - and access functions

--- a/src/plans/bundle_plan.jl
+++ b/src/plans/bundle_plan.jl
@@ -170,7 +170,7 @@ Initialize the warning to warning level (`:Once`) and introduce a tolerance for 
 The `warn` level can be set to `:Once` to only warn the first time the cost increases,
 to `:Always` to report an increase every time it happens, and it can be set to `:No`
 to deactivate the warning, then this [`DebugAction`](@ref) is inactive.
-All other symbols are handled as if they were `:Always:`
+All other symbols are handled as if they were `:Always`.
 """
 mutable struct DebugWarnIfLagrangeMultiplierIncreases <: DebugAction
     status::Symbol

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -229,7 +229,7 @@ end
 # Special single ones
 #
 @doc raw"""
-    DebugCallback <: DDebugAction
+    DebugCallback <: DebugAction
 
 Debug for a simple callback function, mainly for compatibility to other solvers and if
 a user already has a callback function or functor available
@@ -1341,9 +1341,10 @@ Note that the Shortcut symbols should all start with a capital letter.
 * `:IterativeTime` creates a [`DebugTime`](@ref)`(:Iterative)`
 * `:Stepsize` creates a [`DebugStepsize`](@ref)
 * `:Stop` creates a [`StoppingCriterion`](@ref)`()`
+* `:WarnBacktracking` creates a [`DebugWarnIfBacktrackingNotConverged`](@ref)
+* `:WarnBundle` creates a [`DebugWarnIfLagrangeMultiplierIncreases`](@ref)
 * `:WarnCost` creates a [`DebugWarnIfCostNotFinite`](@ref)
 * `:WarnGradient` creates a [`DebugWarnIfFieldNotFinite`](@ref) for the `::Gradient`.
-* `:WarnBundle` creates a [`DebugWarnIfLagrangeMultiplierIncreases`](@ref)
 * `:Time` creates a [`DebugTime`](@ref)
 * `:WarningMessages` creates a [`DebugMessages`](@ref)`(:Warning)`
 * `:InfoMessages` creates a [`DebugMessages`](@ref)`(:Info)`
@@ -1363,6 +1364,7 @@ function DebugActionFactory(d::Symbol)
     (d == :Feasibility) && return DebugFeasibility()
     (d == :Stepsize) && return DebugStepsize()
     (d == :Stop) && return DebugStoppingCriterion()
+    (d == :WarnBacktracking) && return DebugWarnIfBacktrackingNotConverged()
     (d == :WarnBundle) && return DebugWarnIfLagrangeMultiplierIncreases()
     (d == :WarnCost) && return DebugWarnIfCostNotFinite()
     (d == :WarnGradient) && return DebugWarnIfFieldNotFinite(:Gradient)

--- a/src/solvers/proximal_gradient_method.jl
+++ b/src/solvers/proximal_gradient_method.jl
@@ -102,6 +102,7 @@ function proximal_gradient_method!(
         copyto!(get_manifold(pr), st.a, st.p)
         return st
     end,
+    debug=[DebugWarnIfBacktrackingNotConverged()],
     evaluation::AbstractEvaluationType=AllocatingEvaluation(),
     stepsize::Union{Stepsize,ManifoldDefaultsFactory}=default_stepsize(
         M, ProximalGradientMethodState
@@ -138,13 +139,6 @@ function proximal_gradient_method!(
             stopping_criterion=StopAfterIteration(2500) | StopWhenSubgradientNormLess(1e-8),
         )
     end,
-    # ::Union{AbstractEvaluationType,AbstractManoptSolverState,Nothing}=if isnothing(
-    #     mpgo.proximal_map_h!!
-    # )
-    #     maybe_wrap_evaluation_type(evaluation)
-    # else
-    #     nothing
-    # end,
     kwargs...,
 ) where {
     O<:Union{ManifoldProximalGradientObjective,AbstractDecoratedManifoldObjective},

--- a/test/plans/test_debug.jl
+++ b/test/plans/test_debug.jl
@@ -296,6 +296,8 @@ Manopt.get_parameter(d::TestDebugParameterState, ::Val{:value}) = d.value
         @test isa(df2[:Iteration], DebugWarnIfFieldNotFinite)
         df3 = DebugFactory([:WarnBundle])
         @test isa(df3[:Iteration], DebugWarnIfLagrangeMultiplierIncreases)
+        df4 = DebugFactory([:WarnBacktracking])
+        @test isa(df4[:Iteration], DebugWarnIfBacktrackingNotConverged)
     end
     @testset "Debug Time" begin
         io = IOBuffer()


### PR DESCRIPTION
Introduce a `DebugAction`,`DebugWarnIfBacktrackingNotConverged`, and a related `:WarnBacktracking` symbol for the debug dictionary. This is to be used in conjunction with the `ProximalGradientMethodBacktracking` stepsize to warn if the backtracking procedure of the `proximal_gradient_method` hit the stepsize length threshold without converging.
Also fixed a couple of typos in the docs.