### PR TITLE
Don't print debug actions when `k=-1`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* a small bug where debug statements were printed even though they should not be due to `DebugEvery` and unified warnings to print independent of `DebugEntry`. (#609)
+* a small bug where debug statements were printed even though they should not be due to `DebugEvery` and unified warnings to print independent of `DebugEvery`. (#609)
 
 ## [0.5.38] May 19, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.39] June 2, 2026
+
+### Fixed
+
+* a small bug where debug statements were printed even though they should not be due to `DebugEvery`. (#609)
+
 ## [0.5.38] May 19, 2026
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,11 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.39] June 2, 2026
+## [0.5.39] June 3, 2026
 
 ### Fixed
 
-* a small bug where debug statements were printed even though they should not be due to `DebugEvery`. (#609)
+* a small bug where debug statements were printed even though they should not be due to `DebugEvery` and unified warnings to print independent of `DebugEntry`. (#609)
 
 ## [0.5.38] May 19, 2026
 

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -1011,7 +1011,6 @@ end
 function (d::DebugWarnIfCostIncreases)(
         p::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
-    (k < 0) && (return nothing)
     if d.status !== :No
         cost = get_cost(p, get_iterate(st))
         if cost > d.old_cost + d.tol
@@ -1062,7 +1061,6 @@ end
 function (d::DebugWarnIfCostNotFinite)(
         p::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
-    (k < 0) && (return nothing)
     if d.status !== :No
         cost = get_cost(p, get_iterate(st))
         if !isfinite(cost)
@@ -1109,7 +1107,6 @@ end
 function (d::DebugWarnIfFieldNotFinite)(
         ::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
-    (k < 0) && (return nothing)
     if d.status !== :No
         if d.field == :Iterate
             v = get_iterate(st)
@@ -1169,7 +1166,6 @@ end
 function (d::DebugWarnIfGradientNormTooLarge)(
         mp::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
-    (k < 0) && (return nothing)
     if d.status !== :No
         M = get_manifold(mp)
         p = get_iterate(st)
@@ -1222,7 +1218,7 @@ end
 function (d::DebugWarnIfStepsizeCollapsed)(
         amp::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
-    (k < 1) && (return nothing)
+    (k == 0) && (return nothing)
     if d.status !== :No
         if get_last_stepsize(amp, st, k) ≤ d.stop_when_stepsize_less
             @warn "Backtracking stopped because the stepsize fell below the threshold $(d.stop_when_stepsize_less)."

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -939,15 +939,15 @@ end
 function (d::DebugTime)(::AbstractManoptProblem, ::AbstractManoptSolverState, k)
     if k == 0 || d.last_time == Nanosecond(0) # init
         d.last_time = Nanosecond(time_ns())
-    else
+    elseif k > 0
         t = time_ns()
         p = Nanosecond(t) - d.last_time
         Printf.format(
             d.io, Printf.Format(d.format), canonicalize(round(p, d.time_accuracy))
         )
-    end
-    if d.mode == :iterative
-        d.last_time = Nanosecond(time_ns())
+        if d.mode == :iterative
+            d.last_time = Nanosecond(time_ns())
+        end
     end
     return nothing
 end

--- a/src/plans/debug.jl
+++ b/src/plans/debug.jl
@@ -614,7 +614,7 @@ function (d::DebugEntryChange)(
     end
     x = get_storage(d.storage, d.field)
     v = d.distance(p, st, getproperty(st, d.field), x)
-    Printf.format(d.io, Printf.Format(d.format), v)
+    (k > 0) && Printf.format(d.io, Printf.Format(d.format), v)
     d.storage(p, st, k)
     return nothing
 end
@@ -1062,6 +1062,7 @@ end
 function (d::DebugWarnIfCostNotFinite)(
         p::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
+    (k < 0) && (return nothing)
     if d.status !== :No
         cost = get_cost(p, get_iterate(st))
         if !isfinite(cost)
@@ -1108,6 +1109,7 @@ end
 function (d::DebugWarnIfFieldNotFinite)(
         ::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
+    (k < 0) && (return nothing)
     if d.status !== :No
         if d.field == :Iterate
             v = get_iterate(st)
@@ -1167,6 +1169,7 @@ end
 function (d::DebugWarnIfGradientNormTooLarge)(
         mp::AbstractManoptProblem, st::AbstractManoptSolverState, k::Int
     )
+    (k < 0) && (return nothing)
     if d.status !== :No
         M = get_manifold(mp)
         p = get_iterate(st)


### PR DESCRIPTION
This fixes a small bug, when using some debug actions (`DebugTime`, `DebugEntryChange`, `DebugWarnIfCostNotFinite`, `DebugWarnIfFieldNotFinite`, and `DebugWarnIfGradientNormTooLarge`) together with `DebugEvery` (with `always_update = true`), where the actions ignore the `DebugEvery` and print their output at _each_ iteration instead of only every `every` iterations. This is because they don't add a guard for `k = -1`, which is passed by `DebugEvery` for the iterations that should be skipped. For the warnings it might be debatable whether they should intentionally skip the `DebugEvery` or not, but since `DebugWarnIfCostIncreases` and `DebugWarnIfStepsizeCollapsed` already had the `k < 0` included, I also added it to the other three warning debug actions for consistency. I can also remove it consistently for all five warning debug actions if preferred.