### PR TITLE
Always evaluate all stopping criteria for StopWhenAll/StopWhenAny

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `StopWhenAll` and `StopWhenAny` evaluated their criteria with short-circuiting, so criteria later in the list were not called in every iteration. Stateful criteria like
   `StopWhenChangeLess` or `StopWhenRepeated` were hence not updated and the reset at
-  initialization did not reach them either. Not `requires_update` is used to determine, which ones need to be called even after one could use a short cut already – only the ones without state are “short-circuited”. (#632,#635)
+  initialization did not reach them either. Now `requires_update` is used to determine which ones need to be called even after one could use a shortcut already – only the ones without state are “short-circuited”. (#632,#635)
 
 ## [0.6.4] August 21, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.5] August 22, 2026
 
+### Added
+
+* a new function `has_state` that per `<:StoppingCriterion` type can indicate, whether a state is present that needs updating in every iteration.
+* a new shortcut for the `StopWhenCriterionWithIterationCondition` that only evaluates every `n`th iteration using `stopping_criterion ≞ n` (`\measeq` <TAB> on REPL) as constructor. While in theory also `%` would have been possible, there was a discussion not to use mnore-common symbols here, cf. (#509) – and the `m` could be seen as “modulo”.
+
 ### Fixed
 
-* `StopWhenAll` and `StopWhenAny` evaluated their criteria with short-circuiting, so criteria
-  later in the list were not called in every iteration. Stateful criteria like
+* `StopWhenAll` and `StopWhenAny` evaluated their criteria with short-circuiting, so criteria later in the list were not called in every iteration. Stateful criteria like
   `StopWhenChangeLess` or `StopWhenRepeated` were hence not updated and the reset at
-  initialization did not reach them either. All criteria are now evaluated in every call. (#632,#635)
+  initialization did not reach them either. Not `has_state` is used to determine, which ones need to be called even after one could use a short cut already – only the ones without state are “short-circuited”. (#632,#635)
 
 ## [0.6.4] August 21, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,15 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] August 22, 2026
+
+### Fixed
+
+* `StopWhenAll` and `StopWhenAny` evaluated their criteria with short-circuiting, so criteria
+  later in the list were not called in every iteration. Stateful criteria like
+  `StopWhenChangeLess` or `StopWhenRepeated` were hence not updated and the reset at
+  initialization did not reach them either. All criteria are now evaluated in every call. (#632,#635)
+
 ## [0.6.4] August 21, 2026
 
 As an overarching scheme of this release, the single functions in an objective become more independent; their wrapping happens automatically and the objective gets – in turn – a bit more lightweight and has “less cases to handle”.

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* a new function `has_state` that per `<:StoppingCriterion` type can indicate, whether a state is present that needs updating in every iteration.
+* a new function `requires_update` that per `<:StoppingCriterion` type can indicate, whether a state is present that needs updating in every iteration.
 * a new shortcut for the `StopWhenCriterionWithIterationCondition` that only evaluates every `n`th iteration using `stopping_criterion ≞ n` (`\measeq` <TAB> on REPL) as constructor. While in theory also `%` would have been possible, there was a discussion not to use mnore-common symbols here, cf. (#509) – and the `m` could be seen as “modulo”.
 
 ### Fixed
 
 * `StopWhenAll` and `StopWhenAny` evaluated their criteria with short-circuiting, so criteria later in the list were not called in every iteration. Stateful criteria like
   `StopWhenChangeLess` or `StopWhenRepeated` were hence not updated and the reset at
-  initialization did not reach them either. Not `has_state` is used to determine, which ones need to be called even after one could use a short cut already – only the ones without state are “short-circuited”. (#632,#635)
+  initialization did not reach them either. Not `requires_update` is used to determine, which ones need to be called even after one could use a short cut already – only the ones without state are “short-circuited”. (#632,#635)
 
 ## [0.6.4] August 21, 2026
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
-version = "0.6.4"
+version = "0.6.5"
 
 [workspace]
 projects = ["test", "docs", "tutorials"]

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -33,7 +33,6 @@ to clone/fork the repository or open an issue.
 The following packages are using `Manopt.jl`:
 
 * [ExponentialFamilyProjection.jl](https://github.com/ReactiveBayes/ExponentialFamilyProjection.jl) package uses `Manopt.jl` to project arbitrary functions onto the closest exponential family distributions. The package also integrates with [`RxInfer.jl`](https://github.com/ReactiveBayes/RxInfer.jl) to enable Bayesian inference in a larger set of probabilistic models.
-* [Caesar.jl](https://github.com/JuliaRobotics/Caesar.jl) uses `Manopt.jl` within non-Gaussian factor graph inference algorithms.
 * [SummationByPartsOperatorsExtra.jl](https://github.com/JoshuaLampert/SummationByPartsOperatorsExtra.jl) uses `Manopt.jl` to construct function space summation by parts operators for the numerical solution of partial differential equations.
 
 The following papers are using `Manopt.jl`:

--- a/docs/src/base/stopping_criterion.md
+++ b/docs/src/base/stopping_criterion.md
@@ -44,4 +44,5 @@ is_active_stopping_criterion
 has_converged
 get_active_stopping_criteria
 get_reason
+has_state
 ```

--- a/docs/src/base/stopping_criterion.md
+++ b/docs/src/base/stopping_criterion.md
@@ -44,5 +44,5 @@ is_active_stopping_criterion
 has_converged
 get_active_stopping_criteria
 get_reason
-has_state
+requires_update
 ```

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -245,7 +245,7 @@ function __init__()
 end
 #
 # General
-export ℝ, ℂ, &, |, ×, ≟, ⩼, ⩻
+export ℝ, ℂ, &, |, ×, ≟, ⩼, ⩻, ≞
 export mid_point, mid_point!, reflect, reflect!
 #
 # Problems

--- a/src/base/stopping_criterion.jl
+++ b/src/base/stopping_criterion.jl
@@ -141,7 +141,7 @@ Return whether a [`StoppingCriterion`](@ref) is active, i.e. it has been called 
 is_active_stopping_criterion(c::StoppingCriterion) = (c.at_iteration >= 0)
 
 """
-    has_state(::Type{<:StoppingCriterion})
+    requires_update(::Type{<:StoppingCriterion})
 
 Return whether a [`StoppingCriterion`](@ref) has an internal state.
 
@@ -151,7 +151,7 @@ group of stopping criteria can maybe “stop early” to evaluate the single cri
 By default this function returns the pessimistic answer of `true`.
 Stopping criteria that do not require internal updates can set this value to `false`.
 """
-has_state(::Type{<:StoppingCriterion}) = true
+requires_update(::Type{<:StoppingCriterion}) = true
 
 
 # pass down from state to stopping criterion

--- a/src/base/stopping_criterion.jl
+++ b/src/base/stopping_criterion.jl
@@ -140,6 +140,20 @@ Return whether a [`StoppingCriterion`](@ref) is active, i.e. it has been called 
 """
 is_active_stopping_criterion(c::StoppingCriterion) = (c.at_iteration >= 0)
 
+"""
+    has_state(::Type{<:StoppingCriterion})
+
+Return whether a [`StoppingCriterion`](@ref) has an internal state.
+
+This is for example used when determining whether a [`StopWhenAll`](@ref)
+group of stopping criteria can maybe “stop early” to evaluate the single criteria.
+
+By default this function returns the pessimistic answer of `true`.
+Stopping criteria that do not require internal updates can set this value to `false`.
+"""
+has_state(::Type{<:StoppingCriterion}) = true
+
+
 # pass down from state to stopping criterion
 function set_parameter!(s::AbstractManoptSolverState, ::Val{:StoppingCriterion}, args...)
     set_parameter!(s.stop, args...)

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -9,16 +9,19 @@
 Evaluate stopping criteria for a [`StopWhenAll`](@ref). Once one criterion returns `false`,
 only criteria not eligible for short-circuiting are evaluated.
 """
+@inline evaluate_all_criteria(
+    ::Tuple{}, ::AbstractManoptProblem, ::AbstractManoptSolverState, ::Int
+) = true
 @inline function evaluate_all_criteria(
-        criteria::Tuple, p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int
-    )
-    result = true
-    for criterion in criteria
-        if result || has_state(typeof(criterion))
-            result &= criterion(p, s, k)::Bool
-        end
-    end
-    return result
+        criteria::Tuple{C, Vararg{StoppingCriterion}},
+        p::AbstractManoptProblem,
+        s::AbstractManoptSolverState,
+        k::Int,
+    ) where {C <: StoppingCriterion}
+    criterion = first(criteria)
+    result = criterion(p, s, k)::Bool
+    return result ? evaluate_all_criteria(Base.tail(criteria), p, s, k) :
+        (_evaluate_update_criteria(Base.tail(criteria), p, s, k); false)
 end
 
 """
@@ -27,16 +30,40 @@ end
 Evaluate stopping criteria for a [`StopWhenAny`](@ref). Once one criterion returns `true`,
 only criteria not eligible for short-circuiting are evaluated.
 """
+@inline evaluate_any_criteria(
+    ::Tuple{}, ::AbstractManoptProblem, ::AbstractManoptSolverState, ::Int
+) = false
 @inline function evaluate_any_criteria(
-        criteria::Tuple, p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int
-    )
-    result = false
-    for criterion in criteria
-        if !result || has_state(typeof(criterion))
-            result |= criterion(p, s, k)::Bool
-        end
+        criteria::Tuple{C, Vararg{StoppingCriterion}},
+        p::AbstractManoptProblem,
+        s::AbstractManoptSolverState,
+        k::Int,
+    ) where {C <: StoppingCriterion}
+    criterion = first(criteria)
+    result = criterion(p, s, k)::Bool
+    return result ? (_evaluate_update_criteria(Base.tail(criteria), p, s, k); true) :
+        evaluate_any_criteria(Base.tail(criteria), p, s, k)
+end
+
+"""
+    _evaluate_update_criteria(criteria::Tuple, problem, state, k)
+
+Evaluate stopping criteria for updating after the truth value has been established by
+either [`evaluate_all_criteria`](@ref) or [`evaluate_any_criteria`](@ref).
+"""
+@inline _evaluate_update_criteria(
+    ::Tuple{}, ::AbstractManoptProblem, ::AbstractManoptSolverState, ::Int
+) = nothing
+@inline function _evaluate_update_criteria(
+        criteria::Tuple{C, Vararg{StoppingCriterion}},
+        p::AbstractManoptProblem,
+        s::AbstractManoptSolverState,
+        k::Int,
+    ) where {C <: StoppingCriterion}
+    if requires_update(C)
+        first(criteria)(p, s, k)::Bool
     end
-    return result
+    return _evaluate_update_criteria(Base.tail(criteria), p, s, k)
 end
 
 @doc """
@@ -67,9 +94,7 @@ end
 function (c::StopWhenAll)(p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int)
     if (k <= 0) # reset on init
         c.at_iteration = -1
-        for ci in c.criteria #reset internals as well
-            ci(p, s, k)
-        end
+        map(ci -> ci(p, s, k), c.criteria) #reset internals as well
     end
     if evaluate_all_criteria(c.criteria, p, s, k)
         c.at_iteration = k
@@ -129,6 +154,9 @@ function Base.show(io::IO, c::StopWhenAll)
         show(io, cs)
     end
     return print(io, "])")
+end
+function requires_update(::Type{StopWhenAll{TC}}) where {TC <: Tuple}
+    return any(map(requires_update, Tuple(TC.parameters)))
 end
 
 """
@@ -255,6 +283,9 @@ function Base.show(io::IO, c::StopWhenAny)
     end
     return print(io, "])")
 end
+function requires_update(::Type{StopWhenAny{TC}}) where {TC <: Tuple}
+    return any(map(requires_update, Tuple(TC.parameters)))
+end
 """
     |(s1,s2)
     s1 | s2
@@ -305,9 +336,9 @@ for example `Minute(15)`.
 
 # Constructor
 
-    StopAfter(t)
+    StopAfter(t::Period)
 
-initialize the stopping criterion to a `Period t` to stop after.
+initialize the stopping criterion to a `Period` `t` to stop after.
 """
 mutable struct StopAfter <: StoppingCriterion
     threshold::Period
@@ -352,6 +383,7 @@ end
 function Base.show(io::IO, c::StopAfter)
     return print(io, "StopAfter($(repr(c.threshold)))")
 end
+requires_update(::Type{StopAfter}) = false
 @doc """
     set_parameter!(c::StopAfter, :MaxTime, v::Period)
 
@@ -412,7 +444,7 @@ end
 function Base.show(io::IO, c::StopAfterIteration)
     return print(io, "StopAfterIteration($(c.max_iterations))")
 end
-has_state(::Type{StopAfterIteration}) = false
+requires_update(::Type{StopAfterIteration}) = false
 
 """
     set_parameter!(c::StopAfterIteration, :MaxIteration, v::Int)
@@ -655,7 +687,7 @@ end
 function Base.show(io::IO, c::StopWhenCostLess)
     return print(io, "StopWhenCostLess($(c.threshold))")
 end
-has_state(::Type{<:StopWhenCostLess}) = false
+requires_update(::Type{<:StopWhenCostLess}) = false
 
 """
     set_parameter!(c::StopWhenCostLess, :MinCost, v)
@@ -715,7 +747,7 @@ end
 function Base.show(io::IO, ::StopWhenCostNaN)
     return print(io, "StopWhenCostNaN()")
 end
-has_state(::Type{StopWhenCostNaN}) = false
+requires_update(::Type{StopWhenCostNaN}) = false
 
 #
 #
@@ -1088,7 +1120,7 @@ function get_reason(c::StopWhenGradientMappingNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientMappingNormLess) = true
-has_state(::Type{<:StopWhenGradientMappingNormLess}) = false
+requires_update(::Type{<:StopWhenGradientMappingNormLess}) = false
 function Base.show(io::IO, c::StopWhenGradientMappingNormLess)
     return print(io, "StopWhenGradientMappingNormLess($(c.threshold))")
 end
@@ -1182,7 +1214,7 @@ function get_reason(c::StopWhenGradientNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientNormLess) = true
-has_state(::Type{<:StopWhenGradientNormLess}) = false
+requires_update(::Type{<:StopWhenGradientNormLess}) = false
 function status_summary(c::StopWhenGradientNormLess; context::Symbol = :default)
     (context == :short) && return repr(c)
     has_stopped = (c.at_iteration >= 0)
@@ -1246,7 +1278,7 @@ end
 function Base.show(io::IO, ::StopWhenIterateNaN)
     return print(io, "StopWhenIterateNaN()")
 end
-has_state(::Type{StopWhenIterateNaN}) = false
+requires_update(::Type{StopWhenIterateNaN}) = false
 
 #
 #
@@ -1341,7 +1373,7 @@ function show(io::IO, sc::StopWhenLagrangeMultiplierLess)
         "StopWhenLagrangeMultiplierLess($(sc.tolerances); mode=:$(sc.mode)$n)",
     )
 end
-has_state(::Type{<:StopWhenLagrangeMultiplierLess}) = false
+requires_update(::Type{<:StopWhenLagrangeMultiplierLess}) = false
 
 #
 #
@@ -1520,7 +1552,7 @@ function status_summary(c::StopWhenProjectedNegativeGradientNormLess; context::S
     return "A stopping criterion to stop when the projected negative gradient norm is less than a threshold of $(c.threshold):\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(c::StopWhenProjectedNegativeGradientNormLess) = true
-has_state(::Type{<:StopWhenProjectedNegativeGradientNormLess}) = false
+requires_update(::Type{<:StopWhenProjectedNegativeGradientNormLess}) = false
 function Base.show(io::IO, c::StopWhenProjectedNegativeGradientNormLess)
     return print(io, "StopWhenProjectedNegativeGradientNormLess($(c.threshold); norm = $(c.norm))")
 end
@@ -1665,7 +1697,7 @@ end
 function Base.show(io::IO, c::StopWhenSmallerOrEqual)
     return print(io, "StopWhenSmallerOrEqual(:$(c.value), $(c.minValue))")
 end
-has_state(::Type{<:StopWhenSmallerOrEqual}) = false
+requires_update(::Type{<:StopWhenSmallerOrEqual}) = false
 #
 #
 # ---
@@ -1724,7 +1756,7 @@ end
 function Base.show(io::IO, c::StopWhenStepsizeLess)
     return print(io, "StopWhenStepsizeLess($(c.threshold))")
 end
-has_state(::Type{<:StopWhenStepsizeLess}) = false
+requires_update(::Type{<:StopWhenStepsizeLess}) = false
 """
     set_parameter!(c::StopWhenStepsizeLess, :MinStepsize, v)
 
@@ -1777,7 +1809,7 @@ function (c::StopWhenSubgradientNormLess)(
     return false
 end
 indicates_convergence(c::StopWhenSubgradientNormLess) = true
-has_state(::Type{<:StopWhenSubgradientNormLess}) = false
+requires_update(::Type{<:StopWhenSubgradientNormLess}) = false
 function get_reason(c::StopWhenSubgradientNormLess)
     if (c.value < c.threshold) && (c.at_iteration >= 0)
         return "The algorithm reached approximately critical point after $(c.at_iteration) iterations; the subgradient norm ($(c.value)) is less than $(c.threshold).\n"

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -750,14 +750,19 @@ A stopping criterion that indicates to stop when the gradient norm is small but 
 
     StopWhenCriterionWithIterationCondition(StopWhenGradientNormLess(1e-6), 3)
 
-You can also use the infix operators `≟` (`\\questeq` on REPL), `⩻` (`\\ltquest`), and `⩼` (`\\gtquest`) to create such a criterion:
+You can also use the infix operators `≟` (`\\questeq` on REPL), `⩻` (`\\ltquest`), `⩼` (`\\gtquest`), and `≞` (`\\measeq`) to create such a criterion:
 
     StopWhenGradientNormLess(1e-6) ≟ 3
     StopWhenGradientNormLess(1e-6) ⩻ 3
     StopWhenGradientNormLess(1e-6) ⩼ 3
+    StopWhenGradientNormLess(1e-6) ≞ 3
 
-These are equivalent to specifying `comp = (==(3))`, `comp = (<(3))`, and `comp = (>(3))`, respectively.
-Their interpretation is “the stopping criterion is only checked (asked) if the condition is met”.
+These are equivalent to specifying `comp = (==(3))`, `comp = (<(3))`, `comp = (>(3))`, and `comp = rem(k,n)==0` respectively.
+Their interpretation is “the stopping criterion is only checked (asked) if the condition is met”:
+* `≟` is only checked exactly at iteration 3,
+* `⩻` is only checked up to (but not including) iteration 3
+* `⩼` is only checked after (but not including) iteration 3
+* `≞` is only checked on iterations that are zero modulo 3
 """
 mutable struct StopWhenCriterionWithIterationCondition{SC <: StoppingCriterion, F} <:
     StoppingCriterion
@@ -778,6 +783,9 @@ function ⩼(sc::StoppingCriterion, n::Int)
 end
 function ≟(sc::StoppingCriterion, n::Int)
     return StopWhenCriterionWithIterationCondition(sc; comp = (==(n)))
+end
+function ≞(sc::StoppingCriterion, n::Int)
+    return StopWhenCriterionWithIterationCondition(sc; comp = k -> rem(k, n) == 0)
 end
 function (c::StopWhenCriterionWithIterationCondition)(
         p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -1,16 +1,43 @@
 #
 # Meta Stopping Criteria
 # ---
-"""
-    evaluate_criteria(criteria::Tuple, problem, state, k)
 
-Evaluate every [`StoppingCriterion`](@ref) in the tuple `criteria` exactly once at iteration `k`
-and return the results as a tuple of `Bool`s.
+eligible_for_short_circuit(::Type{<:StoppingCriterion}) = false
+
 """
-@inline function evaluate_criteria(
+    evaluate_all_criteria(criteria::Tuple, problem, state, k)
+
+Evaluate stopping criteria for a [`StopWhenAll`](@ref). Once one criterion returns `false`,
+only criteria not eligible for short-circuiting are evaluated.
+"""
+@inline function evaluate_all_criteria(
         criteria::Tuple, p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int
     )
-    return map(subC -> subC(p, s, k)::Bool, criteria)
+    result = true
+    for criterion in criteria
+        if result || !eligible_for_short_circuit(typeof(criterion))
+            result &= criterion(p, s, k)::Bool
+        end
+    end
+    return result
+end
+
+"""
+    evaluate_any_criteria(criteria::Tuple, problem, state, k)
+
+Evaluate stopping criteria for a [`StopWhenAny`](@ref). Once one criterion returns `true`,
+only criteria not eligible for short-circuiting are evaluated.
+"""
+@inline function evaluate_any_criteria(
+        criteria::Tuple, p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int
+    )
+    result = false
+    for criterion in criteria
+        if !result || !eligible_for_short_circuit(typeof(criterion))
+            result |= criterion(p, s, k)::Bool
+        end
+    end
+    return result
 end
 
 @doc """
@@ -45,8 +72,7 @@ function (c::StopWhenAll)(p::AbstractManoptProblem, s::AbstractManoptSolverState
             ci(p, s, k)
         end
     end
-    # evaluate all criteria first (this also forwards the reset), only then combine
-    if all(evaluate_criteria(c.criteria, p, s, k))
+    if evaluate_all_criteria(c.criteria, p, s, k)
         c.at_iteration = k
         return true
     end
@@ -167,8 +193,7 @@ function (c::StopWhenAny)(p::AbstractManoptProblem, s::AbstractManoptSolverState
             ci(p, s, k)
         end
     end
-    # evaluate all criteria first (this also forwards the reset), only then combine
-    if any(evaluate_criteria(c.criteria, p, s, k))
+    if evaluate_any_criteria(c.criteria, p, s, k)
         c.at_iteration = k
         return true
     end
@@ -388,6 +413,7 @@ end
 function Base.show(io::IO, c::StopAfterIteration)
     return print(io, "StopAfterIteration($(c.max_iterations))")
 end
+eligible_for_short_circuit(::Type{StopAfterIteration}) = true
 
 """
     set_parameter!(c::StopAfterIteration, :MaxIteration, v::Int)
@@ -630,6 +656,7 @@ end
 function Base.show(io::IO, c::StopWhenCostLess)
     return print(io, "StopWhenCostLess($(c.threshold))")
 end
+eligible_for_short_circuit(::Type{<:StopWhenCostLess}) = true
 
 """
     set_parameter!(c::StopWhenCostLess, :MinCost, v)
@@ -689,6 +716,7 @@ end
 function Base.show(io::IO, ::StopWhenCostNaN)
     return print(io, "StopWhenCostNaN()")
 end
+eligible_for_short_circuit(::Type{StopWhenCostNaN}) = true
 
 #
 #
@@ -1053,6 +1081,7 @@ function get_reason(c::StopWhenGradientMappingNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientMappingNormLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenGradientMappingNormLess}) = true
 function Base.show(io::IO, c::StopWhenGradientMappingNormLess)
     return print(io, "StopWhenGradientMappingNormLess($(c.threshold))")
 end
@@ -1146,6 +1175,7 @@ function get_reason(c::StopWhenGradientNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientNormLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenGradientNormLess}) = true
 function status_summary(c::StopWhenGradientNormLess; context::Symbol = :default)
     (context == :short) && return repr(c)
     has_stopped = (c.at_iteration >= 0)
@@ -1209,6 +1239,7 @@ end
 function Base.show(io::IO, ::StopWhenIterateNaN)
     return print(io, "StopWhenIterateNaN()")
 end
+eligible_for_short_circuit(::Type{StopWhenIterateNaN}) = true
 
 #
 #
@@ -1303,6 +1334,7 @@ function show(io::IO, sc::StopWhenLagrangeMultiplierLess)
         "StopWhenLagrangeMultiplierLess($(sc.tolerances); mode=:$(sc.mode)$n)",
     )
 end
+eligible_for_short_circuit(::Type{<:StopWhenLagrangeMultiplierLess}) = true
 
 #
 #
@@ -1481,6 +1513,7 @@ function status_summary(c::StopWhenProjectedNegativeGradientNormLess; context::S
     return "A stopping criterion to stop when the projected negative gradient norm is less than a threshold of $(c.threshold):\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(c::StopWhenProjectedNegativeGradientNormLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenProjectedNegativeGradientNormLess}) = true
 function Base.show(io::IO, c::StopWhenProjectedNegativeGradientNormLess)
     return print(io, "StopWhenProjectedNegativeGradientNormLess($(c.threshold); norm = $(c.norm))")
 end
@@ -1625,6 +1658,7 @@ end
 function Base.show(io::IO, c::StopWhenSmallerOrEqual)
     return print(io, "StopWhenSmallerOrEqual(:$(c.value), $(c.minValue))")
 end
+eligible_for_short_circuit(::Type{<:StopWhenSmallerOrEqual}) = true
 #
 #
 # ---
@@ -1683,6 +1717,7 @@ end
 function Base.show(io::IO, c::StopWhenStepsizeLess)
     return print(io, "StopWhenStepsizeLess($(c.threshold))")
 end
+eligible_for_short_circuit(::Type{<:StopWhenStepsizeLess}) = true
 """
     set_parameter!(c::StopWhenStepsizeLess, :MinStepsize, v)
 
@@ -1735,6 +1770,7 @@ function (c::StopWhenSubgradientNormLess)(
     return false
 end
 indicates_convergence(c::StopWhenSubgradientNormLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenSubgradientNormLess}) = true
 function get_reason(c::StopWhenSubgradientNormLess)
     if (c.value < c.threshold) && (c.at_iteration >= 0)
         return "The algorithm reached approximately critical point after $(c.at_iteration) iterations; the subgradient norm ($(c.value)) is less than $(c.threshold).\n"

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -1,12 +1,26 @@
 #
 # Meta Stopping Criteria
 # ---
+"""
+    evaluate_criteria(criteria::Tuple, problem, state, k)
+
+Evaluate every [`StoppingCriterion`](@ref) in the tuple `criteria` exactly once at iteration `k`
+and return the results as a tuple of `Bool`s.
+"""
+@inline function evaluate_criteria(
+        criteria::Tuple, p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int
+    )
+    return map(subC -> subC(p, s, k)::Bool, criteria)
+end
+
 @doc """
     StopWhenAll <: StoppingCriterionSet
 
 Store an array of [`StoppingCriterion`](@ref) elements and indicate to stop
 when _all_ of them indicate to stop. The `reason` is given by the concatenation of all
 reasons.
+All criteria are evaluated in every call, since some internal criteria might keep an internal
+status.
 
 # Fields
 
@@ -25,8 +39,14 @@ mutable struct StopWhenAll{TCriteria <: Tuple} <: StoppingCriterionSet
     StopWhenAll(c...) = new{typeof(c)}(c, -1)
 end
 function (c::StopWhenAll)(p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int)
-    (k == 0) && (c.at_iteration = -1) # reset on init
-    if all(subC -> subC(p, s, k), c.criteria)
+    if (k <= 0) # reset on init
+        c.at_iteration = -1
+        for ci in c.criteria #reset internals as well
+            ci(p, s, k)
+        end
+    end
+    # evaluate all criteria first (this also forwards the reset), only then combine
+    if all(evaluate_criteria(c.criteria, p, s, k))
         c.at_iteration = k
         return true
     end
@@ -122,6 +142,8 @@ end
 Store an array of [`StoppingCriterion`](@ref) elements and indicate to stop
 when _any_ single one indicates to stop. The `reason` is given by the
 concatenation of all reasons (assuming that all non-indicating return `""`).
+All criteria are evaluated in every call, since some internal criteria might keep an internal
+status.
 
 # Fields
 
@@ -138,24 +160,15 @@ mutable struct StopWhenAny{TCriteria <: Tuple} <: StoppingCriterionSet
     StopWhenAny(c::Vector{<:StoppingCriterion}) = new{typeof(tuple(c...))}(tuple(c...), -1)
     StopWhenAny(c::StoppingCriterion...) = new{typeof(c)}(c, -1)
 end
-
-# `_fast_any(f, tup::Tuple)`` is functionally equivalent to `any(f, tup)`` but on Julia 1.10
-# this implementation is faster on heterogeneous tuples
-# for length zero -> return false
-@inline _fast_any(f, tup::Tuple{}) = false
-# for one-element tuples, evaluate that one element
-@inline _fast_any(f, tup::Tuple{T}) where {T} = f(tup[1])
-# for more than that -> finish fast, if the first is true end checks, otherwise continue with tail
-@inline function _fast_any(f, tup::Tuple)
-    if f(tup[1])
-        return true
-    else
-        return _fast_any(f, tup[2:end])
-    end
-end
 function (c::StopWhenAny)(p::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int)
-    (k == 0) && (c.at_iteration = -1) # reset on init
-    if _fast_any(subC -> subC(p, s, k), c.criteria)
+    if (k <= 0) # reset on init
+        c.at_iteration = -1
+        for ci in c.criteria #reset internals as well
+            ci(p, s, k)
+        end
+    end
+    # evaluate all criteria first (this also forwards the reset), only then combine
+    if any(evaluate_criteria(c.criteria, p, s, k))
         c.at_iteration = k
         return true
     end

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -2,7 +2,6 @@
 # Meta Stopping Criteria
 # ---
 
-eligible_for_short_circuit(::Type{<:StoppingCriterion}) = false
 
 """
     evaluate_all_criteria(criteria::Tuple, problem, state, k)
@@ -15,7 +14,7 @@ only criteria not eligible for short-circuiting are evaluated.
     )
     result = true
     for criterion in criteria
-        if result || !eligible_for_short_circuit(typeof(criterion))
+        if result || has_state(typeof(criterion))
             result &= criterion(p, s, k)::Bool
         end
     end
@@ -33,7 +32,7 @@ only criteria not eligible for short-circuiting are evaluated.
     )
     result = false
     for criterion in criteria
-        if !result || !eligible_for_short_circuit(typeof(criterion))
+        if !result || has_state(typeof(criterion))
             result |= criterion(p, s, k)::Bool
         end
     end
@@ -413,7 +412,7 @@ end
 function Base.show(io::IO, c::StopAfterIteration)
     return print(io, "StopAfterIteration($(c.max_iterations))")
 end
-eligible_for_short_circuit(::Type{StopAfterIteration}) = true
+has_state(::Type{StopAfterIteration}) = false
 
 """
     set_parameter!(c::StopAfterIteration, :MaxIteration, v::Int)
@@ -656,7 +655,7 @@ end
 function Base.show(io::IO, c::StopWhenCostLess)
     return print(io, "StopWhenCostLess($(c.threshold))")
 end
-eligible_for_short_circuit(::Type{<:StopWhenCostLess}) = true
+has_state(::Type{<:StopWhenCostLess}) = false
 
 """
     set_parameter!(c::StopWhenCostLess, :MinCost, v)
@@ -716,7 +715,7 @@ end
 function Base.show(io::IO, ::StopWhenCostNaN)
     return print(io, "StopWhenCostNaN()")
 end
-eligible_for_short_circuit(::Type{StopWhenCostNaN}) = true
+has_state(::Type{StopWhenCostNaN}) = false
 
 #
 #
@@ -1081,7 +1080,7 @@ function get_reason(c::StopWhenGradientMappingNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientMappingNormLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenGradientMappingNormLess}) = true
+has_state(::Type{<:StopWhenGradientMappingNormLess}) = false
 function Base.show(io::IO, c::StopWhenGradientMappingNormLess)
     return print(io, "StopWhenGradientMappingNormLess($(c.threshold))")
 end
@@ -1175,7 +1174,7 @@ function get_reason(c::StopWhenGradientNormLess)
     return ""
 end
 indicates_convergence(c::StopWhenGradientNormLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenGradientNormLess}) = true
+has_state(::Type{<:StopWhenGradientNormLess}) = false
 function status_summary(c::StopWhenGradientNormLess; context::Symbol = :default)
     (context == :short) && return repr(c)
     has_stopped = (c.at_iteration >= 0)
@@ -1239,7 +1238,7 @@ end
 function Base.show(io::IO, ::StopWhenIterateNaN)
     return print(io, "StopWhenIterateNaN()")
 end
-eligible_for_short_circuit(::Type{StopWhenIterateNaN}) = true
+has_state(::Type{StopWhenIterateNaN}) = false
 
 #
 #
@@ -1334,7 +1333,7 @@ function show(io::IO, sc::StopWhenLagrangeMultiplierLess)
         "StopWhenLagrangeMultiplierLess($(sc.tolerances); mode=:$(sc.mode)$n)",
     )
 end
-eligible_for_short_circuit(::Type{<:StopWhenLagrangeMultiplierLess}) = true
+has_state(::Type{<:StopWhenLagrangeMultiplierLess}) = false
 
 #
 #
@@ -1513,7 +1512,7 @@ function status_summary(c::StopWhenProjectedNegativeGradientNormLess; context::S
     return "A stopping criterion to stop when the projected negative gradient norm is less than a threshold of $(c.threshold):\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(c::StopWhenProjectedNegativeGradientNormLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenProjectedNegativeGradientNormLess}) = true
+has_state(::Type{<:StopWhenProjectedNegativeGradientNormLess}) = false
 function Base.show(io::IO, c::StopWhenProjectedNegativeGradientNormLess)
     return print(io, "StopWhenProjectedNegativeGradientNormLess($(c.threshold); norm = $(c.norm))")
 end
@@ -1658,7 +1657,7 @@ end
 function Base.show(io::IO, c::StopWhenSmallerOrEqual)
     return print(io, "StopWhenSmallerOrEqual(:$(c.value), $(c.minValue))")
 end
-eligible_for_short_circuit(::Type{<:StopWhenSmallerOrEqual}) = true
+has_state(::Type{<:StopWhenSmallerOrEqual}) = false
 #
 #
 # ---
@@ -1717,7 +1716,7 @@ end
 function Base.show(io::IO, c::StopWhenStepsizeLess)
     return print(io, "StopWhenStepsizeLess($(c.threshold))")
 end
-eligible_for_short_circuit(::Type{<:StopWhenStepsizeLess}) = true
+has_state(::Type{<:StopWhenStepsizeLess}) = false
 """
     set_parameter!(c::StopWhenStepsizeLess, :MinStepsize, v)
 
@@ -1770,7 +1769,7 @@ function (c::StopWhenSubgradientNormLess)(
     return false
 end
 indicates_convergence(c::StopWhenSubgradientNormLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenSubgradientNormLess}) = true
+has_state(::Type{<:StopWhenSubgradientNormLess}) = false
 function get_reason(c::StopWhenSubgradientNormLess)
     if (c.value < c.threshold) && (c.at_iteration >= 0)
         return "The algorithm reached approximately critical point after $(c.at_iteration) iterations; the subgradient norm ($(c.value)) is less than $(c.threshold).\n"

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -72,8 +72,8 @@ end
 Store an array of [`StoppingCriterion`](@ref) elements and indicate to stop
 when _all_ of them indicate to stop. The `reason` is given by the concatenation of all
 reasons.
-All criteria are evaluated in every call, since some internal criteria might keep an internal
-status.
+All criteria that [`requires_update`](@ref) return `true` for are evaluated in every
+call, since some internal criteria might keep an internal status.
 
 # Fields
 
@@ -195,8 +195,8 @@ end
 Store an array of [`StoppingCriterion`](@ref) elements and indicate to stop
 when _any_ single one indicates to stop. The `reason` is given by the
 concatenation of all reasons (assuming that all non-indicating return `""`).
-All criteria are evaluated in every call, since some internal criteria might keep an internal
-status.
+All criteria that [`requires_update`](@ref) return `true` for are evaluated in every
+call, since some internal criteria might keep an internal status.
 
 # Fields
 

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -582,7 +582,7 @@ function show(io::IO, c::StopWhenCovarianceIllConditioned)
         io, "StopWhenCovarianceIllConditioned($(c.threshold))"
     )
 end
-has_state(::Type{<:StopWhenCovarianceIllConditioned}) = false
+requires_update(::Type{<:StopWhenCovarianceIllConditioned}) = false
 
 """
     StopWhenBestCostInGenerationConstant <: StoppingCriterion
@@ -805,7 +805,7 @@ end
 function show(io::IO, c::StopWhenPopulationStronglyConcentrated)
     return print(io, "StopWhenPopulationStronglyConcentrated($(c.tol))")
 end
-has_state(::Type{<:StopWhenPopulationStronglyConcentrated}) = false
+requires_update(::Type{<:StopWhenPopulationStronglyConcentrated}) = false
 
 """
     StopWhenPopulationDiverges{TParam<:Real} <: StoppingCriterion

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -582,6 +582,7 @@ function show(io::IO, c::StopWhenCovarianceIllConditioned)
         io, "StopWhenCovarianceIllConditioned($(c.threshold))"
     )
 end
+eligible_for_short_circuit(::Type{<:StopWhenCovarianceIllConditioned}) = true
 
 """
     StopWhenBestCostInGenerationConstant <: StoppingCriterion
@@ -804,6 +805,7 @@ end
 function show(io::IO, c::StopWhenPopulationStronglyConcentrated)
     return print(io, "StopWhenPopulationStronglyConcentrated($(c.tol))")
 end
+eligible_for_short_circuit(::Type{<:StopWhenPopulationStronglyConcentrated}) = true
 
 """
     StopWhenPopulationDiverges{TParam<:Real} <: StoppingCriterion

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -582,7 +582,7 @@ function show(io::IO, c::StopWhenCovarianceIllConditioned)
         io, "StopWhenCovarianceIllConditioned($(c.threshold))"
     )
 end
-eligible_for_short_circuit(::Type{<:StopWhenCovarianceIllConditioned}) = true
+has_state(::Type{<:StopWhenCovarianceIllConditioned}) = false
 
 """
     StopWhenBestCostInGenerationConstant <: StoppingCriterion
@@ -805,7 +805,7 @@ end
 function show(io::IO, c::StopWhenPopulationStronglyConcentrated)
     return print(io, "StopWhenPopulationStronglyConcentrated($(c.tol))")
 end
-eligible_for_short_circuit(::Type{<:StopWhenPopulationStronglyConcentrated}) = true
+has_state(::Type{<:StopWhenPopulationStronglyConcentrated}) = false
 
 """
     StopWhenPopulationDiverges{TParam<:Real} <: StoppingCriterion

--- a/src/solvers/conjugate_residual.jl
+++ b/src/solvers/conjugate_residual.jl
@@ -191,6 +191,7 @@ function status_summary(swrr::StopWhenRelativeResidualLess; context::Symbol = :d
     return _is_inline(context) ? "‖r^(k)‖ / c < ε:$(_MANOPT_INDENT)$s" : "A stopping criterion to stop when the relative residual is less than the threshold of $(swrr.ε)\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(::StopWhenRelativeResidualLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenRelativeResidualLess}) = true
 function show(io::IO, swrr::StopWhenRelativeResidualLess)
     return print(io, "StopWhenRelativeResidualLess($(swrr.c), $(swrr.ε))")
 end

--- a/src/solvers/conjugate_residual.jl
+++ b/src/solvers/conjugate_residual.jl
@@ -191,7 +191,7 @@ function status_summary(swrr::StopWhenRelativeResidualLess; context::Symbol = :d
     return _is_inline(context) ? "‖r^(k)‖ / c < ε:$(_MANOPT_INDENT)$s" : "A stopping criterion to stop when the relative residual is less than the threshold of $(swrr.ε)\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(::StopWhenRelativeResidualLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenRelativeResidualLess}) = true
+has_state(::Type{<:StopWhenRelativeResidualLess}) = false
 function show(io::IO, swrr::StopWhenRelativeResidualLess)
     return print(io, "StopWhenRelativeResidualLess($(swrr.c), $(swrr.ε))")
 end

--- a/src/solvers/conjugate_residual.jl
+++ b/src/solvers/conjugate_residual.jl
@@ -191,7 +191,7 @@ function status_summary(swrr::StopWhenRelativeResidualLess; context::Symbol = :d
     return _is_inline(context) ? "‖r^(k)‖ / c < ε:$(_MANOPT_INDENT)$s" : "A stopping criterion to stop when the relative residual is less than the threshold of $(swrr.ε)\n$(_MANOPT_INDENT)$s"
 end
 indicates_convergence(::StopWhenRelativeResidualLess) = true
-has_state(::Type{<:StopWhenRelativeResidualLess}) = false
+requires_update(::Type{<:StopWhenRelativeResidualLess}) = false
 function show(io::IO, swrr::StopWhenRelativeResidualLess)
     return print(io, "StopWhenRelativeResidualLess($(swrr.c), $(swrr.ε))")
 end

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -448,7 +448,7 @@ function status_summary(swrr::StopWhenKKTResidualLess; context::Symbol = :defaul
     return (_is_inline(context) ? "‖F(p, λ, μ)‖ < ε = $(swrr.ε):$(_MANOPT_INDENT)" : "Stop when the KKT residual is less than ε = $(swrr.ε)\n$(_MANOPT_INDENT)") * s
 end
 indicates_convergence(::StopWhenKKTResidualLess) = true
-eligible_for_short_circuit(::Type{<:StopWhenKKTResidualLess}) = true
+has_state(::Type{<:StopWhenKKTResidualLess}) = false
 function Base.show(io::IO, c::StopWhenKKTResidualLess)
     return print(io, "StopWhenKKTResidualLess($(c.ε))")
 end

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -448,6 +448,7 @@ function status_summary(swrr::StopWhenKKTResidualLess; context::Symbol = :defaul
     return (_is_inline(context) ? "‖F(p, λ, μ)‖ < ε = $(swrr.ε):$(_MANOPT_INDENT)" : "Stop when the KKT residual is less than ε = $(swrr.ε)\n$(_MANOPT_INDENT)") * s
 end
 indicates_convergence(::StopWhenKKTResidualLess) = true
+eligible_for_short_circuit(::Type{<:StopWhenKKTResidualLess}) = true
 function Base.show(io::IO, c::StopWhenKKTResidualLess)
     return print(io, "StopWhenKKTResidualLess($(c.ε))")
 end

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -448,7 +448,7 @@ function status_summary(swrr::StopWhenKKTResidualLess; context::Symbol = :defaul
     return (_is_inline(context) ? "‖F(p, λ, μ)‖ < ε = $(swrr.ε):$(_MANOPT_INDENT)" : "Stop when the KKT residual is less than ε = $(swrr.ε)\n$(_MANOPT_INDENT)") * s
 end
 indicates_convergence(::StopWhenKKTResidualLess) = true
-has_state(::Type{<:StopWhenKKTResidualLess}) = false
+requires_update(::Type{<:StopWhenKKTResidualLess}) = false
 function Base.show(io::IO, c::StopWhenKKTResidualLess)
     return print(io, "StopWhenKKTResidualLess($(c.ε))")
 end

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -522,14 +522,16 @@ end
         end
     end
 
-    @testset "Stopping criterion short-circuit eligibility" begin
+    @testset "Stopping criterion `has_state` indicators." begin
         for c in (
                 StopAfterIteration(1),
                 StopWhenCostLess(1.0),
                 StopWhenCostNaN(),
+                StopWhenCovarianceIllConditioned(1.0),
                 StopWhenGradientMappingNormLess(1.0),
                 StopWhenGradientNormLess(1.0),
                 StopWhenIterateNaN(),
+                StopWhenKKTResidualLess(1.0),
                 StopWhenLagrangeMultiplierLess(1.0),
                 StopWhenProjectedNegativeGradientNormLess(1.0),
                 StopWhenSmallerOrEqual(:p, 1.0),

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -533,7 +533,7 @@ end
                 StopWhenStepsizeLess(1.0),
                 StopWhenSubgradientNormLess(1.0),
             )
-            @test Manopt.eligible_for_short_circuit(typeof(c))
+            @test !Manopt.has_state(typeof(c))
         end
 
         for c in (
@@ -548,7 +548,7 @@ end
                 StopWhenRepeated(StopAfterIteration(1), 2),
                 StopWhenRelativeAPosterioriCostChangeLessOrEqual(1.0),
             )
-            @test !Manopt.eligible_for_short_circuit(typeof(c))
+            @test Manopt.has_state(typeof(c))
         end
     end
 end

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -493,12 +493,12 @@ end
     end
 
     # cf. reported bug in https://github.com/JuliaManifolds/Manopt.jl/issues/632
-    @testset "StopWhenAll/StopWhenAny evaluate every criterion (#632)" begin
+    @testset "StopWhenAll/StopWhenAny short-circuit eligible criteria (#632)" begin
         M = Euclidean(2)
         mp = DefaultManoptProblem(M, ManifoldGradientObjective((M, x) -> sum(x .^ 2), (M, x) -> 2x))
         st = GradientDescentState(M; p = [1.0, 2.0])
         # `&`: the first criterion is false, `|`: the first one is true;
-        # in both cases the second one still has to be evaluated and updated
+        # the second, stateful criterion is still evaluated and updated.
         for sc in [
                 StopAfterIteration(100) & StopWhenChangeLess(M, 1.0e-9),
                 StopAfterIteration(1) | StopWhenChangeLess(M, 1.0e-9),
@@ -508,6 +508,47 @@ end
             Manopt.set_iterate!(st, M, [0.5, 1.0])
             sc(mp, st, 1)
             @test sc.criteria[2].last_change ≈ distance(M, [1.0, 2.0], [0.5, 1.0])
+        end
+        # Criteria eligible for short-circuiting are skipped once the result is fixed.
+        for sc in [
+                StopAfterIteration(100) & StopAfterIteration(1),
+                StopAfterIteration(1) | StopAfterIteration(100),
+            ]
+            sc(mp, st, 1)
+            @test sc.criteria[2].at_iteration == -1
+        end
+    end
+
+    @testset "Stopping criterion short-circuit eligibility" begin
+        for c in (
+                StopAfterIteration(1),
+                StopWhenCostLess(1.0),
+                StopWhenCostNaN(),
+                StopWhenGradientMappingNormLess(1.0),
+                StopWhenGradientNormLess(1.0),
+                StopWhenIterateNaN(),
+                StopWhenLagrangeMultiplierLess(1.0),
+                StopWhenProjectedNegativeGradientNormLess(1.0),
+                StopWhenSmallerOrEqual(:p, 1.0),
+                StopWhenStepsizeLess(1.0),
+                StopWhenSubgradientNormLess(1.0),
+            )
+            @test Manopt.eligible_for_short_circuit(typeof(c))
+        end
+
+        for c in (
+                StopWhenAll(),
+                StopWhenAny(),
+                StopAfter(Second(1)),
+                StopWhenChangeLess(Euclidean(), 1.0),
+                StopWhenCostChangeLess(1.0),
+                StopWhenCriterionWithIterationCondition(StopAfterIteration(1)),
+                StopWhenEntryChangeLess(:p, (mp, s, x, y) -> abs(x - y), 1.0),
+                StopWhenGradientChangeLess(Euclidean(), 1.0),
+                StopWhenRepeated(StopAfterIteration(1), 2),
+                StopWhenRelativeAPosterioriCostChangeLessOrEqual(1.0),
+            )
+            @test !Manopt.eligible_for_short_circuit(typeof(c))
         end
     end
 end

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -381,6 +381,9 @@ end
         @test sc4.comp === (==(5))
         sc6 = s ⩻ 5
         @test sc6.comp === (<(5))
+        sc7 = s ≞ 10
+        @test !sc7.comp(12)
+        @test sc7.comp(20)
 
         # test that it does not hit at 5
         @test !sc(mp, st, 5) # still count 0

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -45,8 +45,9 @@ end
         @test get_reason(sn) == ""
         @test !Manopt.indicates_convergence(sn) # since it might stop after 10 iterations
         @test repr(sn) == "StopWhenAny([$(repr(sn1)), $(repr(s3))])"
-        # or over an empty set has to be false for any function
-        @test !Manopt._fast_any(x -> false, ())
+        # any/all over an empty set of criteria: identities false/true
+        @test !StopWhenAny()(p, s, 1)
+        @test StopWhenAll()(p, s, 1)
 
         sn2 = StopAfterIteration(10) | s3
         @test get_stopping_criteria(sn)[1].max_iterations ==
@@ -488,6 +489,25 @@ end
             @test has_converged(sh4)
             # As well as sh5, since one of its children does indicate convergence
             @test has_converged(sh5)   # false -- expected true
+        end
+    end
+
+    # cf. reported bug in https://github.com/JuliaManifolds/Manopt.jl/issues/632
+    @testset "StopWhenAll/StopWhenAny evaluate every criterion (#632)" begin
+        M = Euclidean(2)
+        mp = DefaultManoptProblem(M, ManifoldGradientObjective((M, x) -> sum(x .^ 2), (M, x) -> 2x))
+        st = GradientDescentState(M; p = [1.0, 2.0])
+        # `&`: the first criterion is false, `|`: the first one is true;
+        # in both cases the second one still has to be evaluated and updated
+        for sc in [
+                StopAfterIteration(100) & StopWhenChangeLess(M, 1.0e-9),
+                StopAfterIteration(1) | StopWhenChangeLess(M, 1.0e-9),
+            ]
+            Manopt.set_iterate!(st, M, [1.0, 2.0])
+            sc(mp, st, 0) # init stores the iterate
+            Manopt.set_iterate!(st, M, [0.5, 1.0])
+            sc(mp, st, 1)
+            @test sc.criteria[2].last_change ≈ distance(M, [1.0, 2.0], [0.5, 1.0])
         end
     end
 end

--- a/test/commons/test_stopping_criteria.jl
+++ b/test/commons/test_stopping_criteria.jl
@@ -522,7 +522,7 @@ end
         end
     end
 
-    @testset "Stopping criterion `has_state` indicators." begin
+    @testset "Stopping criterion `requires_update` indicators." begin
         for c in (
                 StopAfterIteration(1),
                 StopWhenCostLess(1.0),
@@ -537,14 +537,14 @@ end
                 StopWhenSmallerOrEqual(:p, 1.0),
                 StopWhenStepsizeLess(1.0),
                 StopWhenSubgradientNormLess(1.0),
+                StopAfter(Second(1)),
+                StopWhenAll(StopAfterIteration(1), StopWhenCostNaN()),
+                StopWhenAny(StopAfterIteration(1), StopWhenCostNaN()),
             )
-            @test !Manopt.has_state(typeof(c))
+            @test !Manopt.requires_update(typeof(c))
         end
 
         for c in (
-                StopWhenAll(),
-                StopWhenAny(),
-                StopAfter(Second(1)),
                 StopWhenChangeLess(Euclidean(), 1.0),
                 StopWhenCostChangeLess(1.0),
                 StopWhenCriterionWithIterationCondition(StopAfterIteration(1)),
@@ -552,8 +552,27 @@ end
                 StopWhenGradientChangeLess(Euclidean(), 1.0),
                 StopWhenRepeated(StopAfterIteration(1), 2),
                 StopWhenRelativeAPosterioriCostChangeLessOrEqual(1.0),
+                StopWhenAny(StopAfterIteration(1), StopWhenCostChangeLess(1.0)),
+                StopWhenAll(StopAfterIteration(1), StopWhenCostChangeLess(1.0)),
             )
-            @test Manopt.has_state(typeof(c))
+            @test Manopt.requires_update(typeof(c))
         end
+    end
+
+    @testset "Type stability of Any/All" begin                # Keep tuple evaluation type-stable for heterogeneous stopping criteria.
+        cost_problem = DefaultManoptProblem(
+            Euclidean(2), ManifoldCostObjective((M, p) -> norm(p))
+        )
+        nelder_mead_state = NelderMeadState(Euclidean(2); p = [1.0, 2.0])
+        all_criteria = StopWhenAll(StopAfterIteration(1), StopWhenCostChangeLess(1.0))
+        any_criteria = StopWhenAny(StopAfterIteration(1), StopWhenCostChangeLess(1.0))
+        @test !(
+            @inferred Manopt.evaluate_all_criteria(
+                all_criteria.criteria, cost_problem, nelder_mead_state, 1
+            )
+        )
+        @test @inferred Manopt.evaluate_any_criteria(
+            any_criteria.criteria, cost_problem, nelder_mead_state, 1
+        )
     end
 end


### PR DESCRIPTION
This fixes the side effects encountered in #632.

One could maybe make the former fast evaluation optional – but for now we do not really have a (side effect free) expensive stopping criterion that would make that worth doing. I would maybe introduce that (again) when it becomes necessary / requested.
One could then store a binary mask which ones have to be updated – do them first and on the other ones stop early (if the first group already provides the binary result for example – of when the first “kicks”)

But for now – the solution here aims for simplicity.

Transparency remark: Parts of this PR were proposed by an AI – but still assessed and even mainly written by myself.