### PR TITLE
add methods to the functions `<` and `<=` instead of to `>`, `>=`

### DIFF
--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -1391,10 +1391,10 @@ function StopWhenCriterionWithIterationCondition(
     ) where {SC <: StoppingCriterion, F}
     return StopWhenCriterionWithIterationCondition{SC, F}(sc, comp, -1)
 end
-function Base.:>(sc::StoppingCriterion, n::Int)
+function Base.:<(n::Int, sc::StoppingCriterion)
     return StopWhenCriterionWithIterationCondition(sc, n; comp = (>(n)))
 end
-function Base.:>=(sc::StoppingCriterion, n::Int)
+function Base.:<=(n::Int, sc::StoppingCriterion)
     return StopWhenCriterionWithIterationCondition(sc, n; comp = (>=(n)))
 end
 function Base.:(==)(sc::StoppingCriterion, n::Int)


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. Similarly with `>=`. A package should never add a method to either `>` or `>=`.