### PR TITLE
Fix stopping criterion activation short notation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,14 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.23] candidate
+
+### Changed
+
+* formerly a stopping criterion could be activated at certain iterations with `sc > 5`, `sc >= 5`, `sc == 5`, `sc <= 5`, and `sc < 5`.
+  This caused too many issues with invalidations, so it has been reduced and moved to `sc ⩼ 5`, `sc ≟ 5`, `sc ⩻ 5` for the cases 1, 3, and 5, respectively,
+  cf. (#509).
+
 ## [0.5.22] September 09, 2025
 
 ### Added

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -261,7 +261,7 @@ function __init__()
 end
 #
 # General
-export ℝ, ℂ, &, |
+export ℝ, ℂ, &, |, ×, ≟, ⩼, ⩻
 export mid_point, mid_point!, reflect, reflect!
 #
 # Problems
@@ -448,6 +448,7 @@ export NeverRestart, RestartOnNonDescent, RestartOnNonSufficientDescent
 #
 # Solvers
 export adaptive_regularization_with_cubics,
+    accepted_keywords,
     adaptive_regularization_with_cubics!,
     alternating_gradient_descent,
     alternating_gradient_descent!,
@@ -481,7 +482,6 @@ export adaptive_regularization_with_cubics,
     gradient_descent!,
     interior_point_Newton,
     interior_point_Newton!,
-    keywords_accepted,
     LevenbergMarquardt,
     LevenbergMarquardt!,
     mesh_adaptive_direct_search,

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -160,7 +160,7 @@ define!(
 )
 define!(:Math, :vector_transport, :name, "the vector transport")
 define!(
-    :Math, :VT, (a = "⋅", b = "⋅") -> _math(:vector_transport, :symbol, a,b)
+    :Math, :VT, (a = "⋅", b = "⋅") -> _math(:vector_transport, :symbol, a, b)
 )
 _math(args...; kwargs...) = glossary(:Math, args...; kwargs...)
 

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -159,6 +159,9 @@ define!(
     :Math, :vector_transport, :symbol, (a = "⋅", b = "⋅") -> raw"\mathcal T_{" * "$a←$b" * "}"
 )
 define!(:Math, :vector_transport, :name, "the vector transport")
+define!(
+    :Math, :VT, (a = "⋅", b = "⋅") -> _math(:vector_transport, :symbol, a,b)
+)
 _math(args...; kwargs...) = glossary(:Math, args...; kwargs...)
 
 #

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -67,9 +67,9 @@ function check_differential(
     )
 end
 
-_doc_check_gradient_formula = raw"""
+_doc_check_gradient_formula = """
 ```math
-f(\operatorname{retr}_p(tX)) = f(p) + t⟨\operatorname{grad} f(p), X⟩ + \mathcal O(t^2)
+f($(_tex(:retr))_p(tX)) = f(p) + t⟨$(_tex(:grad)) f(p), X⟩ + $(_tex(:Cal, "O"))(t^2)
 ```
 """
 @doc """
@@ -139,9 +139,9 @@ function check_gradient(
     return check_differential(M, f, df, p, X; name = "gradient", error = error, kwargs...)
 end
 
-_doc_check_Hess_formula = raw"""
+_doc_check_Hess_formula = """
 ```math
-f(\operatorname{retr}_p(tX)) = f(p) + t⟨\operatorname{grad} f(p), X⟩ + $(_tex(:frac, "t^2", "2"))⟨$(_tex(:Hess))f(p)[X], X⟩ + \mathcal O(t^3)
+f($(_tex(:retr))_p(tX)) = f(p) + t⟨$(_tex(:grad)) f(p), X⟩ + $(_tex(:frac, "t^2", "2"))⟨$(_tex(:Hess))f(p)[X], X⟩ + $(_tex(:Cal, "O"))(t^3)
 ```
 """
 

--- a/src/plans/hessian_plan.jl
+++ b/src/plans/hessian_plan.jl
@@ -229,12 +229,12 @@ An abstract supertype for approximate Hessian functions, declares them also to b
 """
 abstract type AbstractApproxHessian <: Function end
 
-_doc_ApproxHessian_formula = raw"""
+_doc_ApproxHessian_formula = """
 ```math
 $(_tex(:Hess))f(p)[X] ≈
-\frac{\lVert X \rVert_p}{c}\Bigl(
-  \mathcal T_{p\gets q}\bigr($(_tex(:grad))f(q)\bigl) - $(_tex(:grad))f(p)
-\Bigl)
+$(_tex(:frac, "$(_tex(:norm, "X"))", "c"))$(_tex(:Bigl))(
+  $(_math(:VT, "p", "q"))$(_tex(:bigl))( $(_tex(:grad))f(q)$(_tex(:bigr)) - $(_tex(:grad))f(p)
+$(_tex(:Bigr)))
 ```
 """
 _doc_ApproxHessian_step = raw"\operatorname{retr}_p(\frac{c}{\lVert X \rVert_p}X)"

--- a/src/plans/quasi_newton_plan.jl
+++ b/src/plans/quasi_newton_plan.jl
@@ -306,12 +306,12 @@ _doc_QN_H_update = "``H_k ↦ H_{k+1}``"
 _doc_QN_B_update = "``B_k ↦ B_{k+1}``"
 _doc_QN_H_full_system = """
 ```math
-$(_tex(:text, "Solve"))$(_tex(:quad)) $(_tex(:hat, "η_k")) = - H_k $(_tex(:widehat, "$(_tex(:operatorname, "grad"))f(x_k)")),
+$(_tex(:text, "Solve"))$(_tex(:quad))$(_tex(:hat, "η_k")) = - H_k $(_tex(:widehat, "$(_tex(:grad))f(x_k)")),
 ```
 """
 _doc_QN_B_full_system = """
 ```math
-$(_tex(:hat, "η_k")) = - B_k $(_tex(:widehat, "$(_tex(:operatorname, "grad"))f(x_k)")),
+$(_tex(:hat, "η_k")) = - B_k $(_tex(:widehat, "$(_tex(:grad))f(x_k)")),
 ```
 """
 
@@ -504,9 +504,10 @@ function initialize_update!(d::QuasiNewtonMatrixDirectionUpdate)
     return d
 end
 
-_doc_QN_B = raw"""
+_doc_QN_B = """
 ```math
-\mathcal{B}^{(0)}_k[⋅] = $(_tex(:frac, "g_{p_k}(s_{k-1}, y_{k-1})", "g_{p_k}(y_{k-1}, y_{k-1})} \; $(_tex(:Id))_{T_{p_k} $(_math(:M))"))[⋅]
+$(_tex(:Cal, "B"))_k^{(0)}[⋅]
+= $(_tex(:frac, "$(_tex(:inner, "s_{k-1}", "y_{k-1}"; index="p_k"))", "$(_tex(:inner, "y_{k-1}", "y_{k-1}"; index="p_k"))"))$(_tex(:Id))_{$(_math(:TpM))"[⋅]
 ```
 """
 

--- a/src/plans/quasi_newton_plan.jl
+++ b/src/plans/quasi_newton_plan.jl
@@ -507,7 +507,7 @@ end
 _doc_QN_B = """
 ```math
 $(_tex(:Cal, "B"))_k^{(0)}[⋅]
-= $(_tex(:frac, "$(_tex(:inner, "s_{k-1}", "y_{k-1}"; index="p_k"))", "$(_tex(:inner, "y_{k-1}", "y_{k-1}"; index="p_k"))"))$(_tex(:Id))_{$(_math(:TpM))"[⋅]
+= $(_tex(:frac, "$(_tex(:inner, "s_{k-1}", "y_{k-1}"; index = "p_k"))", "$(_tex(:inner, "y_{k-1}", "y_{k-1}"; index = "p_k"))"))$(_tex(:Id))_{$(_math(:TpM))"[⋅]
 ```
 """
 

--- a/src/plans/stopping_criterion.jl
+++ b/src/plans/stopping_criterion.jl
@@ -1347,38 +1347,39 @@ function show(io::IO, sc::StopWhenRepeated)
 end
 
 @doc """
-    StopWhenCriterionWithIterationCondition <: StoppingCriterion
+    StopWhenCriterionWithCondition <: StoppingCriterion
 
-A stopping criterion that indicates to stop when the (internal) stopping criterion it wraps,
-has indicated to stop with an additional check compared to the current iteration, e.g.
+A stopping criterion, that only evaluates a certain (inner) stopping based on a condition
+on the iterate `k`.
+The condition is a function `condition(k) -> Bool`.
 
-* `>(n)` only (stricly) after iteration `n`
-* `>=(n)` only including and after iteration `n`
-* `==(n)` only exactly at `n`
-* `<=(n)` only including and before iteration `n`
-* `<(n)` only (strictly) before iteration `n`
-* any functor `f(k) -> Bool` indicating to evaluate the stopping criterion at iteration `k`.
+## Example `(k) -> >(n)` would only activate that stopping criterion after `n` iterations.`.
 
-# Fields
+## Fields
 
 * `criterion`: the [`StoppingCriterion`](@ref) to wrap
 * `comp`: the number of times the criterion has to indicate to stop
 
-# Constructor
+## Constructor
 
     StopWhenRepeated(criterion::StoppingCriterion, n=0; comp = (>(n)))
 
 Create a stopping criterion that indicates to stop when the `comp` has indicated to
 check the inner criterion. The `n` is ignored if you provide a manual functor `comp`.
 
-As well as for a given [` StoppingCriterion`] `sc` the shortcuts
-`sc > n`, `sc >= n`, `sc == n`, `sc <= n`, `sc < n` for the cases above.
-
-# Examples
+## Examples
 
 A stopping criterion that indicates to stop when the gradient norm is small but only after the third iteration
     StopWhenCriterionWithIterationCondition(StopWhenGradientNormLess(1e-6), 3)
-    StopWhenGradientNormLess(1e-6) > 3
+
+You can also use the infix operators `≟` (`\\questeq` on REPL),  `⩻` (`\\ltquest`), and `⩼` (`\\gtquest`) to create such a criterion:
+
+    StopWhenGradientNormLess(1e-6) ≟ 3
+    StopWhenGradientNormLess(1e-6) ⩻ 3
+    StopWhenGradientNormLess(1e-6) ⩼ 3
+
+These are equivalent to specifying `comp = (==(3))`, `comp = (<(3))`, and `comp = (>(3))`, respectively.
+Their interpretation is “the stopping criterion is only checked (asked) if the condition is met”
 """
 mutable struct StopWhenCriterionWithIterationCondition{SC <: StoppingCriterion, F} <:
     StoppingCriterion
@@ -1391,20 +1392,14 @@ function StopWhenCriterionWithIterationCondition(
     ) where {SC <: StoppingCriterion, F}
     return StopWhenCriterionWithIterationCondition{SC, F}(sc, comp, -1)
 end
-function Base.:>(sc::StoppingCriterion, n::Int)
-    return StopWhenCriterionWithIterationCondition(sc, n; comp = (>(n)))
+function ⩻(sc::StoppingCriterion, n::Int)
+    return StopWhenCriterionWithIterationCondition(sc; comp = (<(n)))
 end
-function Base.:>=(sc::StoppingCriterion, n::Int)
-    return StopWhenCriterionWithIterationCondition(sc, n; comp = (>=(n)))
+function ⩼(sc::StoppingCriterion, n::Int)
+    return StopWhenCriterionWithIterationCondition(sc; comp = (>(n)))
 end
-function Base.:(==)(sc::StoppingCriterion, n::Int)
-    return StopWhenCriterionWithIterationCondition(sc, n; comp = (==(n)))
-end
-function Base.:<(sc::StoppingCriterion, n::Int)
-    return StopWhenCriterionWithIterationCondition(sc, n; comp = (<(n)))
-end
-function Base.:<=(sc::StoppingCriterion, n::Int)
-    return StopWhenCriterionWithIterationCondition(sc, n; comp = (<=(n)))
+function ≟(sc::StoppingCriterion, n::Int)
+    return StopWhenCriterionWithIterationCondition(sc; comp = (==(n)))
 end
 function (c::StopWhenCriterionWithIterationCondition)(
         p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -249,7 +249,7 @@ m(X_k) \leq m(0)
 A stopping criterion related to the Riemannian adaptive regularization with cubics (ARC)
 solver indicating that the model function at the current (outer) iterate,
 
-$_doc_ARC_mdoel
+$_doc_ARC_model
 
 defined on the tangent space ``$(_math(:TpM))`` fulfills at the current iterate ``X_k`` that
 

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -168,13 +168,13 @@ end
 
 _doc_ARC_model = """
 ```math
-m_k(X) = f(p_k) + $(_tex(:inner, "X" , "$(_tex(:grad)) f(p^{(k)})")) + $(_tex(:frac, "1","2)) $(_tex(:inner, "X", "$(_tex(:Hess)) f(p^{(k)})[X]")) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
+m_k(X) = f(p_k) + $(_tex(:inner, "X", "$(_tex(:grad)) f(p^{(k)})")) + $(_tex(:frac, "1", "2)) $(_tex(:inner, "X", "$(_tex(:Hess)) f(p^{(k)})[X]")) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
 ```
 """
 
 _doc_ARC_improvement = """
 ```math
-  ρ_k = $(_tex(:frac, "f(p_k) - f($(_tex(:retr))_{p_k}(X_k))" , "m_k(0) - m_k(X_k) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
+  ρ_k = $(_tex(:frac, "f(p_k) - f($(_tex(:retr))_{p_k}(X_k))", "m_k(0) - m_k(X_k) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
 ```
 """
 _doc_ARC_regularization_update = raw"""

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -166,15 +166,15 @@ function show(io::IO, arcs::AdaptiveRegularizationState)
     return print(io, s)
 end
 
-_doc_ARC_mdoel = raw"""
+_doc_ARC_model = """
 ```math
-m_k(X) = f(p_k) + ⟨X, \operatorname{grad} f(p^{(k)})⟩ + \frac{1}{2}⟨X, $(_tex(:Hess)) f(p^{(k)})[X]⟩ + \frac{σ_k}{3}\lVert X \rVert^3
+m_k(X) = f(p_k) + $(_tex(:inner, "X" , "$(_tex(:grad)) f(p^{(k)})")) + $(_tex(:frac, "1","2)) $(_tex(:inner, "X", "$(_tex(:Hess)) f(p^{(k)})[X]")) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
 ```
 """
 
-_doc_ARC_improvement = raw"""
+_doc_ARC_improvement = """
 ```math
-  ρ_k = \frac{f(p_k) - f(\operatorname{retr}_{p_k}(X_k))}{m_k(0) - m_k(X_k) + \frac{σ_k}{3}\lVert X_k\rVert^3}.
+  ρ_k = $(_tex(:frac, "f(p_k) - f($(_tex(:retr))_{p_k}(X_k))" , "m_k(0) - m_k(X_k) + $(_tex(:frac, "σ_k", "3"))$(_tex(:norm, "X"))^3"))
 ```
 """
 _doc_ARC_regularization_update = raw"""
@@ -198,7 +198,7 @@ _doc_ARC = """
 
 Solve an optimization problem on the manifold `M` by iteratively minimizing
 
-$_doc_ARC_mdoel
+$_doc_ARC_model
 
 on the tangent space at the current iterate ``p_k``, where ``X ∈ $(_math(:TpM; p = "p_k"))`` and
 ``σ_k > 0`` is a regularization parameter.

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -165,7 +165,7 @@ _doc_EMP_ρ_update = raw"""
 ```math
 ρ^{(k)} = \begin{cases}
 ρ^{(k-1)}/θ_ρ,  & \text{if } \displaystyle \max_{j ∈ \mathcal{E},i ∈ \mathcal{I}} \Bigl\{ \vert h_j(x^{(k)}) \vert, g_i(x^{(k)})\Bigr\} \geq u^{(k-1)} \Bigr) ,\\
-ρ^{(k-1)}, & $(_tex(:text, "else,"))
+ρ^{(k-1)}, & \text{ else,}
 \end{cases}
 ```
 

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -1,10 +1,10 @@
 _doc_PDSN_formula = raw"""
-Given a `cost` function ``\mathcal E: $(_math(:M)) → \overline{ℝ}`` of the form
+Given a `cost` function ``\mathcal E: \mathcal M → \overline{ℝ}`` of the form
 ```math
 \mathcal E(p) = F(p) + G( Λ(p) ),
 ```
-where ``F: $(_math(:M)) → \overline{ℝ}``, ``G: \mathcal N → \overline{ℝ}``,
-and ``Λ: $(_math(:M)) → \mathcal N``. The remaining input parameters are
+where ``F: \mathcal M → \overline{ℝ}``, ``G: \mathcal N → \overline{ℝ}``,
+and ``Λ: \mathcal M → \mathcal N``. The remaining input parameters are
 """
 
 _doc_PDSN = """
@@ -15,7 +15,7 @@ Perform the Primal-Dual Riemannian semismooth Newton algorithm.
 $(_doc_PDSN_formula)
 
 * `p, X`:                          primal and dual start points ``p∈$(_math(:M))`` and ``X ∈ T_n$(_tex(:Cal, "N"))``
-* `m,n`:                           base points on ``$(_math(:M))`` and ``$(_tex(:Cal, "N"))`, respectively.
+* `m,n`:                           base points on ``$(_math(:M))`` and ``$(_tex(:Cal, "N"))``, respectively.
 * `linearized_forward_operator`:   the linearization ``DΛ(⋅)[⋅]`` of the operator ``Λ(⋅)``.
 * `adjoint_linearized_operator`:   the adjoint ``DΛ^*`` of the linearized operator ``DΛ(m):  $(_math(:TpM; p = "m")) → $(_math(:TpM; M = "N", p = "Λ(m)"))``
 * `prox_F, prox_G_Dual`:           the proximal maps of ``F`` and ``G^$(_tex(:ast))_n``

--- a/src/solvers/proximal_bundle_method.jl
+++ b/src/solvers/proximal_bundle_method.jl
@@ -207,7 +207,7 @@ end
 
 _doc_PBM_dk = raw"""
 ```math
-d_k = \frac{1}{\mu_k} \sum_{j\in J_k} λ_j^k $(_tex(:rm, "P"))_{p_k←q_j}X_{q_j},
+d_k = \frac{1}{\mu_k} \sum_{j\in J_k} λ_j^k \mathrm{P}_{p_k←q_j}X_{q_j},
 ```
 
 with ``X_{q_j} ∈ ∂f(q_j)``, ``p_k`` the last serious iterate,

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -403,9 +403,9 @@ end
 _doc_TCG_subproblem = raw"""
 ```math
 \begin{align*}
-$(_tex(:argmin))_{Y  ∈  T_p\mathcal{M}}&\ m_p(Y) = f(p) +
+\operatorname{arg\,min}_{Y  ∈  T_p\mathcal{M}}&\ m_p(Y) = f(p) +
 ⟨\operatorname{grad}f(p), Y⟩_p + \frac{1}{2} ⟨\mathcal{H}_p[Y], Y⟩_p\\
-$(_tex(:text, "such that"))& \ \lVert Y \rVert_p ≤ Δ
+$(\text{such that"}& \ \lVert Y \rVert_p ≤ Δ
 \end{align*}
 ```
 """

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -405,7 +405,7 @@ _doc_TCG_subproblem = raw"""
 \begin{align*}
 \operatorname{arg\,min}_{Y  ∈  T_p\mathcal{M}}&\ m_p(Y) = f(p) +
 ⟨\operatorname{grad}f(p), Y⟩_p + \frac{1}{2} ⟨\mathcal{H}_p[Y], Y⟩_p\\
-$(\text{such that"}& \ \lVert Y \rVert_p ≤ Δ
+\text{such that} & \ \lVert Y \rVert_p ≤ Δ
 \end{align*}
 ```
 """

--- a/test/plans/test_stopping_criteria.jl
+++ b/test/plans/test_stopping_criteria.jl
@@ -349,16 +349,11 @@ using Manifolds, ManifoldsBase, Manopt, ManoptTestSuite, Test, ManifoldsBase, Da
             "StopWhenCriterionWithIterationCondition with the Stopping Criterion:\n",
         )
         @test startswith(Manopt.status_summary(sc), "Base.Fix2{typeof(>), Int64}(>, 5) &&")
-        sc2 = s > 5
+        sc2 = s ⩼ 5
         @test typeof(sc) === typeof(sc2)
-        # Test other constructors
-        sc3 = s >= 5
-        @test sc3.comp === (>=(5))
-        sc4 = s == 5
+        sc4 = s ≟ 5
         @test sc4.comp === (==(5))
-        sc5 = s <= 5
-        @test sc5.comp === (<=(5))
-        sc6 = s < 5
+        sc6 = s ⩻ 5
         @test sc6.comp === (<(5))
 
         # test that it does not hit at 5


### PR DESCRIPTION
This resolves #509.

It removed the shortcuts `>`, `>=`, `==`, `<=`, `<` for stopping criteria to only be active before/at/after a certain iteration.
It introduces the (not even yet defined in Base) infix operators `⩼`, `≟`, and `⩻` and exports there.
They are documented with their REPL short code, because they have the small disadvantage of being a bit uncommon in symbols.

I do not expect them to be used often, so I think we can also consider this more a bugfix than a breaking PR.