### PR TITLE
Add warm start to CRPG backtracking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.21] unreleased
+
+### Added
+
+* a `warm_start_factor` field to `ProximalGradientMethodBacktrackingStepsize` to allow to scale the stepsize in the backtracking procedure.
+
 ## [0.5.20] July 8, 2025
 
 ### Added

--- a/test/solvers/test_proximal_gradient_method.jl
+++ b/test/solvers/test_proximal_gradient_method.jl
@@ -74,6 +74,7 @@ using Manopt, Manifolds, Test, ManifoldDiff, ManoptTestSuite
             M; initial_stepsize=1.0, strategy=:convex, stop_when_stepsize_less=2.0
         )
 
+        @test st.warm_start_factor == 1.0
         @test st.last_stepsize == 1.0
         @test get_initial_stepsize(st) == 1.0
         pr = prox_h(M, 1.0, p0)
@@ -81,8 +82,11 @@ using Manopt, Manifolds, Test, ManifoldDiff, ManoptTestSuite
         @test_throws DomainError Manopt.ProximalGradientMethodBacktrackingStepsize(
             M; strategy=:neither
         )
+        @test_throws DomainError Manopt.ProximalGradientMethodBacktrackingStepsize(
+            M; warm_start_factor=-1.0
+        )
 
-        @testset "Warnings" begin
+        @testset "Backtracking Warnings" begin
             dw1 = DebugWarnIfStepsizeCollapsed(:Once)
             @test repr(dw1) == "DebugWarnIfStepsizeCollapsed()"
             pgms_warn = ProximalGradientMethodState(


### PR DESCRIPTION
Just like the title says. The user can now use a `warm_start_factor` keyword argument (which defaults to `1`) when initializing a `ProximalGradientMethodBacktracking` stepsize.
This can also wait to be released later of course :)