### PR TITLE
Fix LM surrogate operator documentation

### DIFF
--- a/src/plans/nonlinear_least_squares/nls_general_plan.jl
+++ b/src/plans/nonlinear_least_squares/nls_general_plan.jl
@@ -203,15 +203,15 @@ For the derivation of the Riemannian case, see [BaranBergmann:2026](@cite).
 
 In order to build a surrogate also for the robustified Levenberg-Marquardt, introduce
 ``α = 1 - $(_tex(:sqrt, "1 + 2 $(_tex(:frac, "ρ''(p)", "ρ'(p)"))$(_tex(:norm, "F(p)"; index = "2"))^2"))``
-and set ``y = $(_tex(:frac, _tex(:sqrt, "ρ'(p)"), "1-α"))F(p)`` and ``$(_tex(:Cal, "L"))(X) = CJ_F^*(p)[F(p)]``
+and set ``y = $(_tex(:frac, _tex(:sqrt, "ρ'(p)"), "1-α"))F(p)`` and ``$(_tex(:Cal, "L"))(X) = CJ_F(p)[X]``
 with
 
 ```math
 C = $(_tex(:sqrt, "ρ'(p)"))(I-αP), $(_tex(:qquad)) P = $(_tex(:frac, "F(p)F(p)^" * _tex(:rm, "T"), _tex(:norm, "F(p)"; index = "2") * "^2")),
 ```
 
-where ``F(p) ∈ ℝ^n`` is the vector of residuals at point ``p ∈ M`` and ``J_F^*(p): ℝ^n → $(_math(:TangentSpace))``
-is the adjoint Jacobian.
+where ``F(p) ∈ ℝ^n`` is the vector of residuals at point ``p ∈ M`` and ``J_F(p): $(_math(:TangentSpace)) → ℝ^n``
+is the Jacobian as a linear operator.
 These two can be accessed with [`get_vector_field`](@ref) for ``y`` and [`get_linear_operator`](@ref) for ``$(_tex(:Cal, "L"))``,
 respectively.
 For technical details on the scaling using ``α``, especially how the `threshold` and `mode`

--- a/src/plans/nonlinear_least_squares/nls_general_plan.jl
+++ b/src/plans/nonlinear_least_squares/nls_general_plan.jl
@@ -211,7 +211,7 @@ C = $(_tex(:sqrt, "ρ'(p)"))(I-αP), $(_tex(:qquad)) P = $(_tex(:frac, "F(p)F(p)
 ```
 
 where ``F(p) ∈ ℝ^n`` is the vector of residuals at point ``p ∈ M`` and ``J_F(p): $(_math(:TangentSpace)) → ℝ^n``
-is the Jacobian as a linear operator.
+is the Jacobian.
 These two can be accessed with [`get_vector_field`](@ref) for ``y`` and [`get_linear_operator`](@ref) for ``$(_tex(:Cal, "L"))``,
 respectively.
 For technical details on the scaling using ``α``, especially how the `threshold` and `mode`


### PR DESCRIPTION
This PR fixes a small documentation typo in the Levenberg–Marquardt linear surrogate description based on the very reference https://arxiv.org/pdf/2606.23560.

The surrogate operator is defined as $\mathcal L : T_pM \to \mathbb R^n,$ so it should use the Jacobian action $\mathcal L(X) = C J_F(p)[X],$ rather than the adjoint Jacobian applied to the residual. The latter lives in the tangent space and is dimensionally inconsistent with the definition of $\mathcal L$. I also updated the following explanatory sentence to describe $J_F(p)$ as the Jacobian linear operator.

