### PR TITLE
Fix warning and use cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./lcov.info
+          files: ./lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
         if: ${{ matrix.os =='ubuntu-latest' }}

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: "1.7.29"
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
       - name: Julia Cache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:


### PR DESCRIPTION
Looking, e.g., at https://github.com/JuliaManifolds/Manopt.jl/actions/runs/32821271727/job/97719720572?pr=637, there is a warning and a notice from GitHub Actions. The warning is about the argument `file` in codecov/codecov-action, which has been renamed to `files` and the notice is about a missing julia-actions/cache step (this should speed up CI because it can reuse the Pkg cache from previous CI runs).
Does this also need a changelog entry? It's not really relevant for a user.