### PR TITLE
Extra backtracking condition for prox-grad

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,25 +6,31 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] July 20, 2026
+
+### Added
+
+* an extra condition in the backtracking `ProximalGradientMethodBacktrackingStepsize` for the `proximal_gradient_method`.
+
 ## [0.6.2] July 17, 2026
 
 ### Added
 
-* a `callbacks = ` keyword to all solvers (#626)
+* a `callbacks =` keyword to all solvers (#626)
 
 ### Changed
 
 * Replaced internal `ZeroTangentVector` with `ZeroVector` from ManifoldsBase.jl. (#625)
 * internally restructure the `plans/` code folder and documentation and split it into two parts (#626)
-  - a `base/` folder defining inderfaces and documenting design ideas of these
-  - a `commons/` folder collecting things (some or all) solvers have in common
+  * a `base/` folder defining inderfaces and documenting design ideas of these
+  * a `commons/` folder collecting things (some or all) solvers have in common
 
   this should not break other peoples code, but in the documentation, namely “hard link”s to any `plans/` element might break – and will all break in the future. When you are linking to these from another documentation, consider using `DocumenterInterlinks` instead.
 
 ### Deprecated
 
 * with actual callbacks available, the `DebugCallback` action from before is now obsolete and deprecated (#626)
-* the `callback = ` is deprecated, since it only served `DebugCallback` (#626)
+* the `callback =` is deprecated, since it only served `DebugCallback` (#626)
 
 ## [0.6.1] July 4, 2026
 
@@ -78,7 +84,7 @@ We also unified a few of the internal solver state constructors.
 * The extension to JuMP. A replacement as a separate package is planned when the support for variables beyond vectors is more accessible in JuMP
 * the plotting functions to `Asymptote`. They can now be found in the separate package [`ManifoldAsymptote.jl`](https://github.com/JuliaManifolds/ManifoldAsymptote.jl)
   this way, `Manopt.jl` has less dependencies, especially the color and colorschemes dependencies are dropped
-* `linear_subsolver! = ` was removed from the [`LevenbergMarquardt`](https://manoptjl.org/stable/solvers/LevenbergMarquardt/) solver interface, since it is imprecise. If you use a closed form solver before, specify it by passing the function to `sub_problem` and set `sub_state` to the corresponding evaluation type
+* `linear_subsolver! =` was removed from the [`LevenbergMarquardt`](https://manoptjl.org/stable/solvers/LevenbergMarquardt/) solver interface, since it is imprecise. If you use a closed form solver before, specify it by passing the function to `sub_problem` and set `sub_state` to the corresponding evaluation type
 
 ## [0.5.39] June 3, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* an extra condition in the backtracking `ProximalGradientMethodBacktrackingStepsize` for the `proximal_gradient_method`.
+* an extra condition in the backtracking `ProximalGradientMethodBacktrackingStepsize` for the `proximal_gradient_method`. (#629)
 
 ## [0.6.2] July 17, 2026
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
-version = "0.6.2"
+version = "0.6.3"
 
 [workspace]
 projects = ["test", "docs", "tutorials"]

--- a/src/plans/proximal_gradient_plan.jl
+++ b/src/plans/proximal_gradient_plan.jl
@@ -531,7 +531,10 @@ function (s::ProximalGradientMethodBacktrackingStepsize)(
 
     while λ > s.stop_when_stepsize_less
         # Perform gradient step with current λ
-        retract!(M, pgm_temp.a, p, -λ * X, st.retraction_method)
+        direction = -λ * X
+        retract!(M, pgm_temp.a, p, direction, st.retraction_method)
+        distance_gradient = norm(M, p, direction)
+
 
         # Perform proximal step with current λ
         _pgm_proximal_step(mp, pgm_temp, λ)
@@ -539,25 +542,31 @@ function (s::ProximalGradientMethodBacktrackingStepsize)(
 
         # Compute log_p(candidate_point) and its squared norm for the conditions
         log_p_q = inverse_retract(M, p, candidate_point, st.inverse_retraction_method)
-        squared_distance = norm(M, p, log_p_q)^2
-        if s.strategy === :nonconvex
-            # Nonconvex descent condition
-            if get_cost(mp, p) - get_cost(mp, candidate_point) >=
-                    (s.sufficient_decrease / λ) * squared_distance
-                s.last_stepsize = λ
-                return λ
-            end
-        elseif s.strategy === :convex
-            g_p = get_cost_smooth(M, objective, p)
-            g_q = get_cost_smooth(M, objective, candidate_point)
+        distance_candidate = norm(M, p, log_p_q)
+        squared_distance = distance_candidate^2
+        π_k = s.k_max ≤ eps(eltype(s.k_max)) ? Inf : π / √s.k_max
+        r_δ = π_k / (2 + s.δ)
+
+        if max(distance_gradient, distance_candidate) ≤ r_δ
+            if s.strategy === :nonconvex
+                # Nonconvex descent condition
+                if get_cost(mp, p) - get_cost(mp, candidate_point) >=
+                        (s.sufficient_decrease / λ) * squared_distance
+                    s.last_stepsize = λ
+                    return λ
+                end
+            elseif s.strategy === :convex
+                g_p = get_cost_smooth(M, objective, p)
+                g_q = get_cost_smooth(M, objective, candidate_point)
 
 
-            ζ_δ = s.k_max ≤ zero(eltype(s.k_max)) ? one(eltype(s.k_max)) : π / (2 + s.δ) * cot(π / (2 + s.δ))
+                ζ_δ = s.k_max ≤ zero(eltype(s.k_max)) ? one(eltype(s.k_max)) : π / (2 + s.δ) * cot(π / (2 + s.δ))
 
-            # Convex descent condition
-            if g_q <= g_p + inner(M, p, X, log_p_q) + (ζ_δ / 2λ) * squared_distance
-                s.last_stepsize = λ
-                return λ
+                # Convex descent condition
+                if g_q <= g_p + inner(M, p, X, log_p_q) + (ζ_δ / 2λ) * squared_distance
+                    s.last_stepsize = λ
+                    return λ
+                end
             end
         end
 


### PR DESCRIPTION
This adds an additional backtracking condition for the `proximal_gradient_method` that checks that the maximum between two specific distances is below a certain threshold.