### PR TITLE
Allocation-free cost and gradient callback for JuMP interface

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `quasi_Newton`
   * `projected_gradient_method`
 
+### Fixed
+
+* Fixed allocations in the callbacks of the JuMP interface so that the solver can query the cost and gradient without allocating.
+
 ## [0.5.20] July 8, 2025
 
 ### Added

--- a/ext/ManoptJuMPExt.jl
+++ b/ext/ManoptJuMPExt.jl
@@ -306,13 +306,40 @@ already been set.
 """
 MOI.get(model::Optimizer, ::MOI.ObjectiveSense) = model.sense
 
+# We could have it be a subtype of `AbstractManifoldGradientObjective{E,TC,TG}`
+# but I wouldn't know what to do with `TC` and `TG` in this case.
+# But we still implement an API similar to `get_cost` and `get_gradient!`
+# so for consistency.
+struct _EmbeddingObjective{E<:MOI.AbstractNLPEvaluator,T}
+    evaluator::E
+    # Used to store the vectorized point
+    vectorized_point::Vector{Float64}
+    # Used to store the vectorized tangent
+    vectorized_tangent::Vector{Float64}
+    # Used to store the tangent in the embedding space
+    embedding_tangent::T
+end
+
+function _get_cost(M, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    return MOI.eval_objective(objective.evaluator, objective.vectorized_point)
+end
+
+# We put all arguments
+function _get_gradient!(M, gradient, objective::_EmbeddingObjective, p)
+    _vectorize!(objective.vectorized_point, p, _point_shape(M))
+    MOI.eval_objective_gradient(objective.evaluator, objective.vectorized_tangent, objective.vectorized_point)
+    _reshape_vector!(objective.embedding_tangent, objective.vectorized_tangent, _tangent_shape(M))
+    return ManifoldDiff.riemannian_gradient!(M, gradient, p, objective.embedding_tangent)
+end
+
 """
     MOI.set(model::Optimizer, ::MOI.ObjectiveFunction{F}, func::F) where {F}
 
 Set the objective function as `func` for `model`.
 """
 function MOI.set(
-    model::Optimizer, attr::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
+    model::Optimizer, ::MOI.ObjectiveFunction, func::MOI.AbstractScalarFunction
 )
     backend = MOI.Nonlinear.SparseReverseMode()
     vars = [MOI.VariableIndex(i) for i in eachindex(model.variable_primal_start)]
@@ -321,19 +348,24 @@ function MOI.set(
     MOI.Nonlinear.set_objective(nlp_model, nl)
     evaluator = MOI.Nonlinear.Evaluator(nlp_model, backend, vars)
     MOI.initialize(evaluator, [:Grad])
-    function eval_f_cb(M, x)
-        return MOI.eval_objective(evaluator, JuMP.vectorize(x, _shape(model.manifold)))
+    objective = let
+        # To avoid creating a closure capturing the `embedding_obj` object,
+        # we use the `let` block trick detailed in:
+        # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
+        embedding_obj = _EmbeddingObjective(
+            evaluator,
+            zeros(length(_point_shape(model.manifold))),
+            zeros(length(_tangent_shape(model.manifold))),
+            _zero(_tangent_shape(model.manifold)),
+        )
+        RiemannianFunction(
+            Manopt.ManifoldGradientObjective(
+                (M, x) -> _get_cost(M, embedding_obj, x),
+                (M, g, x) -> _get_gradient!(M, g, embedding_obj, x),
+                evaluation = Manopt.InplaceEvaluation(),
+            )
+        )
     end
-    function eval_grad_f_cb(M, X)
-        x = JuMP.vectorize(X, _shape(model.manifold))
-        grad_f = zeros(length(x))
-        MOI.eval_objective_gradient(evaluator, grad_f, x)
-        reshaped_grad_f = JuMP.reshape_vector(grad_f, _shape(model.manifold))
-        return ManifoldDiff.riemannian_gradient(model.manifold, X, reshaped_grad_f)
-    end
-    objective = RiemannianFunction(
-        Manopt.ManifoldGradientObjective(eval_f_cb, eval_grad_f_cb)
-    )
     MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
     return nothing
 end
@@ -384,7 +416,39 @@ struct ArrayShape{N} <: JuMP.AbstractShape
     size::NTuple{N,Int}
 end
 
-function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{M}) where {T,N,M}
+"""
+    length(shape::ArrayShape)
+
+Return the length of the vectors in the vectorized representation.
+"""
+Base.length(shape::ArrayShape) = prod(shape.size)
+
+"""
+    _vectorize!(res::Vector{T}, array::Array{T,N}, shape::ArrayShape{N}) where {T,N}
+
+Inplace version of `res = JuMP.vectorize(array, shape)`.
+"""
+function _vectorize!(res::Vector{T}, array::Array{T,N}, ::ArrayShape{N}) where {T,N,M}
+    copyto!(res, array)
+end
+
+"""
+    _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+
+Inplace version of `res = JuMP.reshape_vector(vec, shape)`.
+"""
+function _reshape_vector!(res::Array{T,N}, vec::Vector{T}, ::ArrayShape{N}) where {T,N}
+    copyto!(res, vec)
+end
+
+"""
+    _zero(shape::ArrayShape)
+
+Return a zero element of the shape `shape`.
+"""
+_zero(shape::ArrayShape{N}) where {N} = zeros(shape.size)
+
+function JuMP.vectorize(array::Array{T,N}, ::ArrayShape{N}) where {T,N}
     return vec(array)
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -42,17 +42,17 @@ function test_sphere()
         # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
         grad_f = ones(3)
 
-        function eval_sum_cb(M, x)
+        function _get_cost(M, x)
             return sum(x)
         end
 
-        function eval_grad_sum_cb(M, g, X)
+        function _get_gradient!(M, g, X)
             return Manopt.riemannian_gradient!(M, g, X, grad_f)
         end
 
         Manopt.ManifoldGradientObjective(
-            eval_sum_cb,
-            eval_grad_sum_cb,
+            _get_cost,
+            _get_gradient!,
             evaluation=Manopt.InplaceEvaluation(),
         )
     end


### PR DESCRIPTION
Revival of https://github.com/JuliaManifolds/Manopt.jl/pull/469 but I think we should merge it to master this time :)
I would find it helpful to merge the part of https://github.com/JuliaManifolds/Manopt.jl/pull/454 that's strict improvement to the array-point case and then leave only the exploratory part dedicated to the non-array-point case to https://github.com/JuliaManifolds/Manopt.jl/pull/454.
As explained on slack, I think there is value is already having a solid array-point case :)