### PR TITLE
Avoid coordinate cache allocation in VectorDifferentialFunction get_jacobian!

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] July 3, 2026
+
+### Fixed
+
+* Fix a typo in Riemannian Levenberg–Marquardt documentation. 
+* Fixed a coordinate-cache allocation in the `VectorDifferentialFunction` Jacobian-action path. (#621)
+
 ## [0.6.0] June 24, 2026
 
 This is a breaking change since the JuMP extension is dropped.

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fix a typo in Riemannian Levenberg–Marquardt documentation. 
-* Fixed a coordinate-cache allocation in the `VectorDifferentialFunction` Jacobian-action path. (#621)
+* Fix a typo in Riemannian Levenberg–Marquardt documentation.  (#621)
+* Fixed a coordinate-cache allocation in the `VectorDifferentialFunction` Jacobian-action path. (#622)
 
 ## [0.6.0] June 24, 2026
 

--- a/src/plans/vectorial_plan.jl
+++ b/src/plans/vectorial_plan.jl
@@ -873,7 +873,7 @@ end
 # (d) Jacobian differential – easiest: just call it
 function get_jacobian!(
         M::AbstractManifold, a, vgf::VectorDifferentialFunction{<:AbstractEvaluationType, FT, <:FunctionVectorialType}, p, X;
-        range = nothing, Y_cache = nothing, c_cache = allocate_result(M, get_coordinates, p, X, get_basis(vgf.jacobian_type))
+        range = nothing, Y_cache = nothing, c_cache = nothing
     ) where {FT}
     a .= vgf.jacobian!!(M, p, X)
     return a


### PR DESCRIPTION
This PR fixes the `FunctionVectorialType` Jacobian-action path for `VectorDifferentialFunction`.
The affected `get_jacobian!` method does not use `c_cache`.

This can fail for manifolds/containers that do not support coordinate allocation, even though the Jacobian action itself is coordinate-free. The default is changed to `nothing`.