### PR TITLE
Fix an inconsistency with `AbstractConstrainedFunction`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `augmented_Lagrangian_method` set the penalty parameter `ρ` of the sub problem's cost to the
   constant `1/3` instead of the current `alms.ρ`, while its gradient did receive `alms.ρ`. (#637)
-* fix `set_parameter!` for `:μ` and `:λ` for  `AugmentedLagrangianCost`. (#637)
-* fix `AbstractConstrainedFunction` to have two parameters, one for the constrained objective it wraps and one for the type of dual parameters.
+* fix `set_parameter!` for `:μ` and `:λ` for `AugmentedLagrangianCost`. (#637)
+* fix `AbstractConstrainedFunction` to have two parameters, one for the constrained objective it wraps and one for the type of dual parameters (#639).
 
 ## [0.6.5] August 22, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,9 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `augmented_Lagrangian_method` set the penalty parameter `ρ` of the sub problem's cost to the
   constant `1/3` instead of the current `alms.ρ`, while its gradient did receive `alms.ρ`. (#637)
-* `set_parameter!` for `:μ` and `:λ` tied the dual variable's type to the type parameter of
-  `AbstractConstrainedFunction`. It hence never applied to `AugmentedLagrangianCost` and, falling
-  back to a no-op, silently left its `μ` and `λ` at their initial values. (#637)
+* fix `set_parameter!` for `:μ` and `:λ` for  `AugmentedLagrangianCost`. (#637)
+* fix `AbstractConstrainedFunction` to have two parameters, one for the constrained objective it wraps and one for the type of dual parameters.
 
 ## [0.6.5] August 22, 2026
 

--- a/src/base/function/constrained.jl
+++ b/src/base/function/constrained.jl
@@ -14,7 +14,7 @@ function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:μ}, μ:
     return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:μ}) = acf.μ
-function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:λ}, λ) where {CO, T}
+function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:λ}, λ::T) where {CO, T}
     acf.λ = λ
     return acf
 end
@@ -24,7 +24,7 @@ function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:ρ}, ρ:
     return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:ρ}) = acf.ρ
-function set_parameter!(epc::AbstractConstrainedFunction{CO, T}, ::Val{:u}, u) where {CO, T}
+function set_parameter!(epc::AbstractConstrainedFunction{CO, T}, ::Val{:u}, u::T) where {CO, T}
     epc.u = u
     return epc
 end

--- a/src/base/function/constrained.jl
+++ b/src/base/function/constrained.jl
@@ -4,8 +4,9 @@
 A common supertype for functions that model functions of the subproblem for a
 constrained objective, which they therefore wrap.
 
-This supertype provides access to the fields `λ` and `μ`, the dual variables of
-constraints of type `T` while the objectives type `CO` is also a parameter.
+This supertype provides access to fields like `λ` and `μ` or `ρ` and `u`, so
+dual variables or penalty terms for constraints of type `T` used for a constrained objective
+of type `CO`.
 """
 abstract type AbstractConstrainedFunction{CO, T} <: AbstractManifoldFunction end
 

--- a/src/base/function/constrained.jl
+++ b/src/base/function/constrained.jl
@@ -24,9 +24,9 @@ function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:ρ}, ρ:
     return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:ρ}) = acf.ρ
-function set_parameter!(epc::AbstractConstrainedFunction{CO, T}, ::Val{:u}, u::T) where {CO, T}
-    epc.u = u
-    return epc
+function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:u}, u::T) where {CO, T}
+    acf.u = u
+    return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:u}) = acf.u
 

--- a/src/base/function/constrained.jl
+++ b/src/base/function/constrained.jl
@@ -1,23 +1,34 @@
 """
-    AbstractConstrainedFunction{T} <: AbstractManifoldFunction
+    AbstractConstrainedFunction{CO, T} <: AbstractManifoldFunction
 
-A common supertype for functors that model constraint functions.
+A common supertype for functions that model functions of the subproblem for a
+constrained objective, which they therefore wrap.
 
 This supertype provides access to the fields `λ` and `μ`, the dual variables of
-constraints of type `T`.
+constraints of type `T` while the objectives type `CO` is also a parameter.
 """
-abstract type AbstractConstrainedFunction{T} <: AbstractManifoldFunction end
+abstract type AbstractConstrainedFunction{CO, T} <: AbstractManifoldFunction end
 
-function set_parameter!(acf::AbstractConstrainedFunction, ::Val{:μ}, μ)
+function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:μ}, μ::T) where {CO, T}
     acf.μ = μ
     return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:μ}) = acf.μ
-function set_parameter!(acf::AbstractConstrainedFunction, ::Val{:λ}, λ)
+function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:λ}, λ) where {CO, T}
     acf.λ = λ
     return acf
 end
 get_parameter(acf::AbstractConstrainedFunction, ::Val{:λ}) = acf.λ
+function set_parameter!(acf::AbstractConstrainedFunction{CO, T}, ::Val{:ρ}, ρ::T) where {CO, T}
+    acf.ρ = ρ
+    return acf
+end
+get_parameter(acf::AbstractConstrainedFunction, ::Val{:ρ}) = acf.ρ
+function set_parameter!(epc::AbstractConstrainedFunction{CO, T}, ::Val{:u}, u) where {CO, T}
+    epc.u = u
+    return epc
+end
+get_parameter(acf::AbstractConstrainedFunction, ::Val{:u}) = acf.u
 
 """
     AbstractConstrainedSlackFunction{T,R} <: AbstractManifoldFunction

--- a/src/commons/sub_functions.jl
+++ b/src/commons/sub_functions.jl
@@ -251,7 +251,7 @@ $(_tex(:Cal, "P"))(x,u) = $(
 struct LinearQuadraticHuber <: SmoothingTechnique end
 
 @doc """
-    ExactPenaltyCost{S, CO, R} <: AbstractManifoldFunction
+    ExactPenaltyCost{S, CO, R} <: AbstractConstrainedFunction{CO, T}
 
 Represent the cost of the exact penalty method based on a [`ConstrainedManifoldObjective`](@ref) `co`
 and a parameter ``ρ`` given by
@@ -267,30 +267,22 @@ to obtain a smooth cost function. This struct is also a functor `(M,p) -> v` of 
 
 ## Fields
 
-* `ρ`, `u`: as described in the mathematical formula.
-* `co`:     the original cost
+* `ρ::T`, `u::T`: as described in the mathematical formula.
+* `co::CO`:     the original cost
 
 ## Constructor
 
     ExactPenaltyCost(co::ConstrainedManifoldObjective, ρ, u; smoothing=LinearQuadraticHuber())
 """
-mutable struct ExactPenaltyCost{S, CO, R} <: AbstractManifoldFunction
+mutable struct ExactPenaltyCost{S, CO, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
-    ρ::R
-    u::R
+    ρ::T
+    u::T
 end
 function ExactPenaltyCost(
-        co::ConstrainedManifoldObjective, ρ::R, u::R; smoothing = LinearQuadraticHuber()
-    ) where {R}
-    return ExactPenaltyCost{typeof(smoothing), typeof(co), R}(co, ρ, u)
-end
-function set_parameter!(epc::ExactPenaltyCost, ::Val{:ρ}, ρ)
-    epc.ρ = ρ
-    return epc
-end
-function set_parameter!(epc::ExactPenaltyCost, ::Val{:u}, u)
-    epc.u = u
-    return epc
+        co::ConstrainedManifoldObjective, ρ::T, u::T; smoothing::S = LinearQuadraticHuber()
+    ) where {T, S <: SmoothingTechnique}
+    return ExactPenaltyCost{S, typeof(co), T}(co, ρ, u)
 end
 function (L::ExactPenaltyCost{<:LogarithmicSumOfExponentials})(M::AbstractManifold, p)
     gp = get_inequality_constraint(M, L.co, p, :)
@@ -314,7 +306,7 @@ function (L::ExactPenaltyCost{<:LinearQuadraticHuber})(M::AbstractManifold, p)
 end
 
 @doc """
-    ExactPenaltyGrad{S, CO, R} <: AbstractConstrainedFunction{R}
+    ExactPenaltyGrad{S, CO, T} <: AbstractConstrainedFunction{CO, T}
 
 Represent the gradient of the [`ExactPenaltyCost`](@ref) based on a [`ConstrainedManifoldObjective`](@ref) `co`
 and a parameter ``ρ`` and a smoothing technique, which uses an additional parameter ``u``.
@@ -325,30 +317,22 @@ This struct is also a functor in both formats
 
 ## Fields
 
-* `ρ`, `u` as stated before
-* `co` the nonsmooth objective
+* `ρ::T`, `u::T` see [`ExactPenaltyCost`](@ref).
+* `co::CO` the nonsmooth objective
 
 ## Constructor
 
     ExactPenaltyGrad(co::ConstrainedManifoldObjective, ρ, u; smoothing=LinearQuadraticHuber())
 """
-mutable struct ExactPenaltyGrad{S, CO, R} <: AbstractConstrainedFunction{R}
+mutable struct ExactPenaltyGrad{S, CO, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
-    ρ::R
-    u::R
-end
-function set_parameter!(epg::ExactPenaltyGrad, ::Val{:ρ}, ρ)
-    epg.ρ = ρ
-    return epg
-end
-function set_parameter!(epg::ExactPenaltyGrad, ::Val{:u}, u)
-    epg.u = u
-    return epg
+    ρ::T
+    u::T
 end
 function ExactPenaltyGrad(
-        co::ConstrainedManifoldObjective, ρ::R, u::R; smoothing = LinearQuadraticHuber()
-    ) where {R}
-    return ExactPenaltyGrad{typeof(smoothing), typeof(co), R}(co, ρ, u)
+        co::ConstrainedManifoldObjective, ρ::R, u::R; smoothing::S = LinearQuadraticHuber()
+    ) where {R, S <: SmoothingTechnique}
+    return ExactPenaltyGrad{S, typeof(co), R}(co, ρ, u)
 end
 # Default (functions constraints): evaluate all gradients
 # Since for LogExp the pre-factor c seems to not be zero, this might be the best way to go here
@@ -759,7 +743,7 @@ function status_summary(KKTvfNSqGrad::KKTVectorFieldNormSqGradient; context::Sym
 end
 
 @doc """
-    LagrangianCost{CO,T} <: AbstractConstrainedFunction{T}
+    LagrangianCost{CO, T} <: AbstractConstrainedFunction{CO, T}
 
 Implement the Lagrangian of a [`ConstrainedManifoldObjective`](@ref) `co`.
 
@@ -786,7 +770,7 @@ you can also call
 LagrangianCost(co, μ, λ)(M,p)
 ```
 """
-mutable struct LagrangianCost{CO, T} <: AbstractConstrainedFunction{T}
+mutable struct LagrangianCost{CO, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
     μ::T
     λ::T
@@ -804,7 +788,7 @@ function show(io::IO, lc::LagrangianCost)
 end
 
 @doc """
-    LagrangianGradient{CO,T} <: AbstractConstrainedFunction{T}
+    LagrangianGradient{CO,T} <: AbstractConstrainedFunction{CO, T}
 
 The gradient of the Lagrangian of a [`ConstrainedManifoldObjective`](@ref) `co`
 with respect to the variable ``p``. The formula reads
@@ -829,7 +813,7 @@ Create a functor for the Lagrangian with fixed dual variables.
 When you directly want to evaluate the gradient of the Lagrangian ``$(_tex(:grad))_p $(_tex(:Cal, "L"))``
 you can also call `LagrangianGradient(co, μ, λ)(M,p)` or `LagrangianGradient(co, μ, λ)(M,X,p)` for the in-place variant.
 """
-mutable struct LagrangianGradient{CO, T} <: AbstractConstrainedFunction{T}
+mutable struct LagrangianGradient{CO, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
     μ::T
     λ::T
@@ -858,7 +842,7 @@ function show(io::IO, lg::LagrangianGradient)
 end
 
 @doc """
-    LagrangianHessian{CO, T} <: AbstractConstrainedFunction{T}
+    LagrangianHessian{CO, T} <: AbstractConstrainedFunction{CO, T}
 
 The Hessian of the Lagrangian of a [`ConstrainedManifoldObjective`](@ref) `co`
 with respect to the variable ``p``. The formula reads
@@ -883,7 +867,7 @@ Create a functor for the Lagrangian with fixed dual variables.
 When you directly want to evaluate the Hessian of the Lagrangian ``$(_tex(:Hess))_p $(_tex(:Cal, "L"))``
 you can also call `LagrangianHessian(co, μ, λ)(M, p, X)` or `LagrangianHessian(co, μ, λ)(M, Y, p, X)` for the in-place variant.
 """
-mutable struct LagrangianHessian{CO, T} <: AbstractConstrainedFunction{T}
+mutable struct LagrangianHessian{CO, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
     μ::T
     λ::T

--- a/src/commons/sub_functions.jl
+++ b/src/commons/sub_functions.jl
@@ -330,9 +330,9 @@ mutable struct ExactPenaltyGrad{S, CO, T} <: AbstractConstrainedFunction{CO, T}
     u::T
 end
 function ExactPenaltyGrad(
-        co::ConstrainedManifoldObjective, ρ::R, u::R; smoothing::S = LinearQuadraticHuber()
-    ) where {R, S <: SmoothingTechnique}
-    return ExactPenaltyGrad{S, typeof(co), R}(co, ρ, u)
+        co::ConstrainedManifoldObjective, ρ::T, u::T; smoothing::S = LinearQuadraticHuber()
+    ) where {T, S <: SmoothingTechnique}
+    return ExactPenaltyGrad{S, typeof(co), T}(co, ρ, u)
 end
 # Default (functions constraints): evaluate all gradients
 # Since for LogExp the pre-factor c seems to not be zero, this might be the best way to go here

--- a/src/commons/sub_objectives.jl
+++ b/src/commons/sub_objectives.jl
@@ -22,7 +22,7 @@ $(_tex(:biggr)))
 """
 
 @doc """
-    AugmentedLagrangianCost{CO,R,T} <: AbstractConstrainedFunction{CO}
+    AugmentedLagrangianCost{CO,R,T} <: AbstractConstrainedFunction{CO, T}
 
 Stores the parameters ``ρ ∈ ℝ``, ``μ ∈ ℝ^m``, ``λ ∈ ℝ^n``
 of the augmented Lagrangian associated to the [`ConstrainedManifoldObjective`](@ref) `co`.
@@ -41,18 +41,18 @@ $_doc_AL_Cost_long
 
     AugmentedLagrangianCost(co, ρ, μ, λ)
 """
-mutable struct AugmentedLagrangianCost{CO, R, T} <: AbstractConstrainedFunction{CO}
+mutable struct AugmentedLagrangianCost{CO, R, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
     ρ::R
     μ::T
     λ::T
 end
-function set_parameter!(alc::AugmentedLagrangianCost, ::Val{:ρ}, ρ)
+# Since the types of ρ and duals differ, we need a specific set function here
+function set_parameter!(alc::AugmentedLagrangianCost{CO, R}, ::Val{:ρ}, ρ::R) where {CO,R}
     alc.ρ = ρ
     return alc
 end
-get_parameter(alc::AugmentedLagrangianCost, ::Val{:ρ}) = alc.ρ
-# μ & λ already set through the abstract constrained function
+# all other get/set for parameters already on the abstract case
 function (L::AugmentedLagrangianCost)(M::AbstractManifold, p)
     gp = get_inequality_constraint(M, L.co, p, :)
     hp = get_equality_constraint(M, L.co, p, :)
@@ -66,7 +66,7 @@ function (L::AugmentedLagrangianCost)(M::AbstractManifold, p)
 end
 
 @doc """
-    AugmentedLagrangianGrad{CO,R,T} <: AbstractConstrainedFunction{T}
+    AugmentedLagrangianGrad{CO, R, T} <: AbstractConstrainedFunction{CO, T}
 
 Stores the parameters ``ρ ∈ ℝ``, ``μ ∈ ℝ^m``, ``λ ∈ ℝ^n``
 of the augmented Lagrangian associated to the [`ConstrainedManifoldObjective`](@ref) `co`.
@@ -91,7 +91,7 @@ Based on the internal [`ConstrainedManifoldObjective`](@ref), it computes the gr
     AugmentedLagrangianGrad(co, ρ, μ, λ)
 
 """
-mutable struct AugmentedLagrangianGrad{CO, R, T} <: AbstractConstrainedFunction{T}
+mutable struct AugmentedLagrangianGrad{CO, R, T} <: AbstractConstrainedFunction{CO, T}
     co::CO
     ρ::R
     μ::T
@@ -101,12 +101,12 @@ function (LG::AugmentedLagrangianGrad)(M::AbstractManifold, p)
     X = zero_vector(M, p)
     return LG(M, X, p)
 end
-function set_parameter!(alg::AugmentedLagrangianGrad, ::Val{:ρ}, ρ)
+# Since the types of ρ and duals differ, we need a specific set function here
+function set_parameter!(alg::AugmentedLagrangianGrad{CO, R}, ::Val{:ρ}, ρ::R) where {CO, R}
     alg.ρ = ρ
     return alg
 end
-get_parameter(alg::AugmentedLagrangianGrad, ::Val{:ρ}) = alg.ρ
-# μ & λ already set through the abstract constrained function
+# all other get/set parameters already defined through the abstract constrained function
 
 # default, that is especially when the `grad_g` and `grad_h` are functions.
 function (LG::AugmentedLagrangianGrad)(

--- a/src/commons/sub_objectives.jl
+++ b/src/commons/sub_objectives.jl
@@ -48,7 +48,7 @@ mutable struct AugmentedLagrangianCost{CO, R, T} <: AbstractConstrainedFunction{
     λ::T
 end
 # Since the types of ρ and duals differ, we need a specific set function here
-function set_parameter!(alc::AugmentedLagrangianCost{CO, R}, ::Val{:ρ}, ρ::R) where {CO,R}
+function set_parameter!(alc::AugmentedLagrangianCost{CO, R}, ::Val{:ρ}, ρ::R) where {CO, R}
     alc.ρ = ρ
     return alc
 end

--- a/test/commons/test_constrained_objective.jl
+++ b/test/commons/test_constrained_objective.jl
@@ -526,6 +526,14 @@ using LRUCache, Manifolds, ManifoldsBase, Manopt, Test, RecursiveArrayTools
                 wg2 = sum(gg .* (c[1] ./ u .* (0 .<= c[1] .< u)) .* ρ)
                 wg3 = sum(gh .* (c[2] ./ sqrt.(c[2] .^ 2 .+ u^2)) .* ρ)
                 @test EPGh(M, p) ≈ gf + wg1 .+ wg2 .+ wg3
+                @test Manopt.set_parameter!(EPCh, :ρ, 2 * ρ) == EPCh
+                @test Manopt.get_parameter(EPCh, :ρ) == 2 * ρ
+                @test Manopt.set_parameter!(EPCh, :u, 2 * u) == EPCh
+                @test Manopt.get_parameter(EPCh, :u) == 2 * u
+                @test Manopt.set_parameter!(EPGh, :ρ, 2 * ρ) == EPGh
+                @test Manopt.get_parameter(EPGh, :ρ) == 2 * ρ
+                @test Manopt.set_parameter!(EPGh, :u, 2 * u) == EPGh
+                @test Manopt.get_parameter(EPGh, :u) == 2 * u
             end
         end
     end


### PR DESCRIPTION
Thanks @JoshuaLampert for noticing. Now it should be nicely unified.

Note that for the one function that actually uses `μ`, `λ`, _and_ `ρ` still need a special setter, since in that case the type of the duals is different from the penalty (which is just a number).
Besides that, the abstract type now does bear both `CO` and `T` as a parameter (instead of a mix of both as before). That way, the types can still be nicely used and checked in the `set_parameter!` function.

I will merge this (and register a new version) after lunch then.