### PR TITLE
Avoid gradient computations [#480, P3]

### DIFF
--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -409,9 +409,9 @@ function (a::ArmijoLinesearchStepsize)(
     p = get_iterate(s)
     if isnothing(gradient)
         if isnothing(X)
-            grad = get_gradient(mp, p)
+            grad = get_gradient(mp, get_iterate(s))
         else
-            grad = get_gradient!(mp, X, p)
+            grad = get_gradient!(mp, X, get_iterate(s))
         end
     else
         grad = gradient
@@ -604,9 +604,9 @@ function (awng::AdaptiveWNGradientStepsize)(
 )
     if isnothing(gradient)
         if isnothing(X)
-            grad = get_gradient(mp, p)
+            grad = get_gradient(mp, get_iterate(s))
         else
-            grad = get_gradient!(mp, X, p)
+            grad = get_gradient!(mp, X, get_iterate(s))
         end
     else
         grad = gradient

--- a/src/plans/stepsize.jl
+++ b/src/plans/stepsize.jl
@@ -100,13 +100,22 @@ function (cs::ConstantStepsize)(
     ams::AbstractManoptSolverState,
     ::Any,
     args...;
-    X=zero_vector(get_manifold(amp), get_iterate(ams)),
-    gradient=get_gradient!(amp, X, get_iterate(ams)),
+    X=nothing,
+    gradient=nothing,
     kwargs...,
 )
     s = cs.length
     if cs.type == :absolute
-        ns = norm(get_manifold(amp), get_iterate(ams), gradient)
+        if isnothing(gradient)
+            if isnothing(X)
+                grad = get_gradient(amp, get_iterate(ams))
+            else
+                grad = get_gradient!(amp, X, get_iterate(ams))
+            end
+        else
+            grad = gradient
+        end
+        ns = norm(get_manifold(amp), get_iterate(ams), grad)
         if ns > eps(eltype(s))
             s /= ns
         end

--- a/src/solvers/conjugate_gradient_descent.jl
+++ b/src/solvers/conjugate_gradient_descent.jl
@@ -176,7 +176,7 @@ end
 function step_solver!(amp::AbstractManoptProblem, cgs::ConjugateGradientDescentState, k)
     M = get_manifold(amp)
     copyto!(M, cgs.p_old, cgs.p)
-    current_stepsize = get_stepsize(amp, cgs, k, cgs.δ)
+    current_stepsize = get_stepsize(amp, cgs, k, cgs.δ; gradient=cgs.X)
     ManifoldsBase.retract_fused!(
         M, cgs.p, cgs.p, cgs.δ, current_stepsize, cgs.retraction_method
     )

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -196,7 +196,7 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
     end
 
     @testset "Stop with step size" begin
-        mgo = ManifoldGradientObjective((M, x) -> x^2, x -> 2x)
+        mgo = ManifoldGradientObjective((M, x) -> x^2, (M, x) -> 2x)
         dmp = DefaultManoptProblem(Euclidean(), mgo)
         gds = GradientDescentState(
             Euclidean();


### PR DESCRIPTION
This is an idea to reduce gradient computations.

It allows to pass the evaluated gradient to any stepwise `gradient=`

The example 3 from #480 now produces (where I am not sure what it produced before)

```
julia> conjugate_gradient_descent!(M, obj, p;
           debug = (args...) -> debug_oi(args...; oi, display_calls = true), 
           retraction_method, vector_transport_method,
           coefficient = SteepestDescentCoefficient(),
           stopping_criterion = Manopt.StopAfterIteration(200))
 Iter   | d | cost       | log10(|g|) | stepsize          | calls cost | calls grad 
--------+---+------------+------------+-------------------+------------+------------
      0 | ✓ | +1.1908973 | -0.2969576 | +1.00000000000000 |          0 |          1 
      1 | ✓ | +1.1546733 | -0.2591312 | +1.36037414199981 |         10 |          2 
      2 | ✓ | +1.1225207 | -0.2778392 | +1.00000000000000 |         18 |          3 
      3 | ✓ | +1.0909885 | -0.3035586 | +0.81450625000000 |         24 |          4 
      4 | ✓ | +1.0714433 | -0.3415070 | +0.69833729609375 |         29 |          5 
    [...]
    200 | ✓ | +1.0000000 | -7.4239552 | +0.66342043128906 |        692 |        201 
```
where I am not sure what the output before was. Sure for every step size checked there is a cost evaluation, one could maybe also check to reduce that, but it would maybe only be a reduction by 1 – but we would have to start to store a cost in states to do the same trick.

I am not yet fully happy with this

* [ ] is `X` as memory really needed? If no gradient is given we could also just allocate – the case that someone has memory but not the gradient is maybe a bit niche. Maybe removing it makes the code easier again.
* [ ] Check where else we can pass down the gradient to step sizes besides in CG