### PR TITLE
Fix warning in DebugFeasibility

### DIFF
--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -456,7 +456,7 @@ mutable struct DebugFeasibility <: DebugAction
     format::Vector{Union{String, Symbol}}
     io::IO
     function DebugFeasibility(format = ["feasible: ", :Feasible]; io::IO = stdout, atol = NaN)
-        isnan(atol) && (@warn "Providing atol= directly to DebugFeasibility is deprecated. Use the keyword for the ConstrainedObjective instead. The value provided here ($(atol)) is ignored")
+        isnan(atol) || (@warn "Providing atol= directly to DebugFeasibility is deprecated. Use the keyword for the ConstrainedObjective instead. The value provided here ($(atol)) is ignored")
         return new(format, io)
     end
 end


### PR DESCRIPTION
I think we made a small mistake in #545. We want the warning only be shown if `atol` is not `NaN` (the default), right? Currently, it shows the warning if you do not pass anything explicitly to `atol`. Sorry for not catching that before.