### PR TITLE
Introduce BarzileiBorwein as its own Stepsize

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'Changelog.md'
       - 'Readme.md'
       - '.zenodo.json'
-      - '_typos.yml'
+      - '_typos.toml'
       - '.github/workflows/changelog.yml'
       - '.github/workflows/ci.yml'
       - '.github/workflows/clear_preview.yml'
@@ -25,7 +25,10 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    if: contains( github.event.pull_request.labels.*.name, 'benchmark') || github.ref == 'refs/heads/master'
+    # only on pull requests a maintainer labelled `benchmark`: adding a label needs write
+    # access, so this is also the safeguard for running the pull request's code under
+    # `pull_request_target`
+    if: contains(github.event.pull_request.labels.*.name, 'benchmark')
     steps:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    if: contains( github.event.pull_request.labels.*.name, 'benchmark') || github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')
+    if: contains( github.event.pull_request.labels.*.name, 'benchmark') || github.ref == 'refs/heads/master'
     steps:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 'master'
-      - 'release-'
+      - 'release-*'
     tags:
       - '*'
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ The following is a set of guidelines to [`Manopt.jl`](https://juliamanifolds.git
 
 #### Table of contents
 
-- [Contributing to `Manopt.jl`](#Contributing-to-manoptjl)
-      - [Table of Contents](#Table-of-Contents)
+- [Contributing to `Manopt.jl`](#Contributing-to-Manopt.jl)
+  - [Table of contents](#Table-of-contents)
   - [I just have a question](#I-just-have-a-question)
-  - [How can I file an issue?](#How-can-I-file-an-issue)
-  - [How can I contribute?](#How-can-I-contribute)
+  - [How can I file an issue?](#How-can-I-file-an-issue?)
+  - [How can I contribute?](#How-can-I-contribute?)
     - [Add a missing method](#Add-a-missing-method)
     - [Provide a new algorithm](#Provide-a-new-algorithm)
     - [Provide a new example](#Provide-a-new-example)
@@ -28,25 +28,25 @@ You can also ask your question on [discourse.julialang.org](https://discourse.ju
 
 ## How can I file an issue?
 
-If you found a bug or want to propose a feature, please open an issue in within the [GitHub repository](https://github.com/JuliaManifolds/Manopt.jl/issues).
+If you found a bug or want to propose a feature, please open an issue in the [GitHub repository](https://github.com/JuliaManifolds/Manopt.jl/issues).
 
 ## How can I contribute?
 
 ### Add a missing method
 
-There is still a lot of methods that can be contributed within the optimization framework of [`Manopt.jl`](https://juliamanifolds.github.io/Manopt.jl/),
+There are still a lot of methods that can be contributed within the optimization framework of [`Manopt.jl`](https://juliamanifolds.github.io/Manopt.jl/),
 may it be functions, gradients, differentials, proximal maps, step size rules or stopping criteria.
 If you notice a method you could contribute or improve an implementation, please do so,
-and the maintainers try help with the necessary details.
+and the maintainers try to help with the necessary details.
 Even providing a single new method is a good contribution.
 
 ### Provide a new algorithm
 
 A main contribution you can provide is another algorithm that is not yet included in the
 package.
-An algorithm is always based on a concrete type of a [`AbstractManoptProblem`](https://manoptjl.org/stable/plans/index.html#AbstractManoptProblems-1) storing the main information of the task and a concrete type of an [`AbstractManoptSolverState`](https://manoptjl.org/stable/plans/index.html#AbstractManoptSolverState-1from) storing all information that needs to be known to the solver in general. The actual algorithm is split into an initialization phase, see [`initialize_solver!`](https://manoptjl.org/stable/solvers/index.html#Manopt.initialize_solver!), and the implementation of the `i`th step of the solver itself, see  before the iterative procedure, see [`step_solver!`](https://manoptjl.org/stable/solvers/index.html#Manopt.step_solver!).
-For these two functions, it would be great if a new algorithm uses functions from the [`ManifoldsBase.jl`](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html) interface as generically as possible. For example, if possible use [`retract!(M,q,p,X)`](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.retract!-Tuple{AbstractManifold,Any,Any,Any}) in favor of [`exp!(M,q,p,X)`](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.exp!-Tuple{AbstractManifold,Any,Any,Any}) to perform a step starting in `p` in direction `X` (in place of `q`), since the exponential map might be too expensive to evaluate or might not be available on a certain manifold. See [Retractions and inverse retractions](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html#Retractions-and-inverse-Retractions) for more details.
-Further, if possible, prefer [`retract!(M,q,p,X)`](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.retract!-Tuple{AbstractManifold,Any,Any,Any}) in favor of [`retract(M,p,X)`](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html#ManifoldsBase.retract-Tuple{AbstractManifold,Any,Any}), since a computation in place of a suitable variable `q` reduces memory allocations.
+An algorithm is always based on a concrete type of a [`AbstractManoptProblem`](https://manoptjl.org/stable/base/problem/#Manopt.AbstractManoptProblem) storing the main information of the task and a concrete type of an [`AbstractManoptSolverState`](https://manoptjl.org/stable/base/state/#Manopt.AbstractManoptSolverState) storing all information that needs to be known to the solver in general. The actual algorithm is split into an initialization phase, see [`initialize_solver!`](https://manoptjl.org/stable/base/solver/#Manopt.initialize_solver!-Tuple{AbstractManoptProblem,%20AbstractManoptSolverState}), which is called before the iterative procedure, and the implementation of the `k`th step of the solver itself, see [`step_solver!`](https://manoptjl.org/stable/base/solver/#Manopt.step_solver!-Tuple{AbstractManoptProblem,%20AbstractManoptSolverState,%20Any}).
+For these two functions, it would be great if a new algorithm uses functions from the [`ManifoldsBase.jl`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/) interface as generically as possible. For example, if possible use [`retract!(M,q,p,X)`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/#ManifoldsBase.retract!) in favor of [`exp!(M,q,p,X)`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/functions/#exp-and-log) to perform a step starting in `p` in direction `X` (in place of `q`), since the exponential map might be too expensive to evaluate or might not be available on a certain manifold. See [Retractions and inverse retractions](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/#sec-retractions) for more details.
+Further, if possible, prefer [`retract!(M,q,p,X)`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/#ManifoldsBase.retract!) in favor of [`retract(M,p,X)`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/retractions/#ManifoldsBase.retract), since a computation in place of a suitable variable `q` reduces memory allocations.
 
 Usually, the methods implemented in `Manopt.jl` also have a high-level interface, that is easier to call, creates the necessary problem and options structure and calls the solver.
 
@@ -95,11 +95,11 @@ We use [crate-ci/typos](https://github.com/crate-ci/typos) for spell checking, w
 ### On the use of AI
 
 Following the [Julia Discourse Guidelines – Keep it tidy](https://discourse.julialang.org/faq#keep-tidy),
-please do not open PRs or issues that are pure AI generated. `Manopt.jl` is in its aspects,
+please do not open PRs or issues that are pure AI generated. `Manopt.jl` is in all its aspects,
 especially the code, the documentation, as well as the tests, carefully curated to be concise,
 well-documented, comprehensive, but in tests also in a (hopefully) good balance between
 ensuring functionality and “over testing”.
 
 Of course it is ok to get help from an AI, e.g. when refactoring parts of the code,
 but please always carefully reflect on the results proposed and do not “[vibe code](https://en.wikipedia.org/wiki/Vibe_coding)”. That usually does not work well nor fit the exact mathematical definitions,
-reliability and stability as well as and abstractions of the provided algorithms `Manopt.jl` aims to provide.
+reliability and stability as well as the abstractions of the provided algorithms `Manopt.jl` aims to provide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Please follow a few internal conventions:
 
 - It is preferred that any subtype of a `AbstractManoptProblem`'s struct contains information about the general structure of the problem.
 - Any implemented function should be accompanied by its mathematical formulae if a closed form exists.
-- `AbstractManoptProblem` and helping functions are stored within the `plan/` folder and sorted by properties of the problem and/or solver at hand.
+- `AbstractManoptProblem` and helping functions are stored within the `base/` folder and sorted by properties of the problem and/or solver at hand.
 - the solver state is usually stored with the solver itself
 - Within the source code of one algorithm, following the state, the high level interface should be next, then the initialization, then the step.
 - Otherwise an alphabetical order of functions is preferable.

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NonmonotoneLinesearchStepsize`.
 * introduce a `StepsizeInitialGuess` that allows to use a `Stepsize` as initial guess of a line search.
 
+### Changed
+
+* since `has_converged` exists, the status reports on REPL now use this to indicate whether an algorithm has converged.
+
 ### Fixed
 
 * since we introduced the differential in the first order objectives,

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.7] unreleased
+## [0.6.7] August 26, 2026
 
 ### Added
 
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `quasi_Newton`, and the Riemannian median on hyperbolic space, benchmarked with `cyclic_proximal_point`.
 * A `BarzileiBorweinStepsize` as a standalone stepsize instead of only being available within the
   `NonmonotoneLinesearchStepsize`.
+* introduce a `StepsizeInitialGuess` that allows to use a `Stepsize` as initial guess of a line search.
 
 
 ## [0.6.6] August 25, 2026

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+The following fixes were reported by an AI assisted code review. Each single point was still carefully checked, and committed by hand.
+They are still listed here in detail in case (a) someone elses code breaks of (b) it was not done careful enough – to then avoid these approaches in the future.
+
+* `cma_es` now uses the fitness-sorted samples in its covariance matrix update,
+  cf. Eq. (47) of [arXiv:1604.00772](https://arxiv.org/abs/1604.00772).
+* `WolfePowellBinaryLinesearch` now bisects correctly the step size fulfils both Wolfe
+  conditions; sometimes a wrong termination check made it stop too early.
+* `default_vector_norm(::Euclidean, p, X)` returned the norm of `p` instead of `X`.
+* `PrimalDualSemismoothNewtonState` is now constructed as `(M, N; kwargs...)` like `ChambollePockState`;
+  the previous `(M; kwargs...)` form errored on its own default `n = rand(N)` when no `n` was provided.
 * since we introduced the differential in the first order objectives,
 they were not fully supported in all places. This was now fixed and unified.
 * for a nicer printing on REPL, a few more `status_summary` functions were added (with the help of an AI)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ The file was started with Version `0.4`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.7] August 26, 2026
+## [0.6.7] unreleased
 
 ### Added
 
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which on a pull request labelled `benchmark` compares it against `master`.
   It starts with two problems, the Riemannian mean on the sphere, benchmarked with `gradient_descent`
   and `quasi_Newton`, and the Riemannian median on hyperbolic space, benchmarked with `cyclic_proximal_point`.
+* A `BarzileiBorweinStepsize` as a standalone stepsize instead of only being available within the
+  `NonmonotoneLinesearchStepsize`.
+
 
 ## [0.6.6] August 25, 2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,7 +38,7 @@ they were not fully supported in all places. This was now fixed and unified.
 ### Added
 
 * a new function `requires_update` that per `<:StoppingCriterion` type can indicate, whether a state is present that needs updating in every iteration.
-* a new shortcut for the `StopWhenCriterionWithIterationCondition` that only evaluates every `n`th iteration using `stopping_criterion ≞ n` (`\measeq` <TAB> on REPL) as constructor. While in theory also `%` would have been possible, there was a discussion not to use mnore-common symbols here, cf. (#509) – and the `m` could be seen as “modulo”.
+* a new shortcut for the `StopWhenCriterionWithIterationCondition` that only evaluates every `n`th iteration using `stopping_criterion ≞ n` (`\measeq` <TAB> on REPL) as constructor. While in theory also `%` would have been possible, there was a discussion not to use more-common symbols here, cf. (#509) – and the `m` could be seen as “modulo”.
 
 ### Fixed
 
@@ -66,7 +66,7 @@ As an overarching scheme of this release, the single functions in an objective b
 * the file structure has been changed and the `plan/` folder has been split with the following motivation
   * all abstract types and generic implementation and documentation of functions has been moved to `base/`.
     This is also reflected in the documentation, where the new `base/` files reflect a developer documentation that additionally includes descriptions of the design choices
-  * concrete types and their implementations have either been used to the specific solver where they are used / defined,
+  * concrete types and their implementations have either been moved to the specific solver where they are used / defined,
     especially for solver states, or now reside in a `commons/` folder, when they are of general use for multiple solvers.
     This structure is also reflected in the documentation.
 * a few internal abstract super types have been renamed for the new scheme that puts more focus on functions, to stay more consistent. The word “functor” is now avoided for structs that actually just represent functions.

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,10 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which on a pull request labelled `benchmark` compares it against `master`.
   It starts with two problems, the Riemannian mean on the sphere, benchmarked with `gradient_descent`
   and `quasi_Newton`, and the Riemannian median on hyperbolic space, benchmarked with `cyclic_proximal_point`.
-* A `BarzileiBorweinStepsize` as a standalone stepsize instead of only being available within the
+* A `BarzilaiBorweinStepsize` as a standalone stepsize instead of only being available within the
   `NonmonotoneLinesearchStepsize`.
 * introduce a `StepsizeInitialGuess` that allows to use a `Stepsize` as initial guess of a line search.
 
+### Fixed
+
+* since we introduced the differential in the first order objectives,
+they were not fully supported in all places. This was now fixed and unified.
+* for a nicer printing on REPL, a few more `status_summary` functions were added (with the help of an AI)
 
 ## [0.6.6] August 25, 2026
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
-version = "0.6.7"
+version = "0.6.8"
 
 [workspace]
 projects = ["test", "docs", "tutorials", "benchmark"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Manopt"
 uuid = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
-version = "0.6.8"
+version = "0.6.7"
 
 [workspace]
 projects = ["test", "docs", "tutorials", "benchmark"]

--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,11 @@
 <div align="center">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JuliaManifolds/Manopt.jl/master/docs/src/assets/logo-text-readme-dark.png">
-      <img alt="Manifolds.jl logo with text on the side" src="https://raw.githubusercontent.com/JuliaManifolds/Manopt.jl/master/docs/src/assets/logo-text-readme.png">
+      <img alt="Manopt.jl logo with text on the side" src="https://raw.githubusercontent.com/JuliaManifolds/Manopt.jl/master/docs/src/assets/logo-text-readme.png">
     </picture>
 </div>
 
-## Optimization Algorithm on Riemannian Manifolds.
+## Optimization Algorithms on Riemannian Manifolds
 
 [![](https://img.shields.io/badge/docs-stable-blue?logo=Julia&logoColor=white)](https://manoptjl.org/stable)
 [![code style: runic](https://img.shields.io/badge/code_style-%E1%9A%B1%E1%9A%A2%E1%9A%BE%E1%9B%81%E1%9A%B2-black)](https://github.com/fredrikekre/Runic.jl)
@@ -23,9 +23,9 @@ For a function $f: ℳ → ℝ$  that maps from a [Riemannian manifold](https://
 
 `Manopt.jl` provides
 
-* A framework to implement arbitrary optimization algorithms on Riemannian Manifolds
-* A library of optimization algorithms on Riemannian manifolds
-* an easy-to-use interface for (debug) output and recording values during an algorithm run.
+* a framework to implement arbitrary optimization algorithms on Riemannian manifolds
+* a library of optimization algorithms on Riemannian manifolds
+* an easy-to-use interface for (debug) output and recording values during an algorithm run
 * several tools to investigate the algorithms, gradients, and optimality criteria
 
 ## Getting started
@@ -54,7 +54,7 @@ a Riemannian manifold.
 The following packages are related to `Manopt.jl`
 
 * [`Manifolds.jl`](https://juliamanifolds.github.io/Manifolds.jl/stable/): a library of manifolds implemented using [`ManifoldsBase.jl`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/) :octocat: [GitHub repository](https://github.com/JuliaManifolds/Manifolds.jl)
-* [`ManifoldsDiff.jl`](https://juliamanifolds.github.io/ManifoldDiff.jl/stable/): a package to use (Euclidean) AD tools on manifolds, that also provides several differentials and gradients. :octocat: [GitHub repository](https://github.com/JuliaManifolds/ManifoldDiff.jl)
+* [`ManifoldDiff.jl`](https://juliamanifolds.github.io/ManifoldDiff.jl/stable/): a package to use (Euclidean) AD tools on manifolds, that also provides several differentials and gradients. :octocat: [GitHub repository](https://github.com/JuliaManifolds/ManifoldDiff.jl)
 
 ## Citation
 
@@ -101,7 +101,7 @@ To refer to a certain version or the source code in general please cite for exam
     Doi       = {10.5281/zenodo.4290905},
     Publisher = {Zenodo},
     Title     = {Manopt.jl},
-    Year      = {2024},
+    Year      = {2026},
 }
 ```
 
@@ -119,7 +119,7 @@ If you are also using [`Manifolds.jl`](https://juliamanifolds.github.io/Manifold
 > arXiv: [2106.08777](https://arxiv.org/abs/2106.08777)
 <details>
 
-  <summary><code>AxenBaranBergmannRzecki:2023</code>(BibLaTeX)</summary>
+  <summary><code>AxenBaranBergmannRzecki:2023</code> (BibLaTeX)</summary>
 
 ```biblatex
 @article{AxenBaranBergmannRzecki:2023,
@@ -129,7 +129,7 @@ If you are also using [`Manifolds.jl`](https://juliamanifolds.github.io/Manifold
     JOURNAL   = {ACM Transactions on Mathematical Software},
     MONTH     = {dec},
     NUMBER    = {4},
-    TITLE     = {Manifolds.Jl: An Extensible Julia Framework for Data Analysis on Manifolds},
+    TITLE     = {Manifolds.jl: An Extensible Julia Framework for Data Analysis on Manifolds},
     VOLUME    = {49},
     YEAR      = {2023}
 }

--- a/_typos.toml
+++ b/_typos.toml
@@ -9,7 +9,7 @@ nd = "nd" # like in 2nd
 [files]
 extend-exclude = [
 "tutorials/*.html",
-# rendered from tutorials/*.qmd -Z we do not want typos twice
+# rendered from tutorials/*.qmd, so we do not want to check for typos twice
 "docs/src/tutorials/*.md",
 "joss/paper.md",
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,6 +47,7 @@ tutorials_menu =
     "Optimize on your own manifold" => "tutorials/ImplementOwnManifold.md",
     "Do constrained optimization" => "tutorials/ConstrainedOptimization.md",
     "Do optimization with bounds" => "tutorials/BoxDomain.md",
+    "Run stochastic gradient descent" => "tutorials/StochasticGradientDescent.md",
 ]
 # Check whether all tutorials are rendered, issue a warning if not (and quarto if not set)
 all_tutorials_exist = true
@@ -158,9 +159,9 @@ makedocs(;
     format = Documenter.HTML(;
         prettyurls = run_on_CI || ("--prettyurls" ∈ ARGS),
         assets = ["assets/favicon.ico", "assets/link-icons.css"],
-        size_threshold = 1100 * 2^10,      # raise slightly 200 to to 300 KiB
-        size_threshold_warn = 900 * 2^10, # raise from 500 KiB to 1.1 MB (for search index)
-        search_size_threshold_warn = 2000 * 2^10,
+        size_threshold = 1100 * 2^10,             # raise from the 200 KiB default
+        size_threshold_warn = 900 * 2^10,         # raise from the 100 KiB default
+        search_size_threshold_warn = 2000 * 2^10, # raise from the 500 KiB default
     ),
     modules = [
         Manopt,
@@ -187,7 +188,7 @@ makedocs(;
             "Convex bundle method" => "solvers/convex_bundle_method.md",
             "Cyclic Proximal Point" => "solvers/cyclic_proximal_point.md",
             "Difference of Convex" => "solvers/difference_of_convex.md",
-            "Douglas—Rachford" => "solvers/DouglasRachford.md",
+            "Douglas–Rachford" => "solvers/DouglasRachford.md",
             "Exact Penalty Method" => "solvers/exact_penalty_method.md",
             "Frank-Wolfe" => "solvers/FrankWolfe.md",
             "Generalized Cauchy direction subsolver" => "solvers/generalized_cauchy_direction_subsolver.md",

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -9,35 +9,35 @@ This can be illustrated by the following example of optimizing the Rosenbrock fu
 using Manopt, Manifolds, LineSearches
 
 # define objective function and its gradient
-p = [1.0, 100.0]
-function rosenbrock(::AbstractManifold, x)
-    val = zero(eltype(x))
-    for i in 1:(length(x) - 1)
-        val += (p[1] - x[i])^2 + p[2] * (x[i + 1] - x[i]^2)^2
+a, b = 1.0, 100.0
+function rosenbrock(::AbstractManifold, p)
+    val = zero(eltype(p))
+    for i in 1:(length(p) - 1)
+        val += (a - p[i])^2 + b * (p[i + 1] - p[i]^2)^2
     end
     return val
 end
-function rosenbrock_grad!(M::AbstractManifold, storage, x)
-    storage .= 0.0
-    for i in 1:(length(x) - 1)
-        storage[i] += -2.0 * (p[1] - x[i]) - 4.0 * p[2] * (x[i + 1] - x[i]^2) * x[i]
-        storage[i + 1] += 2.0 * p[2] * (x[i + 1] - x[i]^2)
+function rosenbrock_grad!(M::AbstractManifold, X, p)
+    X .= 0.0
+    for i in 1:(length(p) - 1)
+        X[i] += -2.0 * (a - p[i]) - 4.0 * b * (p[i + 1] - p[i]^2) * p[i]
+        X[i + 1] += 2.0 * b * (p[i + 1] - p[i]^2)
     end
-    project!(M, storage, x, storage)
-    return storage
+    project!(M, X, p, X)
+    return X
 end
 # define constraint
 n_dims = 5
 M = Manifolds.Sphere(n_dims)
 # set initial point
-x0 = vcat(zeros(n_dims - 1), 1.0)
+p0 = vcat(zeros(n_dims), 1.0)
 # use LineSearches.jl HagerZhang method with Manopt.jl quasiNewton solver
 ls_hz = Manopt.LineSearchesStepsize(M, LineSearches.HagerZhang())
-x_opt = quasi_Newton(
+p_opt = quasi_Newton(
     M,
     rosenbrock,
     rosenbrock_grad!,
-    x0;
+    p0;
     stepsize=ls_hz,
     evaluation=InplaceEvaluation(),
     stopping_criterion=StopAfterIteration(1000) | StopWhenGradientNormLess(1e-6),

--- a/docs/src/solvers/index.md
+++ b/docs/src/solvers/index.md
@@ -31,7 +31,6 @@ For derivative free solvers only function evaluations of ``f`` are used.
 * [Gradient Descent](gradient_descent.md) uses the gradient from ``f`` to determine a descent direction. Here, the direction can also be changed to be averaged, momentum-based, or based on Nesterov's rule.
 * [Conjugate Gradient Descent](conjugate_gradient_descent.md) uses information from the previous descent direction to improve the current (gradient-based) one including several such update rules.
 * The [Quasi-Newton Method](quasi_Newton.md) 🏅 uses gradient evaluations to approximate the Hessian, which is then used in a Newton-like scheme, where both a limited memory and a full Hessian approximation are available with several different update rules.
-* [Steihaug-Toint Truncated Conjugate-Gradient Method](@ref tCG) a solver for a constrained problem defined on a tangent space.
 
 ### Subgradient
 
@@ -56,7 +55,7 @@ This is usually very well tailored for non-smooth objectives.
 
 The following methods require that the splitting, for example into several summands, is smooth in the sense that for every summand of the cost, the gradient should still exist everywhere.
 
-* [Levenberg-Marquardt](LevenbergMarquardt.md) minimizes the square norm of ``f: \mathcal M→ℝ^d``, that is ``\operatorname*{arg\,min}_{p∈\mathcal M} \frac{1}{2}\lVert f(p) \rVert^2 = \frac{1}{2}\sum_{i=1}^d f_i(p)^2``, provided the gradients ``\operatorname{grad} f_i`` of the component functions, or in other words the Jacobian of ``f``.
+* [Levenberg-Marquardt](LevenbergMarquardt.md) minimizes the squared norm of ``f: \mathcal M→ℝ^d``, that is ``\operatorname*{arg\,min}_{p∈\mathcal M} \frac{1}{2}\lVert f(p) \rVert^2 = \frac{1}{2}\sum_{i=1}^d f_i(p)^2``, provided the gradients ``\operatorname{grad} f_i`` of the component functions, or in other words the Jacobian of ``f``.
   A robust variant is available as well, where each summand is additionally passed through a
   [robustifier](../commons/robustifiers.md) ``ρ_i``, that is ``\frac{1}{2}\sum_{i=1}^d ρ_i\bigl(f_i(p)^2\bigr)``,
   to reduce the influence of outliers. It is specified with the `robustifier=` keyword.
@@ -76,11 +75,12 @@ If the gradient does not exist everywhere, that is if the splitting yields summa
 * [Douglas-Rachford](DouglasRachford.md) uses a splitting ``f(p) = F(p) + G(p)`` and their proximal maps to compute a minimizer of ``f``, which can be non-smooth.
 * The [Gradient Sampling Algorithm](gradient_sampling.md) samples the gradient at points in a ball around the current iterate to build a surrogate and solve that instead to find a next iterate.
 * [Primal-dual Riemannian semismooth Newton Algorithm](@ref solver-pdrssn) extends Chambolle-Pock and requires the differentials of the proximal maps additionally.
+* The [Proximal Gradient Method](proximal_gradient_method.md) uses a splitting ``f = g + h`` into a smooth ``g``, whose gradient is required, and a nonsmooth ``h``, whose proximal map is required.
 * The [Proximal Point](proximal_point.md) uses the proximal map of ``f`` iteratively.
 
 ## Constrained
 
-Constrained problems of the form
+Constrained problems have the form
 
 ```math
 \begin{align*}
@@ -95,20 +95,28 @@ For these you can use
 * The [Exact Penalty Method](exact_penalty_method.md) (EPM) uses a penalty term instead of augmentation, but has the same interface as ALM.
 * The [Interior Point Newton Method](interior_point_Newton.md) (IPM) rephrases the KKT system of a constrained problem into a Newton iteration being performed in every iteration.
 * [Frank-Wolfe algorithm](FrankWolfe.md), where besides the gradient of ``f`` either a closed form solution or a (maybe even automatically generated) sub problem solver for ``\operatorname*{arg\,min}_{q ∈ C} ⟨\operatorname{grad} f(p_k), \log_{p_k}q⟩`` is required, where ``p_k`` is a fixed point on the manifold (changed in every iteration).
-* The [Gradient Projection Method](projected_gradient_method.md) projects the gradient step back onto the feasible set in every iteration.
+* The [Projected Gradient Method](projected_gradient_method.md) projects the gradient step back onto the feasible set in every iteration.
 
 ## On the tangent space
 
 * [Conjugate Residual](conjugate_residual.md) a solver for a linear system ``\mathcal A[X] + b = 0`` on a tangent space.
 * [Steihaug-Toint Truncated Conjugate-Gradient Method](truncated_conjugate_gradient_descent.md) a solver for a constrained problem defined on a tangent space.
 
+## Nonlinear equations
+
+The following solver does not minimize a cost, but finds a zero of a mapping into a vector bundle.
+
+* The [Vector Bundle Newton Method](vectorbundle_newton.md) performs Newton's method for a mapping ``F: \mathcal M → \mathcal E`` into a vector bundle ``\mathcal E`` over ``\mathcal M``. In every iteration a Newton equation is solved to determine a direction, and the next iterate is obtained with a retraction.
+
 ## Alphabetical list of algorithms
 
 | Solver   | Function        | State   |
 |:---------|:----------------|:---------|
 | [Adaptive Regularization with Cubics](adaptive_regularization_with_cubics.md) | [`adaptive_regularization_with_cubics`](@ref) | [`AdaptiveRegularizationState`](@ref) |
+| [Alternating Gradient Descent](@ref solver-alternating-gradient-descent) | [`alternating_gradient_descent`](@ref) | [`AlternatingGradientDescentState`](@ref) |
 | [Augmented Lagrangian Method](augmented_Lagrangian_method.md) | [`augmented_Lagrangian_method`](@ref) | [`AugmentedLagrangianMethodState`](@ref) |
 | [Chambolle-Pock](ChambollePock.md) | [`ChambollePock`](@ref) | [`ChambollePockState`](@ref) |
+| [CMA-ES](cma_es.md) | [`cma_es`](@ref) | [`CMAESState`](@ref) |
 | [Conjugate Gradient Descent](conjugate_gradient_descent.md) | [`conjugate_gradient_descent`](@ref) | [`ConjugateGradientDescentState`](@ref) |
 | [Conjugate Residual](conjugate_residual.md) | [`conjugate_residual`](@ref) | [`ConjugateResidualState`](@ref) |
 | [Convex Bundle Method](convex_bundle_method.md) | [`convex_bundle_method`](@ref) |  [`ConvexBundleMethodState`](@ref) |
@@ -122,13 +130,17 @@ For these you can use
 | [Gradient Sampling](gradient_sampling.md) | [`gradient_sampling`](@ref) |  [`GradientSamplingState`](@ref) |
 | [Interior Point Newton](interior_point_Newton.md) | [`interior_point_Newton`](@ref) | [`InteriorPointNewtonState`](@ref) |
 | [Levenberg-Marquardt](LevenbergMarquardt.md) | [`LevenbergMarquardt`](@ref) | [`LevenbergMarquardtState`](@ref) |
+| [Mesh Adaptive Direct Search](mesh_adaptive_direct_search.md) | [`mesh_adaptive_direct_search`](@ref) | [`MeshAdaptiveDirectSearchState`](@ref) |
 | [Nelder-Mead](NelderMead.md) | [`NelderMead`](@ref) | [`NelderMeadState`](@ref) |
 | [Particle Swarm](particle_swarm.md) | [`particle_swarm`](@ref) | [`ParticleSwarmState`](@ref) |
 | [Primal-dual Riemannian semismooth Newton Algorithm](@ref solver-pdrssn) | [`primal_dual_semismooth_Newton`](@ref) | [`PrimalDualSemismoothNewtonState`](@ref) |
+| [Projected Gradient Method](projected_gradient_method.md) | [`projected_gradient_method`](@ref) | [`ProjectedGradientMethodState`](@ref) |
 | [Proximal Bundle Method](proximal_bundle_method.md) | [`proximal_bundle_method`](@ref) | [`ProximalBundleMethodState`](@ref) |
+| [Proximal Gradient Method](proximal_gradient_method.md) | [`proximal_gradient_method`](@ref) | [`ProximalGradientMethodState`](@ref) |
 | [Proximal Point](proximal_point.md) | [`proximal_point`](@ref) |  [`ProximalPointState`](@ref) |
 | [Quasi-Newton Method](quasi_Newton.md) | [`quasi_Newton`](@ref) | [`QuasiNewtonState`](@ref) |
-| [Steihaug-Toint Truncated Conjugate-Gradient Method](@ref tCG) | [`truncated_conjugate_gradient_descent`](@ref) | [`TruncatedConjugateGradientState`](@ref) |
-| [Subgradient Method](subgradient.md) | [`subgradient_method`](@ref) | [`SubGradientMethodState`](@ref) |
-| [Stochastic Gradient Descent](stochastic_gradient_descent.md) | [`stochastic_gradient_descent`](@ref) | [`StochasticGradientDescentState`](@ref) |
 | [Riemannian Trust-Regions](trust_regions.md) | [`trust_regions`](@ref) | [`TrustRegionsState`](@ref) |
+| [Steihaug-Toint Truncated Conjugate-Gradient Method](@ref tCG) | [`truncated_conjugate_gradient_descent`](@ref) | [`TruncatedConjugateGradientState`](@ref) |
+| [Stochastic Gradient Descent](stochastic_gradient_descent.md) | [`stochastic_gradient_descent`](@ref) | [`StochasticGradientDescentState`](@ref) |
+| [Subgradient Method](subgradient.md) | [`subgradient_method`](@ref) | [`SubGradientMethodState`](@ref) |
+| [Vector Bundle Newton](vectorbundle_newton.md) | [`vectorbundle_newton`](@ref) | [`VectorBundleNewtonState`](@ref) |

--- a/docs/src/solvers/primal_dual_semismooth_Newton.md
+++ b/docs/src/solvers/primal_dual_semismooth_Newton.md
@@ -83,6 +83,13 @@ get_differential_dual_prox
 PrimalDualSemismoothNewtonState
 ```
 
+## Internal functions
+
+```@docs
+Manopt.construct_primal_dual_residual_vector
+Manopt.construct_primal_dual_residual_covariant_derivative_matrix
+```
+
 ## Solver specific debug output
 
 [`DebugDualBaseIterate`](@ref), [`DebugDualBaseChange`](@ref), [`DebugPrimalBaseIterate`](@ref),

--- a/docs/src/solvers/vectorbundle_newton.md
+++ b/docs/src/solvers/vectorbundle_newton.md
@@ -9,6 +9,7 @@
 
 ```@docs
 VectorBundleManoptProblem
+Manopt.get_manifold(::VectorBundleManoptProblem)
 ```
 
 ## State

--- a/ext/ManoptLRUCacheExt.jl
+++ b/ext/ManoptLRUCacheExt.jl
@@ -47,7 +47,7 @@ function Manopt.init_caches(
         # Float cache, like for f
         (c === :Cost) && push!(lru_caches, LRU{P, R}(; maxsize = m))
         (c === :Differential) && push!(lru_caches, LRU{Tuple{P, T}, R}(; maxsize = m))
-        # vectors, like for Constraints/EqCOnstraints/InEqCOnstraints
+        # vectors, like for Constraints/EqualityConstraints/InequalityConstraints
         # (a) store whole vectors
         (c === :EqualityConstraints) && push!(lru_caches, LRU{P, Vector{R}}(; maxsize = m))
         (c === :InequalityConstraints) && push!(lru_caches, LRU{P, Vector{R}}(; maxsize = m))

--- a/ext/ManoptManifoldsExt/manifold_functions.jl
+++ b/ext/ManoptManifoldsExt/manifold_functions.jl
@@ -21,7 +21,13 @@ on `DefaultManifold` is the `Inf` norm of `p`.
 """
 Manopt.default_point_distance(::Euclidean, p) = norm(p, Inf)
 
-Manopt.default_vector_norm(::Euclidean, p, X) = norm(p, Inf)
+"""
+    default_vector_norm(::Euclidean, p, X)
+
+Following [HagerZhang:2006:2](@cite), the norm of a tangent vector `X` at `p`
+used within the Hager-Zhang initial guess on `Euclidean` is the `Inf` norm of `X`.
+"""
+Manopt.default_vector_norm(::Euclidean, p, X) = norm(X, Inf)
 
 """
     get_bounds_index(::Hyperrectangle)

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -286,7 +286,7 @@ export AbstractDecoratedManifoldObjective,
 export AbstractVectorFunction, VectorDifferentialFunction
 export AbstractVectorGradientFunction, VectorGradientFunction, VectorHessianFunction
 # Robustifiers
-export AbstractRobustifierFunction, SoftL1Robustifier, AbstractRobustifierFunction,
+export AbstractRobustifierFunction, SoftL1Robustifier,
     CauchyRobustifier, TolerantRobustifier, TukeyRobustifier, ComposedRobustifierFunction,
     ArctanRobustifier, ScaledRobustifierFunction, RobustifierFunction, IdentityRobustifier,
     HuberRobustifier, ComponentwiseRobustifierFunction
@@ -348,7 +348,6 @@ export get_subgradient, get_subgradient!
 export get_subtrahend_gradient!, get_subtrahend_gradient
 export get_proximal_map, get_proximal_map!
 export get_state,
-    get_initial_stepsize,
     get_iterate,
     get_adjoint_jacobian, get_adjoint_jacobian!,
     get_jacobian, get_jacobian!,
@@ -371,7 +370,6 @@ export get_state,
 export get_hessian, get_hessian!
 export get_differential
 export provided_callbacks
-export ApproxHessianFiniteDifference
 export is_state_decorator, dispatch_state_decorator
 export primal_residual, dual_residual
 export equality_constraints_length,
@@ -474,9 +472,7 @@ export initialize_solver!, step_solver!, get_solver_result, stop_solver!
 export solve!
 export ApproxHessianFiniteDifference, ApproxHessianSymmetricRankOne, ApproxHessianBFGS
 export update_hessian!, update_hessian_basis!
-export ExactPenaltyCost, ExactPenaltyGrad, AugmentedLagrangianCost, AugmentedLagrangianGrad
 export AdaptiveRegularizationWithCubicsModelObjective
-export ExactPenaltyCost, ExactPenaltyGrad
 export SmoothingTechnique, LinearQuadraticHuber, LogarithmicSumOfExponentials
 #
 # Stepsize
@@ -488,7 +484,6 @@ export ArmijoLinesearch, Linesearch, NonmonotoneLinesearch, CubicBracketingLines
 export get_stepsize, get_initial_stepsize, get_last_stepsize
 export InteriorPointCentralityCondition
 export DomainBackTracking, DomainBackTrackingStepsize, NullStepBackTrackingStepsize
-export ProximalGradientMethodBacktracking
 export HagerZhangLinesearch
 #
 # Stopping Criteria
@@ -535,9 +530,8 @@ export DebugPrimalBaseChange, DebugPrimalBaseIterate, DebugPrimalChange, DebugPr
 export DebugDualBaseChange, DebugDualBaseIterate, DebugDualChange, DebugDualIterate
 export DebugDualResidual, DebugPrimalDualResidual, DebugPrimalResidual
 export DebugProximalParameter, DebugWarnIfCostIncreases
-export DebugGradient, DebugGradientNorm, DebugStepsize
 export DebugWhenActive, DebugWarnIfFieldNotFinite, DebugIfEntry
-export DebugWarnIfCostNotFinite, DebugWarnIfFieldNotFinite
+export DebugWarnIfCostNotFinite
 export DebugWarnIfLagrangeMultiplierIncreases, DebugWarnIfStepsizeCollapsed
 export DebugWarnIfGradientNormTooLarge, DebugMessages
 #
@@ -551,7 +545,6 @@ export RecordGradient, RecordGradientNorm, RecordStepsize
 export RecordSubsolver, RecordWhenActive, RecordStoppingReason
 export RecordPrimalBaseChange,
     RecordPrimalBaseIterate, RecordPrimalChange, RecordPrimalIterate
-export RecordStoppingReason, RecordWhenActive, RecordSubsolver
 export RecordDualBaseChange, RecordDualBaseIterate, RecordDualChange, RecordDualIterate
 export RecordProximalParameter
 #

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -481,7 +481,7 @@ export SmoothingTechnique, LinearQuadraticHuber, LogarithmicSumOfExponentials
 #
 # Stepsize
 export Stepsize
-export AdaptiveWNGradient, AffineCovariantStepsize, BarzileiBorwein, ConstantLength
+export AdaptiveWNGradient, AffineCovariantStepsize, BarzilaiBorwein, ConstantLength
 export DecreasingLength, Polyak, DistanceOverGradients, DistanceOverGradientsStepsize
 export ProximalGradientMethodBacktracking
 export ArmijoLinesearch, Linesearch, NonmonotoneLinesearch, CubicBracketingLinesearch

--- a/src/Manopt.jl
+++ b/src/Manopt.jl
@@ -398,8 +398,7 @@ export ProximalGradientNonsmoothCost, ProximalGradientNonsmoothSubgradient
 export QuasiNewtonState, QuasiNewtonLimitedMemoryDirectionUpdate, QuasiNewtonLimitedMemoryBoxDirectionUpdate
 export QuasiNewtonMatrixDirectionUpdate
 export QuasiNewtonPreconditioner
-export QuasiNewtonCautiousDirectionUpdate,
-    BFGS, InverseBFGS, DFP, InverseDFP, SR1, InverseSR1
+export QuasiNewtonCautiousDirectionUpdate, BFGS, InverseBFGS, DFP, InverseDFP, SR1, InverseSR1
 export InverseBroyden, Broyden
 export AbstractQuasiNewtonDirectionUpdate, AbstractQuasiNewtonUpdateRule
 export WolfePowellLinesearch, WolfePowellBinaryLinesearch
@@ -482,8 +481,8 @@ export SmoothingTechnique, LinearQuadraticHuber, LogarithmicSumOfExponentials
 #
 # Stepsize
 export Stepsize
-export AdaptiveWNGradient, AffineCovariantStepsize, ConstantLength, DecreasingLength,
-    Polyak, DistanceOverGradients, DistanceOverGradientsStepsize
+export AdaptiveWNGradient, AffineCovariantStepsize, BarzileiBorwein, ConstantLength
+export DecreasingLength, Polyak, DistanceOverGradients, DistanceOverGradientsStepsize
 export ProximalGradientMethodBacktracking
 export ArmijoLinesearch, Linesearch, NonmonotoneLinesearch, CubicBracketingLinesearch
 export get_stepsize, get_initial_stepsize, get_last_stepsize

--- a/src/base/keyword.jl
+++ b/src/base/keyword.jl
@@ -241,8 +241,9 @@ function keywords_accepted(
         if k in kw.deprecated
             push!(d, k)
         end
-        # Not accepted?
-        if (length(kw.accepted) > 0) && (k ∉ kw.accepted)
+        # Not accepted? Note that an empty set of accepted keywords means that none are.
+        # A deprecated keyword is not in `accepted` either, but is reported as deprecated above.
+        if (k ∉ kw.accepted) && (k ∉ kw.deprecated)
             push!(a, k)
         end
     end

--- a/src/base/repl.jl
+++ b/src/base/repl.jl
@@ -46,22 +46,25 @@ function _ordinal_suffix(n::Integer)
 end
 # _in_str - indent a string for use within another one
 # * `indent = 0` how often to raise indentation by `indent_str` (`_MANOPT_INDENT` by default)
-# * `headers = 1` how often to increase headers, also on headers that are indented with `indent_str`
+# * `headers = 1` how often to increase headers, also on headers that are already indented
 # * `indent_str = _MANOPT_INDENT` string to use for indent
 # * `indent_end = ""` a string to end the indentation, for example a `"| "` for visual distinction
+#
+# The headers are raised before indenting, so that this works for any `indent` and `indent_end`,
+# and empty lines are not indented, since that would only introduce trailing whitespace.
 function _in_str(s::String; indent = 0, headers = 1, indent_str = _MANOPT_INDENT, indent_end = "")
-    t = s
-    #add start
-    t = replace("$(indent_end)$t", "\n" => "\n$(indent_end)")
-    #add indent iteratively
-    for _ in 1:indent
-        t = replace("$(indent_str)$t", "\n" => "\n$(indent_str)")
-    end
-    # increase headers iteratively
-    for _ in 1:headers
-        t = replace(t, Regex("(?m)^($(indent_str)*)(#+)") => s"\1#\2")
-    end
-    return t
+    prefix = indent_str^indent * indent_end
+    return join(
+        map(split(s, "\n")) do line
+            if headers > 0
+                # a header might already be indented, keep that indent in front of the header
+                m = match(r"^(\s*)(#+.*)$", line)
+                isnothing(m) || (line = "$(m[1])$("#"^headers)$(m[2])")
+            end
+            return isempty(line) ? rstrip(prefix) : "$(prefix)$(line)"
+        end,
+        "\n",
+    )
 end
 
 # in general, ignore printing the objective by default in tuples on REPL

--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -208,17 +208,17 @@ as well as the [`stop_solver!`](@ref) of the solver.
 This includes the callbacks `:BeforeInit`, `:Init`, `:BeforeStep`, `:Step`, and `:Stop`.
 """
 function solve!(problem::AbstractManoptProblem, state::AbstractManoptSolverState)
-    iteration = 0
+    k = 0
     callback(:BeforeInit, problem, state, 0)
     initialize_solver!(problem, state)
     callback(:Init, problem, state, 0)
-    while !stop_solver!(problem, state, iteration)
-        iteration = iteration + 1
-        callback(:BeforeStep, problem, state, iteration)
-        step_solver!(problem, state, iteration)
-        callback(:Step, problem, state, iteration)
+    while !stop_solver!(problem, state, k)
+        k = k + 1
+        callback(:BeforeStep, problem, state, k)
+        step_solver!(problem, state, k)
+        callback(:Step, problem, state, k)
     end
-    callback(:Stop, problem, state, iteration)
+    callback(:Stop, problem, state, k)
     return state
 end
 

--- a/src/base/state/abstract_state.jl
+++ b/src/base/state/abstract_state.jl
@@ -46,7 +46,7 @@ abstract type AbstractHessianSolverState <: AbstractGradientSolverState end
 A general struct that indicates when to restart.
 It is used within the [`ConjugateGradientDescentState`](@ref).
 
-It is implemented to work as a functor `(problem, state, iteration) -> true|false`
+It is implemented to work as a functor `(problem, state, k) -> true|false`
 and what is done in the restart case (`true`) is decided by the single solver.
 """
 abstract type AbstractRestartCondition end

--- a/src/base/state/callback.jl
+++ b/src/base/state/callback.jl
@@ -1,6 +1,6 @@
 const _MANOPT_DEFAULT_CALLBACKS = [:Any, :BeforeInit, :BeforeStep, :BeforeStop, :Init, :Step, :Stop]
-const _MANOPT_EMPTY_CALLBACK = (problem, state, iteration) -> nothing
-const _MANOPT_EMPTY_ANY_CALLBACK = (symbol::Symbol, problem, state, iteration) -> nothing
+const _MANOPT_EMPTY_CALLBACK = (problem, state, k) -> nothing
+const _MANOPT_EMPTY_ANY_CALLBACK = (symbol::Symbol, problem, state, k) -> nothing
 
 """
     active_callbacks(state::AbstractManoptSolverState)
@@ -15,17 +15,17 @@ function active_callbacks(state::AbstractManoptSolverState)
 end
 
 """
-    callback(name::Symbol, problem::AbstractManoptProblem, state::AbstractManoptSolverState, iteration::Int)
+    callback(name::Symbol, problem::AbstractManoptProblem, state::AbstractManoptSolverState, k::Int)
 
 Perform a callback.
 
 This function performs a call to both possible approaches
 
-* if a callback exists in the dictionary under the symbol `name` it is called with the parameters `problem, state, iteration`
-* if a callback exists in the dictionary that shall be called `:Any` time, this one is called with `name, problem, state, iteration`
+* if a callback exists in the dictionary under the symbol `name` it is called with the parameters `problem, state, k`
+* if a callback exists in the dictionary that shall be called `:Any` time, this one is called with `name, problem, state, k`
 """
 function callback(
-        name::Symbol, problem::AbstractManoptProblem, state::AbstractManoptSolverState, iteration::Int
+        name::Symbol, problem::AbstractManoptProblem, state::AbstractManoptSolverState, k::Int
     )
     cb = get_callbacks(state)
     if isempty(cb)
@@ -33,9 +33,9 @@ function callback(
         return nothing
     end
     cbs = get(cb, name, _MANOPT_EMPTY_CALLBACK)
-    cbs(problem, state, iteration)
+    cbs(problem, state, k)
     cba = get(cb, :Any, _MANOPT_EMPTY_ANY_CALLBACK)
-    cba(name, problem, state, iteration)
+    cba(name, problem, state, k)
     return nothing
 end
 

--- a/src/commons/conjugate_gradient_coefficients.jl
+++ b/src/commons/conjugate_gradient_coefficients.jl
@@ -91,7 +91,7 @@ The following fields from above are keyword arguments
 
 $(_kwargs(:X; name = "initial_gradient"))
 $(_kwargs(:p; add_properties = [:as_Initial]))
-* `coefficient=[`ConjugateDescentCoefficient`](@ref)`()`: specify a CG coefficient, see also the [`ManifoldDefaultsFactory`](@ref).
+* `coefficient=`[`ConjugateDescentCoefficient`](@ref)`()`: specify a CG coefficient, see also the [`ManifoldDefaultsFactory`](@ref).
 * `restart_condition=`[`RestartOnNonDescent`](@ref)`()`: specify a [restart condition](@ref AbstractRestartCondition). It defaults to [`RestartOnNonDescent`](@ref).
 $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, ConjugateGradientDescentState; retraction_method=retraction_method)"))
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(500)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(1e-8)"))

--- a/src/commons/debugs.jl
+++ b/src/commons/debugs.jl
@@ -41,7 +41,7 @@ end
 @doc """
     DebugChange(M=DefaultManifold(); kwargs...)
 
-debug for the amount of change of the iterate (stored in `get_iterate(o)` of the [`AbstractManoptSolverState`](@ref))
+debug for the amount of change of the iterate (stored in `get_iterate` of the [`AbstractManoptSolverState`](@ref))
 during the last iteration. See [`DebugEntryChange`](@ref) for the general case
 
 # Keyword parameters
@@ -589,7 +589,7 @@ end
 function show(io::IO, d::DebugIfEntry)
     return print(io, "DebugIfEntry(:$(d.field), $(d.check); type=:$(d.type), at_init=$(d.at_init))")
 end
-function status_summary(d::DebugIfEntry; context::Symbol = :Default)
+function status_summary(d::DebugIfEntry; context::Symbol = :default)
     (context === :short) && (return repr(d))
     # Inline and default
     return "A DebugAction printing the entry :$(d.field) of the solver state if $(d.check) of that field is true, in format “$(escape_string(d.msg))” as $(d.type)"
@@ -636,7 +636,7 @@ end
 @doc """
     DebugGradientChange()
 
-debug for the amount of change of the gradient (stored in `get_gradient(o)` of the [`AbstractManoptSolverState`](@ref) `o`)
+debug for the amount of change of the gradient (stored in `get_gradient` of the [`AbstractManoptSolverState`](@ref))
 during the last iteration. See [`DebugEntryChange`](@ref) for the general case
 
 # Keyword parameters
@@ -694,7 +694,7 @@ function show(io::IO, dgc::DebugGradientChange)
         "DebugGradientChange(; format=\"$(escape_string(dgc.format))\", vector_transport_method=$(dgc.vector_transport_method))",
     )
 end
-function status_summary(di::DebugGradientChange; context::Symbol = :Default)
+function status_summary(di::DebugGradientChange; context::Symbol = :default)
     (context === :short) && (return "(:GradientChange, \"$(escape_string(di.format))\")")
     # Inline and default
     return "A DebugAction printing the change of the gradient with format “$(escape_string(di.format))”"
@@ -748,7 +748,7 @@ end
 @doc """
     DebugIterate <: DebugAction
 
-debug for the current iterate (stored in `get_iterate(o)`).
+debug for the current iterate (stored in `get_iterate` of the [`AbstractManoptSolverState`](@ref)).
 
 # Constructor
     DebugIterate(; kwargs...)
@@ -1057,7 +1057,7 @@ function Base.show(io::IO, d::DebugProximalParameter)
         io, "DebugGradientChange(; io = ", d.io, ", format=\"$(escape_string(d.format))\", at_init = $(d.at_init))",
     )
 end
-function status_summary(d::DebugProximalParameter; context::Symbol = :Default)
+function status_summary(d::DebugProximalParameter; context::Symbol = :default)
     (context === :short) && (return "(:ProxParameter, \"$(escape_string(d.format))\")")
     # Inline and default
     return "A DebugAction printing the proximal parameter as “$(escape_string(d.format))”"

--- a/src/commons/debugs.jl
+++ b/src/commons/debugs.jl
@@ -4,7 +4,7 @@
 Debug for a simple callback function, mainly for compatibility to other solvers and if
 a user already has a callback function or functor available
 
-The expected format of the is that it is a function with signature `(problem, state, iteration) -> nothing`
+The expected format of the is that it is a function with signature `(problem, state, k) -> nothing`
 A simple callback of the signature `() -> nothing` can be specified by `simple=true`. In this case the callback is wrapped in a function of the generic form
 
 !!! note

--- a/src/commons/debugs.jl
+++ b/src/commons/debugs.jl
@@ -343,7 +343,7 @@ DebugDualIterate(opts...; kwargs...) = DebugEntry(:X, opts...; kwargs...)
 
 Print the dual base variable by using [`DebugEntry`](@ref),
 see their constructors for detail.
-This method is further set display `o.n`.
+This method is further set to display the field `n` of the state.
 """
 DebugDualBaseIterate(; kwargs...) = DebugEntry(:n; kwargs...)
 
@@ -421,10 +421,10 @@ function status_summary(d::DebugEntryChange; context::Symbol = :default)
 end
 
 """
-    DebugDualChange(; storage=StoreStateAction([:n]), io::IO=stdout)
+    DebugDualBaseChange(; storage=StoreStateAction([:n]), kwargs...)
 
 Print the change of the dual base variable by using [`DebugEntryChange`](@ref),
-see their constructors for detail, on `o.n`.
+see their constructors for detail, on the field `n` of the state.
 """
 function DebugDualBaseChange(;
         storage::StoreStateAction = StoreStateAction([:n]), prefix = "Dual Base Change:", kwargs...
@@ -440,15 +440,15 @@ end
 
 Print the primal base variable by using [`DebugEntry`](@ref),
 see their constructors for detail.
-This method is further set display `o.m`.
+This method is further set to display the field `m` of the state.
 """
 DebugPrimalBaseIterate(opts...; kwargs...) = DebugEntry(:m, opts...; kwargs...)
 
 """
-    DebugPrimalBaseChange(a::StoreStateAction=StoreStateAction([:m]),io::IO=stdout)
+    DebugPrimalBaseChange(opts...; prefix="Primal Base Change:", kwargs...)
 
 Print the change of the primal base variable by using [`DebugEntryChange`](@ref),
-see their constructors for detail, on `o.n`.
+see their constructors for detail, on the field `m` of the state.
 """
 function DebugPrimalBaseChange(opts...; prefix = "Primal Base Change:", kwargs...)
     return DebugEntryChange(

--- a/src/commons/debugs.jl
+++ b/src/commons/debugs.jl
@@ -240,7 +240,7 @@ DebugDualResidual(; kwargs...)
 
 # Keyword warguments
 
-* `io=`stdout`: stream to perform the debug to
+* `io=stdout`: stream to perform the debug to
 * `format="\$prefix%s"`: format to print the dual residual, using the
 * `prefix="Dual Residual: "`: short form to just set the prefix
 * `storage` (a new [`StoreStateAction`](@ref)) to store values for the debug.
@@ -910,7 +910,7 @@ with the keywords
 
 # Keyword warguments
 
-* `io=`stdout`: stream to perform the debug to
+* `io=stdout`: stream to perform the debug to
 * `format="\$prefix%s"`: format to print the dual residual, using the
 * `prefix="PD Residual: "`: short form to just set the prefix
 * `storage` (a new [`StoreStateAction`](@ref)) to store values for the debug.
@@ -981,7 +981,7 @@ should at least record `:Iterate`, `:X` and `:n`.
 
 # Keyword warguments
 
-* `io=`stdout`: stream to perform the debug to
+* `io=stdout`: stream to perform the debug to
 * `format="\$prefix%s"`: format to print the dual residual, using the
 * `prefix="Primal Residual: "`: short form to just set the prefix
 * `storage` (a new [`StoreStateAction`](@ref)) to store values for the debug.
@@ -1245,7 +1245,7 @@ The measured time is rounded using the given `time_accuracy` and printed after [
 # Keyword parameters
 
 * `io=stdout`:             default stream to print the debug to.
-* `format="\$prefix %s"`:   format to print the output, where `%s` is the canonicalized time`.
+* `format="\$prefix %s"`:   format to print the output, where `%s` is the canonicalized time.
 * `mode=:cumulative`:      whether to display the total time or reset on every call using `:iterative`.
 * `prefix="Last Change:"`: prefix of the debug output (ignored if you set `format`:
 * `start=false`:           indicate whether to start the timer on creation or not.
@@ -1635,7 +1635,7 @@ one are called with an `i=0` for reset.
    [:Iterate, " | ", :Cost, :Stop, 10]
    ```
 
-   Adds a group to :Iteration of three actions ([`DebugIteration`](@ref), [`DebugDivider`](@ref)`(" | "),  and[`DebugCost`](@ref))
+   Adds a group to :Iteration of three actions ([`DebugIteration`](@ref), [`DebugDivider`](@ref)`(" | ")`, and [`DebugCost`](@ref))
    as a [`DebugGroup`](@ref) inside an [`DebugEvery`](@ref) to only be executed every 10th iteration.
    It also adds the [`DebugStoppingCriterion`](@ref) to the `:EndAlgorithm` entry of the dictionary.
 

--- a/src/commons/direction_updates.jl
+++ b/src/commons/direction_updates.jl
@@ -270,7 +270,7 @@ See [`Nesterov`](@ref) for details
 
 * `γ::Real`, `μ::Real`: coefficients from the last iterate
 * `v::P`:      an interim point to compute the next gradient evaluation point `y_k`
-* `shrinkage`: a function `k -> ...` to compute the shrinkage ``β_k`` per iterate `k``.
+* `shrinkage`: a function `k -> ...` to compute the shrinkage ``β_k`` per iterate `k`.
 $(_kwargs(:inverse_retraction_method))
 
 # Constructor
@@ -281,8 +281,8 @@ $(_kwargs(:inverse_retraction_method))
 ## Keyword arguments
 
 $(_kwargs(:p; add_properties = [:as_Initial]))
-* `γ=0.001``
-* `μ=0.9``
+* `γ=0.001`
+* `μ=0.9`
 * `shrinkage = k -> 0.8`
 $(_kwargs(:inverse_retraction_method))
 

--- a/src/commons/functions.jl
+++ b/src/commons/functions.jl
@@ -14,8 +14,9 @@ function maybe_unwrap_variable end
     maybe_unwrap_variable(p::P, q::P)
     maybe_unwrap_variable(p::P, q::Vector{P})
 
-Undo the wrapping performed by `maybe_wrap_variable`, i.e. given the original
-input variable `p` and the possibly wrapped variable `q`, return the unwrapped variable,
+Undo the wrapping performed by [`maybe_wrap_variable`](@ref).
+
+Given the original input variable `p` and the possibly wrapped variable `q`, return the unwrapped variable,
 i.e. if `q` is a 1-element vector of same element-type `P` as the type of `p`,
 return this one element.
 """

--- a/src/commons/objectives.jl
+++ b/src/commons/objectives.jl
@@ -2806,9 +2806,9 @@ Specify a problem for Hessian based algorithms.
 # Fields
 
 * `cost`:           a function ``f:$(_math(:Manifold))→ℝ`` to minimize
-* `gradient`:       the gradient ``$(_tex(:grad))f:$(_math(:Manifold)) → $(_math(:TangentBundle))`` of the cost function ``f``
-* `hessian`:        the Hessian ``$(_tex(:Hess))f(p)[⋅]: $(_math(:TangentSpace)) → $(_math(:TangentSpace))`` of the cost function ``f``
-* `preconditioner`: the symmetric, positive definite preconditioner
+* `gradient!`:      the gradient ``$(_tex(:grad))f:$(_math(:Manifold)) → $(_math(:TangentBundle))`` of the cost function ``f``
+* `hessian!`:       the Hessian ``$(_tex(:Hess))f(p)[⋅]: $(_math(:TangentSpace)) → $(_math(:TangentSpace))`` of the cost function ``f``
+* `preconditioner!`: the symmetric, positive definite preconditioner
   as an approximation of the inverse of the Hessian of ``f``, a map with the same
   input variables as the `hessian` to numerically stabilize iterations when the Hessian is
   ill-conditioned
@@ -3239,7 +3239,7 @@ which represents proximal maps ``$(_tex(:prox))_{λf_i}`` for summands ``f = f_1
 
 * `cost`: a function ``f:$(_math(:Manifold))→ℝ`` to
   minimize
-* `proxes`: proximal maps ``$(_tex(:prox))_{λf_i}:$(_math(:Manifold)) → $(_math(:Manifold))``
+* `proximal_maps!`: proximal maps ``$(_tex(:prox))_{λf_i}:$(_math(:Manifold)) → $(_math(:Manifold))``
   as functions `(M, λ, p) -> q` or in-place `(M, q, λ, p)`.
 * `number_of_proxes`: number of proximal maps per function,
   to specify when one of the maps is a combined one such that the proximal maps
@@ -3714,7 +3714,7 @@ A structure to store information about an objective for a subgradient based opti
 # Fields
 
 * `cost`:        the function ``f`` to be minimized
-* `subgradient`: a function returning a subgradient ``∂f`` of ``f``
+* `subgradient!`: a function returning a subgradient ``∂f`` of ``f``
 
 # Constructor
 

--- a/src/commons/quasi_newton_updates.jl
+++ b/src/commons/quasi_newton_updates.jl
@@ -442,8 +442,21 @@ mutable struct QuasiNewtonMatrixDirectionUpdate{
     update::NT
     vector_transport_method::VT
 end
-function status_summary(d::QuasiNewtonMatrixDirectionUpdate)
-    return "$(d.update) with $(!isnothing(d.initial_scale) ? "initial scaling $(d.initial_scale) and" : "") vector transport method $(d.vector_transport_method)."
+function status_summary(d::QuasiNewtonMatrixDirectionUpdate; context::Symbol = :default)
+    (context === :short) && return repr(d)
+    scale = isnothing(d.initial_scale) ? "deactivated" : "$(d.initial_scale)"
+    (context === :inline) &&
+        return "A quasi Newton direction update using $(d.update), stored as a matrix."
+    return """
+    A quasi Newton direction update stored as a matrix
+
+    ## Parameters
+    * update rule:             $(_MANOPT_INDENT)$(d.update)
+    * basis:                   $(_MANOPT_INDENT)$(d.basis)
+    * initial scaling:         $(_MANOPT_INDENT)$(scale)
+    * matrix size:             $(_MANOPT_INDENT)$(size(d.matrix, 1))×$(size(d.matrix, 2))
+    * vector transport method: $(_MANOPT_INDENT)$(d.vector_transport_method)
+    """
 end
 function show(io::IO, d::QuasiNewtonMatrixDirectionUpdate)
     s = """
@@ -676,12 +689,26 @@ function QuasiNewtonLimitedMemoryDirectionUpdate(
     )
 end
 get_message(d::QuasiNewtonLimitedMemoryDirectionUpdate) = d.message
-function status_summary(d::QuasiNewtonLimitedMemoryDirectionUpdate{T}) where {T}
-    s = "limited memory $T (size $(length(d.memory_s)))"
-    !isnothing(d.initial_scale) && (s = "$(s) initial scaling $(d.initial_scale)")
-    (d.project! !== copyto!) && (s = "$(s), projections, ")
-    s = "$(s)and $(d.vector_transport_method) as vector transport."
-    return s
+function status_summary(
+        d::QuasiNewtonLimitedMemoryDirectionUpdate{T}; context::Symbol = :default
+    ) where {T}
+    (context === :short) && return repr(d)
+    scale = isnothing(d.initial_scale) ? "deactivated" : "$(d.initial_scale)"
+    (context === :inline) &&
+        return "A limited memory $(T) direction update of memory size $(capacity(d.memory_s))."
+    return """
+    A limited memory quasi Newton direction update
+
+    ## Parameters
+    * update rule:                    $(_MANOPT_INDENT)$(T)
+    * memory size:                    $(_MANOPT_INDENT)$(capacity(d.memory_s))
+    * currently stored:               $(_MANOPT_INDENT)$(length(d.memory_s))
+    * initial scaling:                $(_MANOPT_INDENT)$(scale)
+    * projection:                     $(_MANOPT_INDENT)$(d.project! === copyto! ? "none" : "$(d.project!)")
+    * nonpositive curvature behavior: $(_MANOPT_INDENT):$(d.nonpositive_curvature_behavior)
+    * tolerance sy_tol:               $(_MANOPT_INDENT)$(d.sy_tol)
+    * vector transport method:        $(_MANOPT_INDENT)$(d.vector_transport_method)
+    """
 end
 function (d::QuasiNewtonLimitedMemoryDirectionUpdate{InverseBFGS})(
         mp::AbstractManoptProblem, st
@@ -820,6 +847,24 @@ function QuasiNewtonCautiousDirectionUpdate(
     ) where {U <: Union{QuasiNewtonMatrixDirectionUpdate, QuasiNewtonLimitedMemoryDirectionUpdate}}
     return QuasiNewtonCautiousDirectionUpdate{U, typeof(θ)}(update, θ)
 end
+function status_summary(d::QuasiNewtonCautiousDirectionUpdate; context::Symbol = :default)
+    (context === :short) && return repr(d)
+    (context === :inline) &&
+        return "A cautious direction update with θ = $(d.θ); internally: $(status_summary(d.update; context = :inline))"
+    return """
+    A cautious quasi Newton direction update
+
+    ## Parameters
+    * θ: $(_MANOPT_INDENT)$(d.θ)
+
+    ## Internal direction update
+    $(_in_str(status_summary(d.update; context = context); indent = 1, headers = 1))
+    """
+end
+function show(io::IO, d::QuasiNewtonCautiousDirectionUpdate)
+    print(io, "QuasiNewtonCautiousDirectionUpdate with θ = $(d.θ) and internal state:\n")
+    return print(io, d.update)
+end
 (d::QuasiNewtonCautiousDirectionUpdate)(mp::AbstractManoptProblem, st) = d.update(mp, st)
 function (d::QuasiNewtonCautiousDirectionUpdate)(r, mp::AbstractManoptProblem, st)
     return d.update(r, mp, st)
@@ -882,10 +927,23 @@ mutable struct QuasiNewtonLimitedMemoryBoxDirectionUpdate{
     last_gcd_stepsize::F
 end
 
-function status_summary(d::QuasiNewtonLimitedMemoryBoxDirectionUpdate)
-    s = "limited memory direction update with support for box constraints; "
-    s *= "internal direction update status: $(status_summary(d.qn_du))"
-    return s
+function status_summary(
+        d::QuasiNewtonLimitedMemoryBoxDirectionUpdate; context::Symbol = :default
+    )
+    (context === :short) && return repr(d)
+    (context === :inline) &&
+        return "A limited memory direction update with support for box constraints; internally: $(status_summary(d.qn_du; context = :inline))"
+    return """
+    A limited memory quasi Newton direction update with support for box constraints
+
+    ## Parameters
+    * current scale:                $(_MANOPT_INDENT)$(d.current_scale)
+    * last Cauchy direction result: $(_MANOPT_INDENT):$(d.last_gcd_result)
+    * last Cauchy step size:        $(_MANOPT_INDENT)$(d.last_gcd_stepsize)
+
+    ## Internal direction update
+    $(_in_str(status_summary(d.qn_du; context = context); indent = 1, headers = 1))
+    """
 end
 
 function get_parameter(d::QuasiNewtonLimitedMemoryBoxDirectionUpdate, ::Val{:max_stepsize})

--- a/src/commons/quasi_newton_updates.jl
+++ b/src/commons/quasi_newton_updates.jl
@@ -332,7 +332,7 @@ Add a preconditioning
 
 # Fields
 
-* `preconditioner::F`: the preconditioner function
+* `preconditioner!::F`: the preconditioner function
 
 # Constructors
 

--- a/src/commons/quasi_newton_updates.jl
+++ b/src/commons/quasi_newton_updates.jl
@@ -805,7 +805,7 @@ update is skipped, which means that for [`QuasiNewtonMatrixDirectionUpdate`](@re
 the matrix ``H_k`` or ``B_k`` is not updated.
 The basis ``$(_math(:Sequence, "b", "i", "1", "n"))`` is nevertheless transported into the upcoming tangent
 space ``T_{x_{k+1}} $(_math(:Manifold))``, and for [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref)
-neither the oldest vector pair ``$(_tex(:widetilde, "s"))_{k−m}``, ``$(_tex(:widetilde, "y"))_{k−m}`` is
+neither the oldest vector pair ``$(_tex(:widetilde, "s"))_{k-m}``, ``$(_tex(:widetilde, "y"))_{k-m}`` is
 discarded nor the newest vector pair ``$(_tex(:widetilde, "s"))_k, $(_tex(:widetilde, "y"))_k`` is added
 into storage, but all stored vector pairs ``$(_tex(:set, "$(_tex(:widetilde, "s"))_i, $(_tex(:widetilde, "y"))_i"))_{i=k-m}^{k-1}``
 are transported into the tangent space ``T_{x_{k+1}} $(_math(:Manifold))``.

--- a/src/commons/records.jl
+++ b/src/commons/records.jl
@@ -151,16 +151,16 @@ end
 """
     RecordDualIterate(X)
 
-Create an [`RecordAction`](@ref) that records the dual base point,
-an [`RecordEntry`](@ref) of `o.X`.
+Create a [`RecordAction`](@ref) that records the dual iterate,
+an [`RecordEntry`](@ref) of the field `X` of the state.
 """
 RecordDualIterate(X) = RecordEntry(X, :X)
 
 """
     RecordDualBaseIterate(n)
 
-Create an [`RecordAction`](@ref) that records the dual base point,
-an [`RecordEntry`](@ref) of `o.n`.
+Create a [`RecordAction`](@ref) that records the dual base point,
+an [`RecordEntry`](@ref) of the field `n` of the state.
 """
 RecordDualBaseIterate(n) = RecordEntry(n, :n)
 
@@ -212,10 +212,10 @@ end
 
 
 """
-    RecordDualBaseChange(e)
+    RecordDualBaseChange()
 
-Create an [`RecordAction`](@ref) that records the dual base point change,
-an [`RecordEntryChange`](@ref) of `o.n` with distance to the last value to store a value.
+Create a [`RecordAction`](@ref) that records the dual base point change,
+an [`RecordEntryChange`](@ref) of the field `n` with distance to the last value to store a value.
 """
 function RecordDualBaseChange()
     return RecordEntryChange(:n, (p, o, x, y) -> distance(get_manifold(p, 2), x, y))
@@ -224,8 +224,8 @@ end
 """
     RecordDualChange()
 
-Create the action either with a given (shared) Storage, which can be set to the
-`values` Tuple, if that is provided).
+Create a [`RecordAction`](@ref) that records the change of the dual iterate,
+an [`RecordEntryChange`](@ref) of the field `X` with distance to the last value to store a value.
 """
 function RecordDualChange()
     return RecordEntryChange(:X, (p, o, x, y) -> distance(get_manifold(p, 2), x, y))
@@ -337,34 +337,34 @@ function status_summary(::RecordIteration; context::Symbol = :default)
 end
 
 """
-    RecordPrimalChange(a)
+    RecordPrimalChange()
 
-Create an [`RecordAction`](@ref) that records the primal value change,
-[`RecordChange`](@ref), to record the change of `o.p`.
+Create a [`RecordAction`](@ref) that records the primal value change,
+a [`RecordChange`](@ref), to record the change of the iterate `p`.
 """
 RecordPrimalChange() = RecordChange()
 
 """
-    RecordPrimalIterate(x)
+    RecordPrimalIterate(p)
 
-Create an [`RecordAction`](@ref) that records the primal point, an [`RecordIterate`](@ref) of `o.p`.
+Create a [`RecordAction`](@ref) that records the primal point, an [`RecordIterate`](@ref) of the iterate `p`.
 """
 RecordPrimalIterate(p) = RecordIterate(p)
 
 """
     RecordPrimalBaseChange()
 
-Create an [`RecordAction`](@ref) that records the primal base point change,
-an [`RecordEntryChange`](@ref) of `o.m` with distance to the last value to store a value.
+Create a [`RecordAction`](@ref) that records the primal base point change,
+an [`RecordEntryChange`](@ref) of the field `m` with distance to the last value to store a value.
 """
 function RecordPrimalBaseChange()
     return RecordEntryChange(:m, (p, o, x, y) -> distance(get_manifold(p, 1), x, y))
 end
 
 """
-    RecordPrimalBaseIterate(x)
+    RecordPrimalBaseIterate(m)
 
-Create an [`RecordAction`](@ref) that records the primal base point, an [`RecordEntry`](@ref) of `o.m`.
+Create a [`RecordAction`](@ref) that records the primal base point, an [`RecordEntry`](@ref) of the field `m` of the state.
 """
 RecordPrimalBaseIterate(m) = RecordEntry(m, :m)
 

--- a/src/commons/records.jl
+++ b/src/commons/records.jl
@@ -603,7 +603,7 @@ create a [`RecordAction`](@ref) where
   * `:Change`        to record the change of the iterates, see [`RecordChange`](@ref)
   * `:Cost`          to record the current cost function value
   * `:Gradient`      to record the gradient, see [`RecordGradient`](@ref)
-  * `:GradientNorm   to record the norm of the gradient, see [`RecordGradientNorm`](@ref)
+  * `:GradientNorm`: to record the norm of the gradient, see [`RecordGradientNorm`](@ref)
   * `:Iterate`       to record the iterate
   * `:Iteration`     to record the current iteration number
   * `:IterativeTime` to record the times taken for each iteration.

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -745,7 +745,8 @@ mutable struct BarzilaiBorweinStepsize{
         if max_stepsize <= min_stepsize
             throw(
                 DomainError(
-                    max_stepsize, "The upper bound for the step size lower bound.",
+                    max_stepsize,
+                    "The upper bound for the Barzilai–Borwein step size has to be larger than the lower bound $(min_stepsize).",
                 ),
             )
         end
@@ -1921,21 +1922,18 @@ function Base.show(io::IO, nls::NonmonotoneLinesearchStepsize)
     print(io, "bb_stepsize = ", nls.bb_stepsize, ", ")
     print(io, "last_stepsize = ", nls.last_stepsize, ", ")
     print(io, "memory_size = ", length(nls.old_costs), ", ")
-    print(io, "stepsize_reduction = ", nls.stepsize_reduction, ", ")
-    print(io, "sufficient_decrease = ", nls.sufficient_decrease, ", ")
     print(io, "retraction_method = ", nls.retraction_method, ", ")
-    print(io, "stop_when_stepsize_less = ", nls.stop_when_stepsize_less, ", ")
-    print(io, "stop_when_stepsize_exceeds = ", nls.stop_when_stepsize_exceeds, ", ")
-    print(io, "sufficient_decrease = ", nls.sufficient_decrease, ", ")
+    print(io, "stepsize_reduction = ", nls.stepsize_reduction, ", ")
+    print(io, "stop_decreasing_at_step = ", nls.stop_decreasing_at_step, ", ")
     print(io, "stop_increasing_at_step = ", nls.stop_increasing_at_step, ", ")
-    print(io, "stop_decreasing_at_step = ", nls.stop_decreasing_at_step)
+    print(io, "stop_when_stepsize_exceeds = ", nls.stop_when_stepsize_exceeds, ", ")
+    print(io, "stop_when_stepsize_less = ", nls.stop_when_stepsize_less, ", ")
+    print(io, "sufficient_decrease = ", nls.sufficient_decrease)
     return print(io, ")")
 end
 function status_summary(nls::NonmonotoneLinesearchStepsize; context::Symbol = :default)
     (context === :short) && return repr(nls)
     (context === :inline) && return "A Non-monotone linesearch using $(status_summary(nls.bb_stepsize; context = context))"
-    bb_stgr = status_summary(nls.bb_stepsize; context = context)
-
     return """
     Non-monotone linesearch
 

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -328,7 +328,7 @@ mutable struct ArmijoLinesearchStepsize{TRM <: AbstractRetractionMethod, P, I, F
         return ArmijoLinesearchStepsize(;
             additional_decrease_condition = additional_decrease_condition,
             additional_increase_condition = additional_increase_condition,
-            candidate_point = candidate_point, contraction_factor = cf, initial_stepsize = is, last_stepsize = ls,
+            candidate_point = maybe_wrap_variable(candidate_point), contraction_factor = cf, initial_stepsize = is, last_stepsize = ls,
             initial_guess = initial_guess, retraction_method = retraction_method,
             stop_when_stepsize_less = swsl, stop_when_stepsize_exceeds = swse, sufficient_decrease = sd,
             stop_increasing_at_step = sias, stop_decreasing_at_step = sdas, messages = msgs
@@ -770,13 +770,15 @@ mutable struct BarzileiBorweinStepsize{
         if max_stepsize <= min_stepsize
             throw(
                 DomainError(
-                    bb_max_stepsize, "The upper bound for the step size lower bound.",
+                    max_stepsize, "The upper bound for the step size lower bound.",
                 ),
             )
         end
-        return new{T, R, IRM, RM, VTM, typeof(storage)}(
+        X_ = maybe_wrap_variable(X)
+        p_ = maybe_wrap_variable(p)
+        return new{typeof(X_), R, IRM, RM, VTM, typeof(storage)}(
             inverse_retraction_method, min_stepsize, max_stepsize,
-            retraction_method, ManifoldsBase.copy(M, p, X), storage, strategy, vector_transport_method, X
+            retraction_method, ManifoldsBase.copy(M, p_, X_), storage, strategy, vector_transport_method, X_
         )
     end
 end
@@ -1000,7 +1002,9 @@ mutable struct CubicBracketingLinesearchStepsize{
             vector_transport_method::VTM = default_vector_transport_method(M),
             max_stepsize::Real = max_stepsize(M),
         ) where {R <: Real, I <: Integer, TRM, VTM, P, T}
-        return new{R, I, TRM, VTM, P, T}(candidate_direction, candidate_point, initial_stepsize, initial_stepsize, retraction_method, stepsize_increase, max_iterations, sufficient_curvature, min_bracket_width, hybrid, vector_transport_method, max_stepsize)
+        p = maybe_wrap_variable(candidate_point)
+        X = maybe_wrap_variable(candidate_direction)
+        return new{R, I, TRM, VTM, typeof(p), typeof(X)}(X, p, initial_stepsize, initial_stepsize, retraction_method, stepsize_increase, max_iterations, sufficient_curvature, min_bracket_width, hybrid, vector_transport_method, max_stepsize)
     end
 end
 function CubicBracketingLinesearchStepsize(M::AbstractManifold, p; kwargs...)
@@ -1166,11 +1170,7 @@ function get_univariate_triple!(mp::AbstractManoptProblem, cbls::CubicBracketing
 end
 
 function (cbls::CubicBracketingLinesearchStepsize)(
-        mp::AbstractManoptProblem,
-        s::AbstractManoptSolverState,
-        k::Int,
-        η = (-get_gradient(mp, get_iterate(s)));
-        kwargs...,
+        mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s))); kwargs...,
     )
     M = get_manifold(mp)
     p = get_iterate(s)
@@ -1482,8 +1482,9 @@ function DistanceOverGradientsStepsize(
     R = promote_type(R1, R2)
     id = convert(R, initial_distance)
     κ = convert(R, sectional_curvature_bound)
+    p_ = maybe_wrap_variable(p)
     return DistanceOverGradientsStepsize(;
-        initial_distance = id, max_distance = id, gradient_sum = zero(R), initial_point = copy(M, p),
+        initial_distance = id, max_distance = id, gradient_sum = zero(R), initial_point = copy(M, p_),
         use_curvature = use_curvature, sectional_curvature_bound = κ, last_stepsize = zero(R)
     )
 end
@@ -1690,14 +1691,8 @@ $(_kwargs(:retraction_method))
 $(_kwargs(:vector_transport_method))
 """
 mutable struct NonmonotoneLinesearchStepsize{
-        P,
-        T <: AbstractVector,
-        R <: Real,
-        I <: Integer,
-        TRM <: AbstractRetractionMethod,
-        MSGS <: NamedTuple,
-        IG,
-        BB <: BarzileiBorweinStepsize,
+        P, T <: AbstractVector, R <: Real, I <: Integer, TRM <: AbstractRetractionMethod,
+        MSGS <: NamedTuple, IG, BB <: BarzileiBorweinStepsize,
     } <: Linesearch
     bb_stepsize::BB
     candidate_point::P
@@ -1739,11 +1734,11 @@ mutable struct NonmonotoneLinesearchStepsize{
             M; p = p, min_stepsize = bb_min_stepsize, max_stepsize = bb_max_stepsize,
             inverse_retraction_method = inverse_retraction_method, retraction_method = retraction_method,
             vector_transport_method = vector_transport_method,
-            storage = storage,
-            strategy = strategy
+            storage = storage, strategy = strategy
         )
         return NonmonotoneLinesearchStepsize(
             M, bb;
+            p = p,
             initial_guess = initial_guess, memory_size = memory_size,
             retraction_method = retraction_method,
             stepsize_reduction = stepsize_reduction,
@@ -1776,8 +1771,9 @@ mutable struct NonmonotoneLinesearchStepsize{
             stepsize_less = StepsizeMessage{R, R}(),
             stepsize_exceeds = StepsizeMessage{R, R}(),
         )
-        return new{P, typeof(old_costs), R, I, TRM, typeof(msgs), IG, BBS}(
-            stepsize, p, initial_guess, 1.0, msgs, old_costs,
+        p_ = maybe_wrap_variable(p)
+        return new{typeof(p_), typeof(old_costs), R, I, TRM, typeof(msgs), IG, BBS}(
+            stepsize, p_, initial_guess, 1.0, msgs, old_costs,
             retraction_method,
             stepsize_reduction,
             stop_decreasing_at_step, stop_increasing_at_step, stop_when_stepsize_exceeds, stop_when_stepsize_less,
@@ -1786,7 +1782,7 @@ mutable struct NonmonotoneLinesearchStepsize{
     end
 end
 function NonmonotoneLinesearchStepsize(M::AbstractManifold, p; kwargs...)
-    return NonmonotoneLinesearchStepsize(M; p = allocate(p), kwargs...)
+    return NonmonotoneLinesearchStepsize(M; p = p, kwargs...)
 end
 function (a::NonmonotoneLinesearchStepsize)(
         mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s)));
@@ -2023,9 +2019,11 @@ mutable struct WolfePowellLinesearchStepsize{
             vector_transport_method::VTM, stop_increasing_at_step::I, stop_decreasing_at_step::I,
             messages::TMSG
         ) where {R <: Real, TRM <: AbstractRetractionMethod, VTM <: AbstractVectorTransportMethod, P, T, I <: Integer, TMSG}
-        return new{R, TRM, VTM, P, T, I, TMSG}(
+        p_ = maybe_wrap_variable(candidate_point)
+        X_ = maybe_wrap_variable(candidate_direction)
+        return new{R, TRM, VTM, typeof(p_), typeof(X_), I, TMSG}(
             sufficient_decrease, sufficient_curvature,
-            candidate_direction, candidate_point, last_stepsize, max_stepsize, retraction_method,
+            X_, p_, last_stepsize, max_stepsize, retraction_method,
             stop_when_stepsize_less, vector_transport_method, stop_increasing_at_step, stop_decreasing_at_step, messages
         )
     end
@@ -2281,10 +2279,7 @@ mutable struct WolfePowellBinaryLinesearchStepsize{
     end
 end
 function (a::WolfePowellBinaryLinesearchStepsize)(
-        amp::AbstractManoptProblem,
-        ams::AbstractManoptSolverState,
-        ::Int,
-        η = (-get_gradient(amp, get_iterate(ams)));
+        amp::AbstractManoptProblem, ams::AbstractManoptSolverState, ::Int, η = (-get_gradient(amp, get_iterate(ams)));
         kwargs...,
     )
     M = get_manifold(amp)

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -658,7 +658,7 @@ Note that for ``α=0`` this is the Riemannian variant of `WNGRad`.
 
 ## Keyword arguments
 
-* `adaptive=true`: switches the `gradient_reduction ``α`` (if `true`) to `0`.
+* `adaptive=true`: switches the `gradient_reduction` ``α`` (if `true`) to `0`.
 * `alternate_bound = (bk, hat_c) ->  min(gradient_bound == 0 ? 1.0 : gradient_bound, max(minimal_bound, bk / (3 * hat_c))`:
   how to determine ``$(_tex(:hat, "k"))_k`` as a function of `(bmin, bk, hat_c) -> hat_bk`
 * `count_threshold=4`:  an `Integer` for ``$(_tex(:hat, "c"))``

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -797,7 +797,7 @@ function (bb::BarzilaiBorweinStepsize)(
     #indirect strategy
     return if bb.strategy == :inverse
         if s1 > 0
-            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s1 / s2))
+            stepsize = clamp(s1 / s2, bb.min_stepsize, bb.max_stepsize)
         else
             stepsize = bb.max_stepsize
         end

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -719,8 +719,8 @@ mutable struct BarzilaiBorweinStepsize{
     function BarzilaiBorweinStepsize(
             M::AbstractManifold;
             p::P = rand(M), X::T = zero_vector(M, p),
-            min_stepsize::R = 1.0e-3,
-            max_stepsize::R = injectivity_radius(M) * 0.9,
+            min_stepsize::Real = 1.0e-3,
+            max_stepsize::Real = injectivity_radius(M) * 0.9,
             retraction_method::RM = default_retraction_method(M, typeof(p)),
             inverse_retraction_method::IRM = default_inverse_retraction_method(M, typeof(p)),
             storage::Union{Nothing, StoreStateAction} = StoreStateAction(
@@ -729,7 +729,7 @@ mutable struct BarzilaiBorweinStepsize{
             strategy::Symbol = :direct,
             vector_transport_method::VTM = default_vector_transport_method(M),
         ) where {
-            IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod, VTM <: AbstractVectorTransportMethod, P, R <: Real, T,
+            IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod, VTM <: AbstractVectorTransportMethod, P, T,
         }
         if strategy ∉ [:direct, :inverse, :alternating]
             @warn string(
@@ -749,6 +749,9 @@ mutable struct BarzilaiBorweinStepsize{
                 ),
             )
         end
+        # “Unify” the type of the two bounds, since they share a type parameter
+        R = float(promote_type(typeof(min_stepsize), typeof(max_stepsize)))
+        min_stepsize, max_stepsize = convert.(Ref(R), (min_stepsize, max_stepsize))
         X_ = maybe_wrap_variable(X)
         p_ = maybe_wrap_variable(p)
         return new{typeof(X_), R, IRM, RM, VTM, typeof(storage)}(
@@ -1783,26 +1786,25 @@ mutable struct NonmonotoneLinesearchStepsize{
     # This constructor is semi-legacy, since it passes down a lot of parameters to BB now
     function NonmonotoneLinesearchStepsize(
             M::AbstractManifold;
-            bb_min_stepsize::R = 1.0e-3,
-            bb_max_stepsize::R = 1.0e3,
+            bb_min_stepsize::Real = 1.0e-3,
+            bb_max_stepsize::Real = 1.0e3,
             p::P = allocate_result(M, rand),
             initial_guess::IG = (problem, state, k, last_stepsize, η) -> k == 0 ? 1.0 : last_stepsize,
             inverse_retraction_method = default_inverse_retraction_method(M, typeof(p)),
-            memory_size::I = 10,
+            memory_size::Integer = 10,
             retraction_method::TRM = default_retraction_method(M),
-            stepsize_reduction::R = 0.5,
-            stop_when_stepsize_less::R = 0.0,
-            stop_when_stepsize_exceeds::R = real(max_stepsize(M)),
-            stop_increasing_at_step::I = 100,
-            stop_decreasing_at_step::I = 1000,
+            stepsize_reduction::Real = 0.5,
+            stop_when_stepsize_less::Real = 0.0,
+            stop_when_stepsize_exceeds::Real = float(real(max_stepsize(M))),
+            stop_increasing_at_step::Integer = 100,
+            stop_decreasing_at_step::Integer = 1000,
             storage::Union{Nothing, StoreStateAction} = StoreStateAction(
                 M; store_fields = [:Iterate, :Gradient]
             ),
             strategy::Symbol = :direct,
-            sufficient_decrease::R = 1.0e-4,
+            sufficient_decrease::Real = 1.0e-4,
             vector_transport_method = default_vector_transport_method(M),
-        ) where {TRM, P, R <: Real, I <: Integer, IG}
-        stop_when_stepsize_exceeds = R(stop_when_stepsize_exceeds)
+        ) where {TRM, P, IG}
         bb = BarzilaiBorweinStepsize(
             M; p = p, min_stepsize = bb_min_stepsize, max_stepsize = bb_max_stepsize,
             inverse_retraction_method = inverse_retraction_method, retraction_method = retraction_method,
@@ -1826,16 +1828,30 @@ mutable struct NonmonotoneLinesearchStepsize{
             M::AbstractManifold, stepsize::BBS;
             p::P = rand(M),
             initial_guess::IG = (problem, state, k, last_stepsize, η) -> k == 0 ? 1.0 : last_stepsize,
-            memory_size::I = 10,
+            memory_size::Integer = 10,
             retraction_method::TRM = default_retraction_method(M),
-            stepsize_reduction::R = 0.5,
-            stop_when_stepsize_less::R = 0.0, stop_when_stepsize_exceeds::R = real(max_stepsize(M)),
-            stop_increasing_at_step::I = 100, stop_decreasing_at_step::I = 1000,
-            sufficient_decrease::R = 1.0e-4,
-        ) where {BBS <: Stepsize, P, IG, TRM, R, I}
+            stepsize_reduction::Real = 0.5,
+            stop_when_stepsize_less::Real = 0.0, stop_when_stepsize_exceeds::Real = float(real(max_stepsize(M))),
+            stop_increasing_at_step::Integer = 100, stop_decreasing_at_step::Integer = 1000,
+            sufficient_decrease::Real = 1.0e-4,
+        ) where {BBS <: Stepsize, P, IG, TRM}
         if memory_size <= 0
             throw(DomainError(memory_size, "The memory_size has to be greater than zero."))
         end
+        R = float(
+            promote_type(
+                typeof(stepsize_reduction), typeof(stop_when_stepsize_less),
+                typeof(stop_when_stepsize_exceeds), typeof(sufficient_decrease),
+            )
+        )
+        I = promote_type(typeof(stop_increasing_at_step), typeof(stop_decreasing_at_step))
+        stepsize_reduction, stop_when_stepsize_less, stop_when_stepsize_exceeds, sufficient_decrease =
+            convert.(
+            Ref(R),
+            (stepsize_reduction, stop_when_stepsize_less, stop_when_stepsize_exceeds, sufficient_decrease),
+        )
+        stop_increasing_at_step, stop_decreasing_at_step =
+            convert.(Ref(I), (stop_increasing_at_step, stop_decreasing_at_step))
         old_costs = zeros(memory_size)
         msgs = (;
             non_descent_direction = StepsizeMessage{R, R}(),
@@ -1846,7 +1862,7 @@ mutable struct NonmonotoneLinesearchStepsize{
         )
         p_ = maybe_wrap_variable(p)
         return new{typeof(p_), typeof(old_costs), R, I, TRM, typeof(msgs), IG, BBS}(
-            stepsize, p_, initial_guess, 1.0, msgs, old_costs,
+            stepsize, p_, initial_guess, one(R), msgs, old_costs,
             retraction_method,
             stepsize_reduction,
             stop_decreasing_at_step, stop_increasing_at_step, stop_when_stepsize_exceeds, stop_when_stepsize_less,

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -672,12 +672,10 @@ function AdaptiveWNGradient(args...; kwargs...)
     return ManifoldDefaultsFactory(Manopt.AdaptiveWNGradientStepsize, args...; requires_point = true, kwargs...)
 end
 
-## TODO Introduce the factory as well: BarzileiBorwein and document the formula there.
-
 @doc """
-    BarzileiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Stepsize
+    BarzilaiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Stepsize
 
-Compute a stepsize based on the Barzilei-Borwein rule. See [`BarzileiBorwein`](@ref)
+Compute a stepsize based on the Barzilai-Borwein rule. See [`BarzilaiBorwein`](@ref)
 for details
 
 # Fields
@@ -692,7 +690,7 @@ $(_fields(:vector_transport_method))
 
 # Constructor
 
-    BarzileiBorweinStepsize(M::AbstractManifold, p; kwargs...)
+    BarzilaiBorweinStepsize(M::AbstractManifold, p; kwargs...)
 
 ## Keyword arguments
 
@@ -704,7 +702,7 @@ $(_kwargs([:p, :retraction_method]))
 * `storage=`[`StoreStateAction`](@ref)`(M; store_fields=[:Iterate, :Gradient])`
 $(_kwargs([:vector_transport_method, :X]))
 """
-mutable struct BarzileiBorweinStepsize{
+mutable struct BarzilaiBorweinStepsize{
         T, R <: Real,
         IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod,
         VTM <: AbstractVectorTransportMethod, TSSA <: StoreStateAction,
@@ -718,7 +716,7 @@ mutable struct BarzileiBorweinStepsize{
     strategy::Symbol
     vector_transport_method::VTM
     y::T
-    function BarzileiBorweinStepsize(
+    function BarzilaiBorweinStepsize(
             M::AbstractManifold;
             p::P = rand(M), X::T = zero_vector(M, p),
             min_stepsize::R = 1.0e-3,
@@ -741,7 +739,7 @@ mutable struct BarzileiBorweinStepsize{
         end
         if min_stepsize <= 0.0
             throw(
-                DomainError(min_stepsize, "The lower bound for the Barzilei–Borwein step size has to be positive."),
+                DomainError(min_stepsize, "The lower bound for the Barzilai–Borwein step size has to be positive."),
             )
         end
         if max_stepsize <= min_stepsize
@@ -759,7 +757,7 @@ mutable struct BarzileiBorweinStepsize{
         )
     end
 end
-function (bb::BarzileiBorweinStepsize)(
+function (bb::BarzilaiBorweinStepsize)(
         mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s)));
         gradient = nothing, last_stepsize = nothing, kwargs...
     )
@@ -817,8 +815,8 @@ function (bb::BarzileiBorweinStepsize)(
         end
     end
 end
-function Base.show(io::IO, bbs::BarzileiBorweinStepsize)
-    print(io, "BarzileiBorweinStepsize(; ")
+function Base.show(io::IO, bbs::BarzilaiBorweinStepsize)
+    print(io, "BarzilaiBorweinStepsize(; ")
     print(io, "inverse_retraction_method = ", bbs.inverse_retraction_method, ", ")
     print(io, "min_stepsize = ", bbs.min_stepsize, ", ")
     print(io, "max_stepsize = ", bbs.max_stepsize, ", ")
@@ -828,11 +826,11 @@ function Base.show(io::IO, bbs::BarzileiBorweinStepsize)
     print(io, "vector_transport_method = ", bbs.vector_transport_method)
     return print(io, ")")
 end
-function status_summary(bbs::BarzileiBorweinStepsize; context::Symbol = :default)
+function status_summary(bbs::BarzilaiBorweinStepsize; context::Symbol = :default)
     (context === :short) && return repr(bbs)
-    (context === :inline) && return "An Barzilei–Borwein stepsize with strategy :$(bbs.strategy)."
+    (context === :inline) && return "An Barzilai–Borwein stepsize with strategy :$(bbs.strategy)."
     return """
-    Barzilei–Borwein stepsize
+    Barzilai–Borwein stepsize
 
     ## Parameters
     * min stepsize:              $(_MANOPT_INDENT)$(bbs.min_stepsize)
@@ -845,8 +843,8 @@ function status_summary(bbs::BarzileiBorweinStepsize; context::Symbol = :default
 end
 
 """
-    BarzileiBorwein(; kwargs...)
-    BarzileiBorwein(M::AbstractManifold; kwargs...)
+    BarzilaiBorwein(; kwargs...)
+    BarzilaiBorwein(M::AbstractManifold; kwargs...)
 
 Consider the current iterate and gradient ``p_k`` and ``X_k`` as well as the last
 iterate and gradient ``p_{k-1}`` and ``X_{k-1}``. Note that in a gradient scheme this also
@@ -899,10 +897,10 @@ $(_kwargs([:p, :retraction_method]))
 * `storage=`[`StoreStateAction`](@ref)`(M; store_fields=[:Iterate, :Gradient])`
 $(_kwargs([:vector_transport_method, :X]))
 
-$(_note(:ManifoldDefaultsFactory, "BarzileiBorweinStepsize"))
+$(_note(:ManifoldDefaultsFactory, "BarzilaiBorweinStepsize"))
 """
-function BarzileiBorwein(args...; kwargs...)
-    return ManifoldDefaultsFactory(Manopt.BarzileiBorweinStepsize, args...; kwargs...)
+function BarzilaiBorwein(args...; kwargs...)
+    return ManifoldDefaultsFactory(Manopt.BarzilaiBorweinStepsize, args...; kwargs...)
 end
 
 """
@@ -1305,8 +1303,25 @@ function Base.show(io::IO, cbls::CubicBracketingLinesearchStepsize)
         "CubicBracketingLinesearch(; initial_stepsize = $(cbls.initial_stepsize),  stepsize_increase = $(cbls.stepsize_increase),  sufficient_curvature = $(cbls.sufficient_curvature),  min_bracket_width = $(cbls.min_bracket_width),  hybrid = $(cbls.hybrid),  retraction_method = $(cbls.retraction_method),  vector_transport_method = $(cbls.vector_transport_method),  max_stepsize = $(cbls.max_stepsize))",
     )
 end
-function status_summary(cbls::CubicBracketingLinesearchStepsize)
-    return "$(cbls)\nand a computed last stepsize of $(cbls.last_stepsize)"
+function status_summary(cbls::CubicBracketingLinesearchStepsize; context = :default)
+    (context === :short) && return repr(cbls)
+    (context === :inline) && return "A Cubic bracketing linesearch."
+    return """
+    Cubic bracketing stepsize
+
+    ## Parameters
+
+    * hybrid:                    $(_MANOPT_INDENT)$(cbls.hybrid ? "true" : "false")
+    * initial stepsize:          $(_MANOPT_INDENT)$(cbls.initial_stepsize)
+    * last stepsize:             $(_MANOPT_INDENT)$(cbls.last_stepsize)
+    * minimal bracket width:     $(_MANOPT_INDENT)$(cbls.min_bracket_width)
+    * max_iterations:            $(_MANOPT_INDENT)$(cbls.max_iterations)
+    * max_stepsize:              $(_MANOPT_INDENT)$(cbls.max_stepsize)
+    * sufficient_curvature:      $(_MANOPT_INDENT)$(cbls.sufficient_curvature)
+    * retraction method:         $(_MANOPT_INDENT)$(cbls.retraction_method)
+    * stepsize_increase:         $(_MANOPT_INDENT)$(cbls.stepsize_increase)
+    * vector transport method:   $(_MANOPT_INDENT)$(cbls.vector_transport_method)
+    """
 end
 
 @doc """
@@ -1446,12 +1461,12 @@ function status_summary(s::DecreasingStepsize; context::Symbol = :default)
     ((l -  k*a)f^k) / (k + s)^e
 
     ## Parameters
-    * length l: $(_MANOPT_INDENT)$(s.length)
+    * length l:     $(_MANOPT_INDENT)$(s.length)
     * subtrahend a: $(_MANOPT_INDENT)$(s.subtrahend)
-    * factor f: $(_MANOPT_INDENT)$(s.factor)
-    * shift s: $(_MANOPT_INDENT)$(s.shift)
-    * exponent e: $(_MANOPT_INDENT)$(s.exponent)
-    * type : $(_MANOPT_INDENT):$(s.type)
+    * factor f:     $(_MANOPT_INDENT)$(s.factor)
+    * shift s:      $(_MANOPT_INDENT)$(s.shift)
+    * exponent e:   $(_MANOPT_INDENT)$(s.exponent)
+    * type :        $(_MANOPT_INDENT):$(s.type)
     """
 end
 """
@@ -1749,7 +1764,7 @@ $(_kwargs(:vector_transport_method))
 """
 mutable struct NonmonotoneLinesearchStepsize{
         P, T <: AbstractVector, R <: Real, I <: Integer, TRM <: AbstractRetractionMethod,
-        MSGS <: NamedTuple, IG, BB <: BarzileiBorweinStepsize,
+        MSGS <: NamedTuple, IG, BB <: BarzilaiBorweinStepsize,
     } <: Linesearch
     bb_stepsize::BB
     candidate_point::P
@@ -1787,7 +1802,7 @@ mutable struct NonmonotoneLinesearchStepsize{
             vector_transport_method = default_vector_transport_method(M),
         ) where {TRM, P, R <: Real, I <: Integer, IG}
         stop_when_stepsize_exceeds = R(stop_when_stepsize_exceeds)
-        bb = BarzileiBorweinStepsize(
+        bb = BarzilaiBorweinStepsize(
             M; p = p, min_stepsize = bb_min_stepsize, max_stepsize = bb_max_stepsize,
             inverse_retraction_method = inverse_retraction_method, retraction_method = retraction_method,
             vector_transport_method = vector_transport_method,
@@ -1927,7 +1942,7 @@ end
 
 A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
 
-Base on the step size from the [`BarzileiBorweinStepsize`](@ref) `α_k^{$(_tex(:text, "BB"))}`
+Base on the step size from the [`BarzilaiBorweinStepsize`](@ref) `α_k^{$(_tex(:text, "BB"))}`
 Then find the smallest ``h = 0, 1, 2, …`` such that
 
 ```math

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -700,7 +700,7 @@ for the `:direct` strategy, or
 τ_{k} =  $(_tex(:frac, "⟨s, y⟩_{p_k}", "⟨y, y⟩_{p_k}")),
 ```
 
-for the `:inverse` strategy. The `:alternating` stragety uses the direct for odd, the inverse for even iterations `k`.
+for the `:inverse` strategy. The `:alternating` strategy uses the direct for odd, the inverse for even iterations `k`.
 
 # Fields
 
@@ -1794,7 +1794,6 @@ function (a::NonmonotoneLinesearchStepsize)(
     )
     M = get_manifold(mp)
     p = get_iterate(s)
-    @info p
     X = isnothing(gradient) ? get_gradient(mp, p) : gradient
     f(M, p) = get_cost(M, get_objective(mp), p)
     reset_messages!(a.messages)

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -654,16 +654,59 @@ function AdaptiveWNGradient(args...; kwargs...)
     return ManifoldDefaultsFactory(Manopt.AdaptiveWNGradientStepsize, args...; requires_point = true, kwargs...)
 end
 
-@doc """
-    BarzileiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Linesearch
+## TODO Introduce the factory as well: BarzileiBorwein and document the formula there.
 
-A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
+@doc """
+    BarzileiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Stepsize
+
+Compute a stepsize based on the Barzilei-Borwein rule.
+
+Consider the current iterate and gradient ``p_k`` and ``X_k`` as well as the last
+iterate and gradient ``p_{k-1}`` and ``X_{k-1}``. Note that in a gradient scheme this also
+yields the relation that ``p_k = $(_tex(:exp))_{p_{k-1}}(αX_{k-1}))`` when ``α`` is the stepsize
+from the last iteration.
+
+We compute the changes of the iterates and the vectors, respectively
+
+```math
+s = $(_tex(:invretr))_{p_{k}}(p_{k-1})
+$(_tex(:quad))$(_tex(:text, " and "))$(_tex(:quad))
+y_{k} = X_k - $(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1}),
+```
+where alternatively ``s = α$(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1})`` if the `last_stepsize =`
+was passed to the function.
+
+Then the Barzilai—Borwein step size is
+
+```math
+α^{$(_tex(:text, "BB"))} = $(
+    _tex(
+        :cases,
+        "$(_tex(:min))(α_{$(_tex(:text, "max"))}, $(_tex(:max))(α_{$(_tex(:text, "min"))}, τ_{k})), & $(_tex(:text, "if")) ⟨s_{k}, y_{k}⟩_{p_k} > 0,",
+        "α_{$(_tex(:text, "max"))}, & $(_tex(:text, "else,"))"
+    )
+)
+```
+
+where
+
+```math
+τ_{k} = $(_tex(:frac, "⟨s, s⟩_{p_k}", "⟨s, y⟩_{p_k}")),
+```
+
+for the `:direct` strategy, or
+
+```math
+τ_{k} =  $(_tex(:frac, "⟨s, y⟩_{p_k}", "⟨y, y⟩_{p_k}")),
+```
+
+for the `:inverse` strategy. The `:alternating` stragety uses the direct for odd, the inverse for even iterations `k`.
 
 # Fields
 
 $(_fields(:inverse_retraction_method))
-* `min_stepsize`:          lower bound for the Barzilai-Borwein step size, greater than zero
-* `max_stepsize`:          upper bound for the Barzilai-Borwein step size, greater than `bb_min_stepsize`
+* `min_stepsize`:          lower bound ``α_{$(_tex(:text, "min"))}`` for the Barzilai-Borwein step size, greater than zero
+* `max_stepsize`:          upper bound ``α_{$(_tex(:text, "max"))}`` for the Barzilai-Borwein step size, greater than ``α_{$(_tex(:text, "min"))}``.
 $(_fields(:retraction_method))
 * `strategy`:                 defines if the new step size is computed using the `:direct`, `:inverse` or `:alternating` strategy
 * `storage`:                  (for `:Iterate` and `:Gradient`) a [`StoreStateAction`](@ref)
@@ -688,7 +731,7 @@ mutable struct BarzileiBorweinStepsize{
         T, R <: Real,
         IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod,
         VTM <: AbstractVectorTransportMethod, TSSA <: StoreStateAction,
-    } <: Linesearch
+    } <: Stepsize
     inverse_retraction_method::IRM
     min_stepsize::R
     max_stepsize::R
@@ -703,8 +746,8 @@ mutable struct BarzileiBorweinStepsize{
             p::P = rand(M), X::T = zero_vector(M, p),
             min_stepsize::R = 1.0e-3,
             max_stepsize::R = 1.0e3,
-            retraction_method::RM = default_retraction_method(M, P),
-            inverse_retraction_method::IRM = default_inverse_retraction_method(M, P),
+            retraction_method::RM = default_retraction_method(M, typeof(p)),
+            inverse_retraction_method::IRM = default_inverse_retraction_method(M, typeof(p)),
             storage::Union{Nothing, StoreStateAction} = StoreStateAction(
                 M; store_fields = [:Iterate, :Gradient]
             ),
@@ -713,7 +756,6 @@ mutable struct BarzileiBorweinStepsize{
         ) where {
             IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod, VTM <: AbstractVectorTransportMethod, P, R <: Real, T,
         }
-        stop_when_stepsize_exceeds = R(stop_when_stepsize_exceeds)
         if strategy ∉ [:direct, :inverse, :alternating]
             @warn string(
                 "The strategy '", strategy, "' is not defined. The 'direct' strategy is used instead.",
@@ -734,7 +776,7 @@ mutable struct BarzileiBorweinStepsize{
         end
         return new{T, R, IRM, RM, VTM, typeof(storage)}(
             inverse_retraction_method, min_stepsize, max_stepsize,
-            retraction_method, copy(M, p, X), storage, strategy, vector_transport_method, X
+            retraction_method, ManifoldsBase.copy(M, p, X), storage, strategy, vector_transport_method, X
         )
     end
 end
@@ -757,7 +799,7 @@ function (bb::BarzileiBorweinStepsize)(
     update_storage!(bb.storage, mp, s)
 
     # compute the y_k – difference of gradients, but remember to transport
-    vector_transport_to!(M, bb.y, old_p, old_X, p, bb.vector_transport_method)
+    vector_transport_to!(M, bb.y, p_old, X_old, p, bb.vector_transport_method)
     copyto!(M, bb.y, p, X .- bb.y)
     # for s_k there are two possibilities
     if !isnothing(last_stepsize) # Variant 1: Someone gave us the last stepsize, so we can just use -last_stepsize * X_old and transport it to the current iterate
@@ -765,7 +807,6 @@ function (bb::BarzileiBorweinStepsize)(
     else # Variant 2: otherwise we use the inverse retraction method
         inverse_retract!(M, bb.s, p, p_old, bb.inverse_retraction_method)
     end
-
     #compute the new Barzilai-Borwein step size
     s1 = real(inner(M, p, bb.s, bb.y))
     s2 = real(inner(M, p, bb.y, bb.y))
@@ -1654,13 +1695,11 @@ mutable struct NonmonotoneLinesearchStepsize{
         R <: Real,
         I <: Integer,
         TRM <: AbstractRetractionMethod,
-        VTM <: AbstractVectorTransportMethod,
-        TSSA <: StoreStateAction,
         MSGS <: NamedTuple,
         IG,
+        BB <: BarzileiBorweinStepsize,
     } <: Linesearch
-    bb_min_stepsize::R
-    bb_max_stepsize::R
+    bb_stepsize::BB
     candidate_point::P
     initial_guess::IG
     last_stepsize::R
@@ -1672,16 +1711,15 @@ mutable struct NonmonotoneLinesearchStepsize{
     stop_increasing_at_step::I
     stop_when_stepsize_exceeds::R
     stop_when_stepsize_less::R
-    storage::TSSA
-    strategy::Symbol
     sufficient_decrease::R
-    vector_transport_method::VTM
+    # This constructor is semi-legacy, since it passes down a lot of parameters to BB now
     function NonmonotoneLinesearchStepsize(
             M::AbstractManifold;
             bb_min_stepsize::R = 1.0e-3,
             bb_max_stepsize::R = 1.0e3,
             p::P = allocate_result(M, rand),
             initial_guess::IG = (problem, state, k, last_stepsize, η) -> k == 0 ? 1.0 : last_stepsize,
+            inverse_retraction_method = default_inverse_retraction_method(M, typeof(p)),
             memory_size::I = 10,
             retraction_method::TRM = default_retraction_method(M),
             stepsize_reduction::R = 0.5,
@@ -1694,29 +1732,39 @@ mutable struct NonmonotoneLinesearchStepsize{
             ),
             strategy::Symbol = :direct,
             sufficient_decrease::R = 1.0e-4,
-            vector_transport_method::VTM = default_vector_transport_method(M),
-        ) where {TRM, VTM, P, R <: Real, I <: Integer, IG}
+            vector_transport_method = default_vector_transport_method(M),
+        ) where {TRM, P, R <: Real, I <: Integer, IG}
         stop_when_stepsize_exceeds = R(stop_when_stepsize_exceeds)
-        if strategy ∉ [:direct, :inverse, :alternating]
-            @warn string(
-                "The strategy '", strategy, "' is not defined. The 'direct' strategy is used instead.",
-            )
-            strategy = :direct
-        end
-        if bb_min_stepsize <= 0.0
-            throw(
-                DomainError(
-                    bb_min_stepsize, "The lower bound for the step size bb_min_stepsize has to be greater than zero.",
-                ),
-            )
-        end
-        if bb_max_stepsize <= bb_min_stepsize
-            throw(
-                DomainError(
-                    bb_max_stepsize, "The upper bound for the step size bb_max_stepsize has to be greater than its lower bound bb_min_stepsize.",
-                ),
-            )
-        end
+        bb = BarzileiBorweinStepsize(
+            M; p = p, min_stepsize = bb_min_stepsize, max_stepsize = bb_max_stepsize,
+            inverse_retraction_method = inverse_retraction_method, retraction_method = retraction_method,
+            vector_transport_method = vector_transport_method,
+            storage = storage,
+            strategy = strategy
+        )
+        return NonmonotoneLinesearchStepsize(
+            M, bb;
+            initial_guess = initial_guess, memory_size = memory_size,
+            retraction_method = retraction_method,
+            stepsize_reduction = stepsize_reduction,
+            stop_when_stepsize_less = stop_when_stepsize_less,
+            stop_when_stepsize_exceeds = stop_when_stepsize_exceeds,
+            stop_increasing_at_step = stop_increasing_at_step,
+            stop_decreasing_at_step = stop_decreasing_at_step,
+            sufficient_decrease = sufficient_decrease,
+        )
+    end
+    function NonmonotoneLinesearchStepsize(
+            M::AbstractManifold, stepsize::BBS;
+            p::P = rand(M),
+            initial_guess::IG = (problem, state, k, last_stepsize, η) -> k == 0 ? 1.0 : last_stepsize,
+            memory_size::I = 10,
+            retraction_method::TRM = default_retraction_method(M),
+            stepsize_reduction::R = 0.5,
+            stop_when_stepsize_less::R = 0.0, stop_when_stepsize_exceeds::R = real(max_stepsize(M)),
+            stop_increasing_at_step::I = 100, stop_decreasing_at_step::I = 1000,
+            sufficient_decrease::R = 1.0e-4,
+        ) where {BBS <: Stepsize, P, IG, TRM, R, I}
         if memory_size <= 0
             throw(DomainError(memory_size, "The memory_size has to be greater than zero."))
         end
@@ -1728,24 +1776,12 @@ mutable struct NonmonotoneLinesearchStepsize{
             stepsize_less = StepsizeMessage{R, R}(),
             stepsize_exceeds = StepsizeMessage{R, R}(),
         )
-        return new{P, typeof(old_costs), R, I, TRM, VTM, typeof(storage), typeof(msgs), IG}(
-            bb_min_stepsize,
-            bb_max_stepsize,
-            p,
-            initial_guess,
-            1.0,
-            msgs,
-            old_costs,
+        return new{P, typeof(old_costs), R, I, TRM, typeof(msgs), IG, BBS}(
+            stepsize, p, initial_guess, 1.0, msgs, old_costs,
             retraction_method,
             stepsize_reduction,
-            stop_decreasing_at_step,
-            stop_increasing_at_step,
-            stop_when_stepsize_exceeds,
-            stop_when_stepsize_less,
-            storage,
-            strategy,
+            stop_decreasing_at_step, stop_increasing_at_step, stop_when_stepsize_exceeds, stop_when_stepsize_less,
             sufficient_decrease,
-            vector_transport_method,
         )
     end
 end
@@ -1753,88 +1789,22 @@ function NonmonotoneLinesearchStepsize(M::AbstractManifold, p; kwargs...)
     return NonmonotoneLinesearchStepsize(M; p = allocate(p), kwargs...)
 end
 function (a::NonmonotoneLinesearchStepsize)(
-        mp::AbstractManoptProblem,
-        s::AbstractManoptSolverState,
-        k::Int,
-        η = (-get_gradient(mp, get_iterate(s)));
-        gradient = nothing,
-        kwargs...,
+        mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s)));
+        gradient = nothing, kwargs...,
     )
-    grad = isnothing(gradient) ? get_gradient(mp, get_iterate(s)) : gradient
-    if !has_storage(a.storage, PointStorageKey(:Iterate)) ||
-            !has_storage(a.storage, VectorStorageKey(:Gradient))
-        # first time call: get old grad/iterate and store.
-        p_old = get_iterate(s)
-        X_old = grad
-    else
-        #fetch
-        p_old = get_storage(a.storage, PointStorageKey(:Iterate))
-        X_old = get_storage(a.storage, VectorStorageKey(:Gradient))
-    end
-    update_storage!(a.storage, mp, s)
-    return a(
-        get_manifold(mp), get_iterate(s), (M, p) -> get_cost(M, get_objective(mp), p),
-        grad, η, p_old, X_old, k;
-        kwargs...,
-    )
-end
-function (a::NonmonotoneLinesearchStepsize)(
-        M::mT, p, f::TF, X::T, η::T, old_p, old_X, iter::Int; kwargs...
-    ) where {mT <: AbstractManifold, TF, T}
+    M = get_manifold(mp)
+    p = get_iterate(s)
+    @info p
+    X = isnothing(gradient) ? get_gradient(mp, p) : gradient
+    f(M, p) = get_cost(M, get_objective(mp), p)
     reset_messages!(a.messages)
-    #find the difference between the current and previous gradient after the previous gradient is transported to the current tangent space
-    grad_diff = X - vector_transport_to(M, old_p, old_X, p, a.vector_transport_method)
-    #transport the previous step into the tangent space of the current manifold point
+    initial_stepsize = a.initial_guess(M, p, k, a.last_stepsize, η)
 
-    initial_stepsize = a.initial_guess(M, p, iter, a.last_stepsize, η)
-
-    x_diff =
-        -initial_stepsize *
-        vector_transport_to(M, old_p, old_X, p, a.vector_transport_method)
-
-    #compute the new Barzilai-Borwein step size
-    s1 = real(inner(M, p, x_diff, grad_diff))
-    s2 = real(inner(M, p, grad_diff, grad_diff))
-    s2 = s2 == 0 ? 1.0 : s2
-    s3 = real(inner(M, p, x_diff, x_diff))
-    #indirect strategy
-    if a.strategy == :inverse
-        if s1 > 0
-            BarzilaiBorwein_stepsize = min(
-                a.bb_max_stepsize, max(a.bb_min_stepsize, s1 / s2)
-            )
-        else
-            BarzilaiBorwein_stepsize = a.bb_max_stepsize
-        end
-        #alternating strategy
-    elseif a.strategy == :alternating
-        if s1 > 0
-            if iter % 2 == 0
-                BarzilaiBorwein_stepsize = min(
-                    a.bb_max_stepsize, max(a.bb_min_stepsize, s1 / s2)
-                )
-            else
-                BarzilaiBorwein_stepsize = min(
-                    a.bb_max_stepsize, max(a.bb_min_stepsize, s3 / s1)
-                )
-            end
-        else
-            BarzilaiBorwein_stepsize = a.bb_max_stepsize
-        end
-        #direct strategy
-    else
-        if s1 > 0
-            BarzilaiBorwein_stepsize = min(
-                a.bb_max_stepsize, max(a.bb_min_stepsize, s2 / s1)
-            )
-        else
-            BarzilaiBorwein_stepsize = a.bb_max_stepsize
-        end
-    end
+    αBB = a.bb_stepsize(mp, s, k, η; gradient = X, last_stepsize = initial_stepsize, kwargs...)
 
     memory_size = length(a.old_costs)
-    if iter <= memory_size
-        a.old_costs[iter] = f(M, p)
+    if k <= memory_size
+        a.old_costs[k] = f(M, p)
     else
         a.old_costs[1:(memory_size - 1)] = a.old_costs[2:memory_size]
         a.old_costs[memory_size] = f(M, p)
@@ -1849,8 +1819,8 @@ function (a::NonmonotoneLinesearchStepsize)(
         swse = (a.stop_when_stepsize_exceeds / l)
     end
     a.last_stepsize = linesearch_backtrack!(
-        M, a.candidate_point, f, p, BarzilaiBorwein_stepsize, a.sufficient_decrease, a.stepsize_reduction, η;
-        lf0 = maximum(view(a.old_costs, 1:min(iter, memory_size))),
+        M, a.candidate_point, f, p, αBB, a.sufficient_decrease, a.stepsize_reduction, η;
+        lf0 = maximum(view(a.old_costs, 1:min(k, memory_size))),
         gradient = X,
         retraction_method = a.retraction_method,
         stop_when_stepsize_less = (a.stop_when_stepsize_less / l),
@@ -1864,7 +1834,7 @@ end
 function Base.show(io::IO, a::NonmonotoneLinesearchStepsize)
     return print(
         io,
-        "NonmonotoneLinesearch(; last_stepsize = $(a.last_stepsize), bb_max_stepsize = $(a.bb_max_stepsize), bb_min_stepsize = $(a.bb_min_stepsize), memory_size = $(length(a.old_costs)), stepsize_reduction = $(a.stepsize_reduction), strategy = :$(a.strategy), sufficient_decrease = $(a.sufficient_decrease), retraction_method = $(a.retraction_method), vector_transport_method = $(a.vector_transport_method))",
+        "NonmonotoneLinesearch(; last_stepsize = $(a.last_stepsize), memory_size = $(length(a.old_costs)), stepsize_reduction = $(a.stepsize_reduction), sufficient_decrease = $(a.sufficient_decrease), retraction_method = $(a.retraction_method))",
     )
 end
 function get_message(a::NonmonotoneLinesearchStepsize)
@@ -1878,44 +1848,8 @@ end
 
 A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
 
-This method first computes
-
-```math
-y_{k} = $(_tex(:grad))f(p_{k}) - $(_math(:VectorTransport, "p_{k-1}", "p_k"))$(_tex(:grad))f(p_{k-1})
-```
-
-and
-```math
-s_{k} = - α_{k-1} ⋅ $(_math(:VectorTransport, "p_{k-1}", "p_k"))$(_tex(:grad))f(p_{k-1}),
-```
-
-where ``α_{k-1}`` is the step size computed in the last iteration and ``$(_math(:VectorTransport))`` is a vector transport.
-Then the Barzilai—Borwein step size is
-
-```math
-α_k^{$(_tex(:text, "BB"))} = $(
-    _tex(
-        :cases,
-        "$(_tex(:min))(α_{$(_tex(:text, "max"))}, $(_tex(:max))(α_{$(_tex(:text, "min"))}, τ_{k})), & $(_tex(:text, "if")) ⟨s_{k}, y_{k}⟩_{p_k} > 0,",
-        "α_{$(_tex(:text, "max"))}, & $(_tex(:text, "else,"))"
-    )
-)
-```
-
-where
-
-```math
-τ_{k} = $(_tex(:frac, "⟨s_{k}, s_{k}⟩_{p_k}", "⟨s_{k}, y_{k}⟩_{p_k}")),
-```
-
-if the direct strategy is chosen, or
-
-```math
-τ_{k} =  $(_tex(:frac, "⟨s_{k}, y_{k}⟩_{p_k}", "⟨y_{k}, y_{k}⟩_{p_k}")),
-```
-
-in case of the inverse strategy or an alternation between the two in cases for
-the alternating strategy. Then find the smallest ``h = 0, 1, 2, …`` such that
+Base on the step size from the [`BazileinBorweinStepsize`](@ref) `α_k^{$(_tex(:text, "BB"))}`
+Then find the smallest ``h = 0, 1, 2, …`` such that
 
 ```math
 f($(_tex(:retr))_{p_k}(- σ^h α_k^{$(_tex(:text, "BB"))} $(_tex(:grad))f(p_k)))  ≤

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -659,48 +659,8 @@ end
 @doc """
     BarzileiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Stepsize
 
-Compute a stepsize based on the Barzilei-Borwein rule.
-
-Consider the current iterate and gradient ``p_k`` and ``X_k`` as well as the last
-iterate and gradient ``p_{k-1}`` and ``X_{k-1}``. Note that in a gradient scheme this also
-yields the relation that ``p_k = $(_tex(:exp))_{p_{k-1}}(αX_{k-1}))`` when ``α`` is the stepsize
-from the last iteration.
-
-We compute the changes of the iterates and the vectors, respectively
-
-```math
-s = $(_tex(:invretr))_{p_{k}}(p_{k-1})
-$(_tex(:quad))$(_tex(:text, " and "))$(_tex(:quad))
-y_{k} = X_k - $(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1}),
-```
-where alternatively ``s = α$(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1})`` if the `last_stepsize =`
-was passed to the function.
-
-Then the Barzilai—Borwein step size is
-
-```math
-α^{$(_tex(:text, "BB"))} = $(
-    _tex(
-        :cases,
-        "$(_tex(:min))(α_{$(_tex(:text, "max"))}, $(_tex(:max))(α_{$(_tex(:text, "min"))}, τ_{k})), & $(_tex(:text, "if")) ⟨s_{k}, y_{k}⟩_{p_k} > 0,",
-        "α_{$(_tex(:text, "max"))}, & $(_tex(:text, "else,"))"
-    )
-)
-```
-
-where
-
-```math
-τ_{k} = $(_tex(:frac, "⟨s, s⟩_{p_k}", "⟨s, y⟩_{p_k}")),
-```
-
-for the `:direct` strategy, or
-
-```math
-τ_{k} =  $(_tex(:frac, "⟨s, y⟩_{p_k}", "⟨y, y⟩_{p_k}")),
-```
-
-for the `:inverse` strategy. The `:alternating` strategy uses the direct for odd, the inverse for even iterations `k`.
+Compute a stepsize based on the Barzilei-Borwein rule. See [`BarzileiBorwein`](@ref)
+for details
 
 # Fields
 
@@ -714,7 +674,6 @@ $(_fields(:vector_transport_method))
 
 # Constructor
 
-    BarzileiBorweinStepsize(M::AbstractManifold; kwargs...)
     BarzileiBorweinStepsize(M::AbstractManifold, p; kwargs...)
 
 ## Keyword arguments
@@ -722,10 +681,10 @@ $(_fields(:vector_transport_method))
 $(_kwargs(:inverse_retraction_method))
 * `min_stepsize=1e-3`
 * `max_stepsize=1e3`
-$(_kwargs(:retraction_method))
+$(_kwargs([:p, :retraction_method]))
 * `strategy=:direct`
 * `storage=`[`StoreStateAction`](@ref)`(M; store_fields=[:Iterate, :Gradient])`
-$(_kwargs(:vector_transport_method))
+$(_kwargs([:vector_transport_method, :X]))
 """
 mutable struct BarzileiBorweinStepsize{
         T, R <: Real,
@@ -840,8 +799,92 @@ function (bb::BarzileiBorweinStepsize)(
         end
     end
 end
-function Base.show(io::IO, a::BarzileiBorweinStepsize)
-    return print(io, "BarzileiBorweinStepsize TODO")
+function Base.show(io::IO, bbs::BarzileiBorweinStepsize)
+    print(io, "BarzileiBorweinStepsize(; ")
+    print(io, "inverse_retraction_method = ", bbs.inverse_retraction_method, ", ")
+    print(io, "min_stepsize = ", bbs.min_stepsize, ", ")
+    print(io, "max_stepsize = ", bbs.max_stepsize, ", ")
+    print(io, "retraction_method = ", bbs.retraction_method, ", ")
+    print(io, "storage = ", bbs.storage, ", ")
+    print(io, "strategy = :", bbs.strategy, ", ")
+    print(io, "vector_transport_method = ", bbs.vector_transport_method)
+    return print(io, ")")
+end
+function status_summary(bbs::BarzileiBorweinStepsize; context::Symbol = :default)
+    (context === :short) && return repr(bbs)
+    (context === :inline) && return "An Barzilei–Borwein stepsize with strategy :$(bbs.strategy)."
+    return """
+    Barzilei–Borwein stepsize
+
+    ## Parameters
+    * min stepsize:              $(_MANOPT_INDENT)$(bbs.min_stepsize)
+    * max stepsize:              $(_MANOPT_INDENT)$(bbs.max_stepsize)
+    * strategy:                  $(_MANOPT_INDENT):$(bbs.strategy)
+    * inverse retraction method: $(_MANOPT_INDENT)$(bbs.inverse_retraction_method)
+    * retraction method:         $(_MANOPT_INDENT)$(bbs.retraction_method)
+    * vector transport method:   $(_MANOPT_INDENT)$(bbs.vector_transport_method)
+    """
+end
+
+"""
+    BarzileiBorwein(; kwargs...)
+    BarzileiBorwein(M::AbstractManifold; kwargs...)
+
+Consider the current iterate and gradient ``p_k`` and ``X_k`` as well as the last
+iterate and gradient ``p_{k-1}`` and ``X_{k-1}``. Note that in a gradient scheme this also
+yields the relation that ``p_k = $(_tex(:exp))_{p_{k-1}}(αX_{k-1}))`` when ``α`` is the stepsize
+from the last iteration.
+
+We compute the changes of the iterates and the vectors, respectively
+
+```math
+s = $(_tex(:invretr))_{p_{k}}(p_{k-1})
+$(_tex(:quad))$(_tex(:text, " and "))$(_tex(:quad))
+y_{k} = X_k - $(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1}),
+```
+where alternatively ``s = α$(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1})`` if the `last_stepsize =`
+was passed to the function.
+
+Then the Barzilai—Borwein step size is
+
+```math
+α^{$(_tex(:text, "BB"))} = $(
+    _tex(
+        :cases,
+        "$(_tex(:min))(α_{$(_tex(:text, "max"))}, $(_tex(:max))(α_{$(_tex(:text, "min"))}, τ_{k})), & $(_tex(:text, "if")) ⟨s_{k}, y_{k}⟩_{p_k} > 0,",
+        "α_{$(_tex(:text, "max"))}, & $(_tex(:text, "else,"))"
+    )
+)
+```
+
+where
+
+```math
+τ_{k} = $(_tex(:frac, "⟨s, s⟩_{p_k}", "⟨s, y⟩_{p_k}")),
+```
+
+for the `:direct` strategy, or
+
+```math
+τ_{k} =  $(_tex(:frac, "⟨s, y⟩_{p_k}", "⟨y, y⟩_{p_k}")),
+```
+
+for the `:inverse` strategy. The `:alternating` strategy uses the direct for odd, the inverse for even iterations `k`.
+
+## Keyword arguments
+
+$(_kwargs(:inverse_retraction_method))
+* `min_stepsize=1e-3`
+* `max_stepsize=1e3`
+$(_kwargs([:p, :retraction_method]))
+* `strategy=:direct`
+* `storage=`[`StoreStateAction`](@ref)`(M; store_fields=[:Iterate, :Gradient])`
+$(_kwargs([:vector_transport_method, :X]))
+
+$(_note(:ManifoldDefaultsFactory, "BarzileiBorweinStepsize"))
+"""
+function BarzileiBorwein(args...; kwargs...)
+    return ManifoldDefaultsFactory(Manopt.BarzileiBorweinStepsize, args...; kwargs...)
 end
 
 """
@@ -877,12 +920,8 @@ function ConstantStepsize(
     return ConstantStepsize{R}(length, type)
 end
 function (cs::ConstantStepsize)(
-        amp::AbstractManoptProblem,
-        ams::AbstractManoptSolverState,
-        ::Any,
-        args...;
-        gradient = nothing,
-        kwargs...,
+        amp::AbstractManoptProblem, ams::AbstractManoptSolverState, ::Any, args...;
+        gradient = nothing, kwargs...,
     )
     s = cs.length
     if cs.type == :absolute
@@ -1827,11 +1866,37 @@ function (a::NonmonotoneLinesearchStepsize)(
     )
     return a.last_stepsize
 end
-function Base.show(io::IO, a::NonmonotoneLinesearchStepsize)
-    return print(
-        io,
-        "NonmonotoneLinesearch(; last_stepsize = $(a.last_stepsize), memory_size = $(length(a.old_costs)), stepsize_reduction = $(a.stepsize_reduction), sufficient_decrease = $(a.sufficient_decrease), retraction_method = $(a.retraction_method))",
-    )
+function Base.show(io::IO, nls::NonmonotoneLinesearchStepsize)
+    print(io, "NonmonotoneLinesearch(; ")
+    print(io, "bb_stepsize = ", nls.bb_stepsize, ", ")
+    print(io, "last_stepsize = ", nls.last_stepsize, ", ")
+    print(io, "memory_size = ", length(nls.old_costs), ", ")
+    print(io, "stepsize_reduction = ", nls.stepsize_reduction, ", ")
+    print(io, "sufficient_decrease = ", nls.sufficient_decrease, ", ")
+    print(io, "retraction_method = ", nls.retraction_method, ", ")
+    print(io, "stop_when_stepsize_less = ", nls.stop_when_stepsize_less, ", ")
+    print(io, "stop_when_stepsize_exceeds = ", nls.stop_when_stepsize_exceeds, ", ")
+    print(io, "sufficient_decrease = ", nls.sufficient_decrease, ", ")
+    print(io, "stop_increasing_at_step = ", nls.stop_increasing_at_step, ", ")
+    print(io, "stop_decreasing_at_step = ", nls.stop_decreasing_at_step)
+    return print(io, ")")
+end
+function status_summary(nls::NonmonotoneLinesearchStepsize; context::Symbol = :default)
+    (context === :short) && return repr(nls)
+    (context === :inline) && return "A Non-monotone linesearch using $(status_summary(nls.bb_stepsize; context = context))"
+    bb_stgr = status_summary(nls.bb_stepsize; context = context)
+
+    return """
+    Non-monotone linesearch
+
+    ## Stepsize
+    $(_in_str(status_summary(nls.bb_stepsize; context = context); indent = 1, headers = 1))
+
+    ## Parameters
+    * memory_size:         $(_MANOPT_INDENT)$(length(nls.old_costs))
+    * retraction method:   $(_MANOPT_INDENT)$(nls.retraction_method)
+    * sufficient decrease: $(_MANOPT_INDENT)$(nls.sufficient_decrease)
+    """
 end
 function get_message(a::NonmonotoneLinesearchStepsize)
     s = [get_message(kv[1], kv[2]) for kv in pairs(a.messages)]
@@ -1844,7 +1909,7 @@ end
 
 A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
 
-Base on the step size from the [`BazileinBorweinStepsize`](@ref) `α_k^{$(_tex(:text, "BB"))}`
+Base on the step size from the [`BarzileiBorweinStepsize`](@ref) `α_k^{$(_tex(:text, "BB"))}`
 Then find the smallest ``h = 0, 1, 2, …`` such that
 
 ```math
@@ -1876,7 +1941,9 @@ $(_kwargs(:retraction_method))
 * `stop_when_stepsize_less=0.0`: smallest stepsize when to stop (the last one before is taken)
 * `stop_when_stepsize_exceeds=`[`max_stepsize`](@ref)`(M)`: largest stepsize when to stop to avoid leaving the injectivity radius
 * `stop_increasing_at_step=100`:  last step to increase the stepsize (phase 1),
-* `stop_decreasing_at_step=1000`: last step size to decrease the stepsize (phase 2),
+* `stop_decreasing_at_step=1000`: last step size to decrease the stepsize (phase 2)
+
+$(_note(:ManifoldDefaultsFactory, "NonmonotoneLinesearchStepsize"))
 """
 function NonmonotoneLinesearch(args...; kwargs...)
     return ManifoldDefaultsFactory(NonmonotoneLinesearchStepsize, args...; requires_point = true, kwargs...)

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -810,7 +810,7 @@ function (bb::BarzilaiBorweinStepsize)(
         end
     else # default: direct strategy
         if s1 > 0
-            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s2 / s1))
+            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s3 / s1))
         else
             stepsize = bb.max_stepsize
         end
@@ -1867,7 +1867,7 @@ function (a::NonmonotoneLinesearchStepsize)(
     X = isnothing(gradient) ? get_gradient(mp, p) : gradient
     f(M, p) = get_cost(M, get_objective(mp), p)
     reset_messages!(a.messages)
-    initial_stepsize = a.initial_guess(M, p, k, a.last_stepsize, η)
+    initial_stepsize = a.initial_guess(mp, s, k, a.last_stepsize, η)
 
     αBB = a.bb_stepsize(mp, s, k, η; gradient = X, last_stepsize = initial_stepsize, kwargs...)
 

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -2415,10 +2415,12 @@ function (a::WolfePowellBinaryLinesearchStepsize)(
         a.sufficient_curvature * get_differential(amp, p, η; Y = X_tmp)
     while (nAt || nWt) &&
             (t > a.stop_when_stepsize_less) &&
-            ((α + β) / 2 - 1 > a.stop_when_stepsize_less)
+            (β - α > a.stop_when_stepsize_less)
         nAt && (β = t)            # A(t) fails
         (!nAt && nWt) && (α = t)  # A(t) holds but W(t) fails
+        t_old = t
         t = isinf(β) ? 2 * α : (α + β) / 2
+        (t == t_old) && break # the bisection cannot make further progress
         # Update trial point
         ManifoldsBase.retract_fused!(M, xNew, get_iterate(ams), η, t, a.retraction_method)
         fNew = get_cost(amp, xNew)

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -141,6 +141,24 @@ function (::ArmijoInitialGuess)(
     return ifelse(isfinite(max_step), min(l, max_step / grad_norm), l)
 end
 
+"""
+    StepsizeInitialGuess{S} <: AbstractInitialLinesearchGuess
+
+Use a [`Stepsize`](@ref) as initial guess for a linesearch
+
+# Constructor
+
+    StepsizeInitialGuess(stepsize::S)
+"""
+struct StepsizeInitialGuess{S <: Stepsize} <: AbstractInitialLinesearchGuess
+    stepsize::S
+end
+
+function (sig::StepsizeInitialGuess)(
+        mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, l = nothing, η = (-get_gradient(mp, get_iterate(s))); kwargs...
+    )
+    return sig.stepsize(mp, s, k, η; last_stepsize = l, kwargs...)
+end
 
 #
 #

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -859,12 +859,16 @@ from the last iteration.
 We compute the changes of the iterates and the vectors, respectively
 
 ```math
-s = $(_tex(:invretr))_{p_{k}}(p_{k-1})
+s_{k} = $(_tex(:invretr))_{p_{k}}(p_{k-1})
 $(_tex(:quad))$(_tex(:text, " and "))$(_tex(:quad))
 y_{k} = X_k - $(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1}),
 ```
-where alternatively ``s = α$(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1})`` if the `last_stepsize =`
-was passed to the function.
+where alternatively ``s_{k} = α_{k-1}$(_math(:VectorTransport, "p_{k-1}", "p_k"))(X_{k-1})`` if
+the last step size ``α_{k-1}`` was passed as the `last_stepsize =` keyword.
+
+If there are not prior iterate ``p_{k-1}`` and and gradient ``X_{k-1}`` available,
+both are set to their current counterpart which yields that ``s_{k} = y_{k} = 0`` are both
+the zero vector.
 
 Then the Barzilai—Borwein step size is
 
@@ -881,16 +885,19 @@ Then the Barzilai—Borwein step size is
 where
 
 ```math
-τ_{k} = $(_tex(:frac, "⟨s, s⟩_{p_k}", "⟨s, y⟩_{p_k}")),
+τ_{k} = $(_tex(:frac, "⟨s_{k}, s_{k}⟩_{p_k}", "⟨s_{k}, y_{k}⟩_{p_k}")),
 ```
 
 for the `:direct` strategy, or
 
 ```math
-τ_{k} =  $(_tex(:frac, "⟨s, y⟩_{p_k}", "⟨y, y⟩_{p_k}")),
+τ_{k} =  $(_tex(:frac, "⟨s_{k}, y_{k}⟩_{p_k}", "⟨y_{k}, y_{k}⟩_{p_k}")),
 ```
 
 for the `:inverse` strategy. The `:alternating` strategy uses the direct for odd, the inverse for even iterations `k`.
+
+In the initial step, that is, for the case that there are no prior iterate and gradient,
+the inner product ``⟨s_{k}, y_{k}⟩_{p_k} = 0``, so that the maximal step size ``α_{$(_tex(:text, "max"))}`` will be returned for this case.
 
 ## Keyword arguments
 

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -805,16 +805,16 @@ function (bb::BarzilaiBorweinStepsize)(
     elseif bb.strategy == :alternating
         if s1 > 0
             if k % 2 == 0
-                stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s1 / s2))
+                stepsize = clamp(s1 / s2, bb.min_stepsize, bb.max_stepsize)
             else
-                stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s3 / s1))
+                stepsize = clamp(s3 / s1, bb.min_stepsize, bb.max_stepsize)
             end
         else
             stepsize = bb.max_stepsize
         end
     else # default: direct strategy
         if s1 > 0
-            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s3 / s1))
+            stepsize = clamp(s3 / s1, bb.min_stepsize, bb.max_stepsize)
         else
             stepsize = bb.max_stepsize
         end

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -1781,8 +1781,9 @@ mutable struct NonmonotoneLinesearchStepsize{
         )
     end
 end
+# Handle this as allocating case:
 function NonmonotoneLinesearchStepsize(M::AbstractManifold, p; kwargs...)
-    return NonmonotoneLinesearchStepsize(M; p = p, kwargs...)
+    return NonmonotoneLinesearchStepsize(M; p = copy(M, p), kwargs...)
 end
 function (a::NonmonotoneLinesearchStepsize)(
         mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s)));

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -783,6 +783,7 @@ function (bb::BarzilaiBorweinStepsize)(
         vector_transport_to!(M, bb.s, p_old, -last_stepsize * X_old, p, bb.vector_transport_method)
     else # Variant 2: otherwise we use the inverse retraction method
         inverse_retract!(M, bb.s, p, p_old, bb.inverse_retraction_method)
+        bb.s = -bb.s
     end
     #compute the new Barzilai-Borwein step size
     s1 = real(inner(M, p, bb.s, bb.y))

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -1720,28 +1720,29 @@ function DistanceOverGradients(args...; kwargs...)
 end
 
 @doc """
-    NonmonotoneLinesearchStepsize{P,T,R<:Real,I<:Integer,TRM,VTM,TSSA,MSGS,IG} <: Linesearch
+    NonmonotoneLinesearchStepsize{P,T,R<:Real,I<:Integer,TRM,MSGS,IG,BB} <: Linesearch
 
 A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
 
 # Fields
 
+* `bb_stepsize`:                the [`BarzilaiBorweinStepsize`](@ref) providing ``α_k^{$(_tex(:text, "BB"))}``
+* `candidate_point`:            to store an interim result
 $(_fields(:initial_guess))
-* `memory_size`:           number of iterations after which the cost value needs to be lower than the current one
-* `bb_min_stepsize`:          lower bound for the Barzilai-Borwein step size, greater than zero
-* `bb_max_stepsize`:          upper bound for the Barzilai-Borwein step size, greater than `bb_min_stepsize`
-* `last_stepsize`:     the last computed stepsize
+* `last_stepsize`:              the last computed stepsize
+* `messages`:                   a `NamedTuple` of [`StepsizeMessage`](@ref)s reporting on the last step
+* `old_costs`:                  the last cost values; its length is the memory size, that is the
+  number of iterations after which the cost value needs to be lower than the current one
 $(_fields(:retraction_method))
-* `strategy`:                 defines if the new step size is computed using the `:direct`, `:inverse` or `:alternating` strategy
-* `storage`:                  (for `:Iterate` and `:Gradient`) a [`StoreStateAction`](@ref)
-* `stepsize_reduction`:       step size reduction factor contained in the interval (0,1)
-* `sufficient_decrease`:     sufficient decrease parameter contained in the interval (0,1)
-$(_fields(:vector_transport_method))
-* `candidate_point`:          to store an interim result
+* `stepsize_reduction`:         step size reduction factor contained in the interval ``(0,1)``
+* `stop_decreasing_at_step`:    last step size to decrease the stepsize (phase 2)
+* `stop_increasing_at_step`:    last step to increase the stepsize (phase 1)
+* `stop_when_stepsize_exceeds`: largest stepsize when to stop
 * `stop_when_stepsize_less`:    smallest stepsize when to stop (the last one before is taken)
-* `stop_when_stepsize_exceeds`: largest stepsize when to stop.
-* `stop_increasing_at_step`:    last step to increase the stepsize (phase 1),
-* `stop_decreasing_at_step`:    last step size to decrease the stepsize (phase 2),
+* `sufficient_decrease`:        sufficient decrease parameter contained in the interval ``(0,1)``
+
+The bounds for the Barzilai-Borwein step size, its `strategy`, its `storage` and the vector
+transport it uses are stored within the `bb_stepsize`.
 
 # Constructor
 

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -722,7 +722,7 @@ mutable struct BarzileiBorweinStepsize{
             M::AbstractManifold;
             p::P = rand(M), X::T = zero_vector(M, p),
             min_stepsize::R = 1.0e-3,
-            max_stepsize::R = 1.0e3,
+            max_stepsize::R = injectivity_radius(M) * 0.9,
             retraction_method::RM = default_retraction_method(M, typeof(p)),
             inverse_retraction_method::IRM = default_inverse_retraction_method(M, typeof(p)),
             storage::Union{Nothing, StoreStateAction} = StoreStateAction(

--- a/src/commons/stepsizes.jl
+++ b/src/commons/stepsizes.jl
@@ -654,6 +654,153 @@ function AdaptiveWNGradient(args...; kwargs...)
     return ManifoldDefaultsFactory(Manopt.AdaptiveWNGradientStepsize, args...; requires_point = true, kwargs...)
 end
 
+@doc """
+    BarzileiBorweinStepsize{T, R<:Real, IRM, RM, VTM, TSSA} <: Linesearch
+
+A functor representing a nonmonotone line search using the Barzilai-Borwein step size [IannazzoPorcelli:2017](@cite).
+
+# Fields
+
+$(_fields(:inverse_retraction_method))
+* `min_stepsize`:          lower bound for the Barzilai-Borwein step size, greater than zero
+* `max_stepsize`:          upper bound for the Barzilai-Borwein step size, greater than `bb_min_stepsize`
+$(_fields(:retraction_method))
+* `strategy`:                 defines if the new step size is computed using the `:direct`, `:inverse` or `:alternating` strategy
+* `storage`:                  (for `:Iterate` and `:Gradient`) a [`StoreStateAction`](@ref)
+$(_fields(:vector_transport_method))
+
+# Constructor
+
+    BarzileiBorweinStepsize(M::AbstractManifold; kwargs...)
+    BarzileiBorweinStepsize(M::AbstractManifold, p; kwargs...)
+
+## Keyword arguments
+
+$(_kwargs(:inverse_retraction_method))
+* `min_stepsize=1e-3`
+* `max_stepsize=1e3`
+$(_kwargs(:retraction_method))
+* `strategy=:direct`
+* `storage=`[`StoreStateAction`](@ref)`(M; store_fields=[:Iterate, :Gradient])`
+$(_kwargs(:vector_transport_method))
+"""
+mutable struct BarzileiBorweinStepsize{
+        T, R <: Real,
+        IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod,
+        VTM <: AbstractVectorTransportMethod, TSSA <: StoreStateAction,
+    } <: Linesearch
+    inverse_retraction_method::IRM
+    min_stepsize::R
+    max_stepsize::R
+    retraction_method::RM
+    s::T
+    storage::TSSA
+    strategy::Symbol
+    vector_transport_method::VTM
+    y::T
+    function BarzileiBorweinStepsize(
+            M::AbstractManifold;
+            p::P = rand(M), X::T = zero_vector(M, p),
+            min_stepsize::R = 1.0e-3,
+            max_stepsize::R = 1.0e3,
+            retraction_method::RM = default_retraction_method(M, P),
+            inverse_retraction_method::IRM = default_inverse_retraction_method(M, P),
+            storage::Union{Nothing, StoreStateAction} = StoreStateAction(
+                M; store_fields = [:Iterate, :Gradient]
+            ),
+            strategy::Symbol = :direct,
+            vector_transport_method::VTM = default_vector_transport_method(M),
+        ) where {
+            IRM <: AbstractInverseRetractionMethod, RM <: AbstractRetractionMethod, VTM <: AbstractVectorTransportMethod, P, R <: Real, T,
+        }
+        stop_when_stepsize_exceeds = R(stop_when_stepsize_exceeds)
+        if strategy ∉ [:direct, :inverse, :alternating]
+            @warn string(
+                "The strategy '", strategy, "' is not defined. The 'direct' strategy is used instead.",
+            )
+            strategy = :direct
+        end
+        if min_stepsize <= 0.0
+            throw(
+                DomainError(min_stepsize, "The lower bound for the Barzilei–Borwein step size has to be positive."),
+            )
+        end
+        if max_stepsize <= min_stepsize
+            throw(
+                DomainError(
+                    bb_max_stepsize, "The upper bound for the step size lower bound.",
+                ),
+            )
+        end
+        return new{T, R, IRM, RM, VTM, typeof(storage)}(
+            inverse_retraction_method, min_stepsize, max_stepsize,
+            retraction_method, copy(M, p, X), storage, strategy, vector_transport_method, X
+        )
+    end
+end
+function (bb::BarzileiBorweinStepsize)(
+        mp::AbstractManoptProblem, s::AbstractManoptSolverState, k::Int, η = (-get_gradient(mp, get_iterate(s)));
+        gradient = nothing, last_stepsize = nothing, kwargs...
+    )
+    M = get_manifold(mp)
+    p = get_iterate(s)
+    X = isnothing(gradient) ? get_gradient(mp, p) : gradient
+    if !has_storage(bb.storage, PointStorageKey(:Iterate)) || !has_storage(bb.storage, VectorStorageKey(:Gradient))
+        # first time call: get old grad/iterate and store.
+        p_old = get_iterate(s)
+        X_old = X
+    else
+        #fetch
+        p_old = get_storage(bb.storage, PointStorageKey(:Iterate))
+        X_old = get_storage(bb.storage, VectorStorageKey(:Gradient))
+    end
+    update_storage!(bb.storage, mp, s)
+
+    # compute the y_k – difference of gradients, but remember to transport
+    vector_transport_to!(M, bb.y, old_p, old_X, p, bb.vector_transport_method)
+    copyto!(M, bb.y, p, X .- bb.y)
+    # for s_k there are two possibilities
+    if !isnothing(last_stepsize) # Variant 1: Someone gave us the last stepsize, so we can just use -last_stepsize * X_old and transport it to the current iterate
+        vector_transport_to!(M, bb.s, p_old, -last_stepsize * X_old, p, bb.vector_transport_method)
+    else # Variant 2: otherwise we use the inverse retraction method
+        inverse_retract!(M, bb.s, p, p_old, bb.inverse_retraction_method)
+    end
+
+    #compute the new Barzilai-Borwein step size
+    s1 = real(inner(M, p, bb.s, bb.y))
+    s2 = real(inner(M, p, bb.y, bb.y))
+    s2 = s2 == 0 ? 1.0 : s2
+    s3 = real(inner(M, p, bb.s, bb.s))
+    #indirect strategy
+    return if bb.strategy == :inverse
+        if s1 > 0
+            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s1 / s2))
+        else
+            stepsize = bb.max_stepsize
+        end
+        #alternating strategy
+    elseif bb.strategy == :alternating
+        if s1 > 0
+            if k % 2 == 0
+                stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s1 / s2))
+            else
+                stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s3 / s1))
+            end
+        else
+            stepsize = bb.max_stepsize
+        end
+    else # default: direct strategy
+        if s1 > 0
+            stepsize = min(bb.max_stepsize, max(bb.min_stepsize, s2 / s1))
+        else
+            stepsize = bb.max_stepsize
+        end
+    end
+end
+function Base.show(io::IO, a::BarzileiBorweinStepsize)
+    return print(io, "BarzileiBorweinStepsize TODO")
+end
+
 """
     ConstantStepsize <: Stepsize
 
@@ -1702,14 +1849,7 @@ function (a::NonmonotoneLinesearchStepsize)(
         swse = (a.stop_when_stepsize_exceeds / l)
     end
     a.last_stepsize = linesearch_backtrack!(
-        M,
-        a.candidate_point,
-        f,
-        p,
-        BarzilaiBorwein_stepsize,
-        a.sufficient_decrease,
-        a.stepsize_reduction,
-        η;
+        M, a.candidate_point, f, p, BarzilaiBorwein_stepsize, a.sufficient_decrease, a.stepsize_reduction, η;
         lf0 = maximum(view(a.old_costs, 1:min(iter, memory_size))),
         gradient = X,
         retraction_method = a.retraction_method,

--- a/src/commons/stopping_criteria.jl
+++ b/src/commons/stopping_criteria.jl
@@ -605,9 +605,9 @@ function StopWhenCostChangeLess(tol::F) where {F <: Real}
     return StopWhenCostChangeLess{F}(tol, -1, zero(tol), 2 * tol)
 end
 function (c::StopWhenCostChangeLess)(
-        problem::AbstractManoptProblem, state::AbstractManoptSolverState, iteration::Int
+        problem::AbstractManoptProblem, state::AbstractManoptSolverState, k::Int
     )
-    if iteration <= 0 # reset on init
+    if k <= 0 # reset on init
         c.at_iteration = -1
         c.last_cost = Inf
         c.last_change = 2 * c.tolerance
@@ -616,7 +616,7 @@ function (c::StopWhenCostChangeLess)(
     c.last_cost = get_cost(problem, state)
     c.last_change = c.last_change - c.last_cost
     if abs(c.last_change) < c.tolerance
-        c.at_iteration = iteration
+        c.at_iteration = k
         return true
     end
     return false
@@ -1606,9 +1606,9 @@ function StopWhenRelativeAPosterioriCostChangeLessOrEqual(tol::F) where {F <: Re
 end
 StopWhenRelativeAPosterioriCostChangeLessOrEqual(; factr::F = 1.0e7) where {F <: Real} = StopWhenRelativeAPosterioriCostChangeLessOrEqual(factr * eps(typeof(factr)))
 function (c::StopWhenRelativeAPosterioriCostChangeLessOrEqual)(
-        problem::AbstractManoptProblem, state::AbstractManoptSolverState, iteration::Int
+        problem::AbstractManoptProblem, state::AbstractManoptSolverState, k::Int
     )
-    if iteration <= 0 # reset on init
+    if k <= 0 # reset on init
         c.at_iteration = -1
         c.last_cost = Inf
         c.last_change = 2 * c.threshold
@@ -1616,8 +1616,8 @@ function (c::StopWhenRelativeAPosterioriCostChangeLessOrEqual)(
     current_cost = get_cost(problem, state)
     c.last_change = (c.last_cost - current_cost) / max(abs(c.last_cost), abs(current_cost), 1)
     c.last_cost = current_cost
-    if iteration > 1 && c.last_change <= c.threshold
-        c.at_iteration = iteration
+    if k > 1 && c.last_change <= c.threshold
+        c.at_iteration = k
         return true
     end
     return false

--- a/src/commons/sub_objectives.jl
+++ b/src/commons/sub_objectives.jl
@@ -848,7 +848,7 @@ $(_tex(:Cal, "A"))(X) = $(_tex(:Cal, "L"))^* $(_tex(:Cal, "L"))(X) + λX
 = J_F^*(p)$(_tex(:bigl))[ C^T C J_F(p)[X] $(_tex(:bigr))] + λX,
 ```
 
-where ``λ = ```penalty` is a damping parameter and with
+where ``λ`` = `penalty` is a damping parameter and with
 ``α = 1 - $(_tex(:sqrt, "1 + 2 $(_tex(:frac, "ρ''(p)", "ρ'(p)"))$(_tex(:norm, "F(p)"; index = "2"))^2"))``
 we have
 
@@ -1448,7 +1448,7 @@ For the variant with `_normal` the result is similar to the surrogate, namely we
 ``$(_tex(:Cal, "L"))(X) + y`` for the surrogate and hence also the same form ``$(_tex(:Cal, "N"))(X) + z``,
 which has to be set to zero to find ``X``.
 
-For the objective here we consider ````$(_tex(:Cal, "N"))(X) = z'``, i.e. the `get_vector_field` `z' = -z``
+For the objective here we consider ``$(_tex(:Cal, "N"))(X) = z'``, that is, the `get_vector_field` ``z' = -z``
 differs by a sign.
 """
 

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -167,6 +167,9 @@ _glossary_links = _glossary[:Link]
 
 __link_formatter = Glossaries.Plain(:link)
 _link(args...; kwargs...) = __link_formatter(_glossary_links, args...; kwargs...)
+# A link for a keyword `default`: `Glossaries.Keyword` appends the closing backtick,
+# so the code span the link brings along has to be left open here.
+_open_link(args...; kwargs...) = "`" * chopsuffix(_link(args...; kwargs...), "`")
 
 Glossaries.define!(
     _glossary_links, :AbstractManifold, :link,
@@ -458,7 +461,7 @@ Glossaries.define!(
     (; M = "M") -> "a point on the manifold ``$(_math(:Manifold, M = M))``"
 )
 Glossaries.define!(_glossary_variables, :p, :type, "P")
-Glossaries.define!(_glossary_variables, :p, :default, (; M = "M") -> "`$(_link(:rand; M = M))` ")
+Glossaries.define!(_glossary_variables, :p, :default, (; M = "M") -> _open_link(:rand; M = M))
 Glossaries.define!(_glossary_variables, :p, :as_Iterate, " storing the current iterate")
 Glossaries.define!(_glossary_variables, :p, :as_Initial, " to specify the initial value")
 
@@ -537,7 +540,7 @@ Glossaries.define!(
     "a tangent vector at the point ``$p`` on the manifold ``$(_math(:Manifold, M = M))``",
 )
 Glossaries.define!(_glossary_variables, :X, :type, "T")
-Glossaries.define!(_glossary_variables, :X, :default, (; M = "M", p = "p") -> "`$(_link(:zero_vector; M = M, p = p))` ")
+Glossaries.define!(_glossary_variables, :X, :default, (; M = "M", p = "p") -> _open_link(:zero_vector; M = M, p = p))
 Glossaries.define!(_glossary_variables, :X, :as_Gradient, "storing the gradient at the current iterate")
 Glossaries.define!(_glossary_variables, :X, :as_Subgradient, "storing a subgradient at the current iterate")
 Glossaries.define!(_glossary_variables, :X, :as_Memory, "to specify the representation of a tangent vector")

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -70,6 +70,7 @@ Glossaries.define!(_glossary_tex_terms, :displaystyle, :math, raw"\displaystyle"
 Glossaries.define!(_glossary_tex_terms, :ell, :math, raw"\ell")
 Glossaries.define!(_glossary_tex_terms, :eR, :math, raw"\bar{\mathbb R}")
 _tex_frac(a, b) = raw"\frac" * "{$a}{$b}"
+Glossaries.define!(_glossary_tex_terms, :exp, :math, raw"\exp")
 Glossaries.define!(_glossary_tex_terms, :frac, :math, _tex_frac)
 Glossaries.define!(_glossary_tex_terms, :grad, :math, raw"\operatorname{grad}")
 _tex_hat(letter) = raw"\hat{" * "$letter" * "}"

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -458,7 +458,7 @@ Glossaries.define!(
     (; M = "M") -> "a point on the manifold ``$(_math(:Manifold, M = M))``"
 )
 Glossaries.define!(_glossary_variables, :p, :type, "P")
-Glossaries.define!(_glossary_variables, :p, :default, (; M = "M") -> "`$(_link(:rand; M = M))` ")
+Glossaries.define!(_glossary_variables, :p, :default, (; M = "M") -> "`$(_link(:rand; M = M))` ")
 Glossaries.define!(_glossary_variables, :p, :as_Iterate, " storing the current iterate")
 Glossaries.define!(_glossary_variables, :p, :as_Initial, " to specify the initial value")
 

--- a/src/documentation_glossary.jl
+++ b/src/documentation_glossary.jl
@@ -492,7 +492,7 @@ Glossaries.define!(
 Glossaries.define!(_glossary_variables, :stopping_criterion, :type, "`[`StoppingCriterion`](@ref)` ")
 
 Glossaries.define!(_glossary_variables, :sub_kwargs)
-Glossaries.define!(_glossary_variables, :sub_kwargs, :description, "a named tuple of keyword arguments that are passed to [`decorate_objective!`](@ref) of the sub solvers objective, the [`decorate_state!`](@ref) of the subsovlers state, and the sub state constructor itself.")
+Glossaries.define!(_glossary_variables, :sub_kwargs, :description, "a named tuple of keyword arguments that are passed to [`decorate_objective!`](@ref) of the sub solvers objective, the [`decorate_state!`](@ref) of the sub solvers state, and the sub state constructor itself.")
 Glossaries.define!(_glossary_variables, :sub_kwargs, :default, "(;)")
 
 Glossaries.define!(_glossary_variables, :sub_problem)
@@ -507,7 +507,7 @@ Glossaries.define!(
     _glossary_variables, :sub_state, :description,
     (; M = "M") -> " a state to specify the sub solver to use. For a closed form solution, this indicates the type of function.",
 )
-Glossaries.define!(_glossary_variables, :sub_state, :type, "Union{`[`AbstractManoptProblem`](@ref)`, F}")
+Glossaries.define!(_glossary_variables, :sub_state, :type, "Union{`[`AbstractManoptSolverState`](@ref)`, `[`AbstractEvaluationType`](@ref)`}")
 
 Glossaries.define!(_glossary_variables, :subgrad_f, :name, "∂f")
 Glossaries.define!(
@@ -537,7 +537,7 @@ Glossaries.define!(
     "a tangent vector at the point ``$p`` on the manifold ``$(_math(:Manifold, M = M))``",
 )
 Glossaries.define!(_glossary_variables, :X, :type, "T")
-Glossaries.define!(_glossary_variables, :X, :default, (; M = "M", p = "p") -> "`$(_link(:zero_vector; M = M, p = p))` ")
+Glossaries.define!(_glossary_variables, :X, :default, (; M = "M", p = "p") -> "`$(_link(:zero_vector; M = M, p = p))` ")
 Glossaries.define!(_glossary_variables, :X, :as_Gradient, "storing the gradient at the current iterate")
 Glossaries.define!(_glossary_variables, :X, :as_Subgradient, "storing a subgradient at the current iterate")
 Glossaries.define!(_glossary_variables, :X, :as_Memory, "to specify the representation of a tangent vector")

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -88,7 +88,7 @@ no plot is generated.
 
 # Keyword arguments
 
-* `check_vector=true`:
+* `check_vector=false`:
   verify that ``$(_tex(:grad))f(p) ∈ $(_math(:TangentSpace))`` using `is_vector`.
 * `exactness_tol=1e-12`:
   if all errors are below this tolerance, the gradient is considered to be exact

--- a/src/helpers/checks.jl
+++ b/src/helpers/checks.jl
@@ -171,7 +171,7 @@ no plot is generated.
 * `check_symmetry=true`:
   verify that the Hessian is symmetric, see [`is_Hessian_symmetric`](@ref)
 * `check_vector=false`:
-  verify that `$(_tex(:Hess)) f(p)[X] ∈ $(_math(:TangentSpace))`` using `is_vector`.
+  verify that ``$(_tex(:Hess)) f(p)[X] ∈ $(_math(:TangentSpace))`` using `is_vector`.
 * `mode=:Default`:
   specify the mode for the verification; the default assumption is,
   that the retraction provided is of second order. Otherwise one can also verify the Hessian

--- a/src/helpers/test.jl
+++ b/src/helpers/test.jl
@@ -59,7 +59,7 @@ mutable struct DummyState <: AbstractManoptSolverState
     storage::Vector{Float64}
 end
 DummyState() = DummyState([])
-Manopt.status_summary(ds::DummyState; context = :Default) = "A Manopt Test state with storage $(ds.storage)"
+Manopt.status_summary(ds::DummyState; context = :default) = "A Manopt Test state with storage $(ds.storage)"
 Base.show(io::IO, ds::DummyState) = print(io, "Manopt.Test.DummyState($(ds.storage))")
 Manopt.get_iterate(::DummyState) = NaN
 Manopt.set_parameter!(s::DummyState, ::Val, v) = s

--- a/src/solvers/ChambollePock.jl
+++ b/src/solvers/ChambollePock.jl
@@ -10,9 +10,9 @@ Describes an Objective linearized or exact Chambolle-Pock algorithm, cf. [Bergma
 
 * `cost`:                          ``F + G(Λ(⋅))`` to evaluate interim cost function values
 * `linearized_forward_operator!`: linearized operator for the forward operation in the algorithm ``DΛ``
-* `linearized_adjoint_operator!`: the adjoint differential ``(DΛ)^* : $(_math(:Manifold; M = "N")) → T$(_math(:Manifold))``
+* `adjoint_linearized_operator!`: the adjoint differential ``(DΛ)^* : $(_math(:Manifold; M = "N")) → T$(_math(:Manifold))``
 * `prox_f!`:                      the proximal map belonging to ``f``
-* `prox_G_dual!`:                 the proximal map belonging to ``g_n^*``
+* `prox_g_dual!`:                 the proximal map belonging to ``g_n^*``
 * `Λ!`:                           the  forward operator (if given) ``Λ: $(_math(:Manifold)) → $(_math(:Manifold; M = "N"))``
 
 Either the linearized operator ``DΛ`` or ``Λ`` are required usually.

--- a/src/solvers/ChambollePock.jl
+++ b/src/solvers/ChambollePock.jl
@@ -99,7 +99,7 @@ $(_fields(:inverse_retraction_method; name = "inverse_retraction_method_dual", M
 * `X::T`:               an initial tangent vector ``X^{(0)} ∈ $(_math(:TangentSpace; p = "p^{(0)}"))``
 * `Xbar::T`:            the relaxed iterate used in the next primal update step (when using `:dual` relaxation)
 * `relaxation::R`:      relaxation in the primal relaxation step (to compute `pbar`:
-* `relax::Symbol:       which variable to relax (`:primal` or `:dual`:
+* `relax::Symbol`:      which variable to relax, `:primal` or `:dual`
 $(_fields(:retraction_method))
 $(_fields(:stopping_criterion; name = "stop"))
 * `variant`:            whether to perform an `:exact` or `:linearized` Chambolle-Pock
@@ -125,7 +125,7 @@ If you activate these to be different from the default identity, you have to pro
 # Keyword arguments
 
 $(_kwargs(:callbacks; show_type = false, add_properties = [:as_dict]))
-* `n=``$(Manopt._link(:rand; M = "N"))
+* `n=`$(Manopt._link(:rand; M = "N"))
 * `p=`$(Manopt._link(:rand))
 * `m=`$(Manopt._link(:rand))
 * `X=`$(Manopt._link(:zero_vector))

--- a/src/solvers/ChambollePock.jl
+++ b/src/solvers/ChambollePock.jl
@@ -231,11 +231,11 @@ get_callbacks(state::ChambollePockState) = state.callbacks
 function status_summary(cps::ChambollePockState; context::Symbol = :default)
     (context === :short) && return repr(cps)
     i = get_count(cps, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(cps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(cps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for Chambolle-Pock algorithm$(conv_inl)"
     i = get_count(cps, :Iterations)
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(cps.stop) ? "Yes" : "No"
+    Conv = has_converged(cps.stop) ? "Yes" : "No"
     as = _callbacks_summary(cps)
     s = """
     # Solver state for `Manopt.jl`s Chambolle-Pock Algorithm
@@ -255,7 +255,7 @@ function status_summary(cps::ChambollePockState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(cps.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 get_solver_result(apds::AbstractPrimalDualSolverState) = get_iterate(apds)

--- a/src/solvers/ChambollePock.jl
+++ b/src/solvers/ChambollePock.jl
@@ -346,7 +346,6 @@ function ChambollePock(
 end
 calls_with_kwargs(::typeof(ChambollePock)) = (ChambollePock!,)
 
-# TODO: Add Eval
 @doc "$(_doc_ChambollePock)"
 function ChambollePock!(
         M::AbstractManifold, N::AbstractManifold, cost::TF, p::P, X::T, m::P, n::Q,

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -15,7 +15,7 @@ $(_fields(:inverse_retraction_method))
 * `R!`:                          method employed in the iteration to perform the reflection of `x` at the prox `p`.
 $(_fields(:p; add_properties = [:as_Iterate]))
   For the parallel Douglas-Rachford, this is not a value from the `PowerManifold` manifold but the mean.
-* `reflection!`:     whether `R` works in-place or allocating
+* `R!`:              whether `R` works in-place or allocating
 $(_fields(:retraction_method))
 * `s`:                         the last result of the double reflection at the proximal maps relaxed by `α`.
 $(_fields(:stopping_criterion; name = "stop"))

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -115,10 +115,10 @@ end
 function status_summary(drs::DouglasRachfordState; context::Symbol = :default)
     (context === :short) && return repr(drs)
     i = get_count(drs, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(drs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(drs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the Douglas Rachford solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(drs.stop) ? "Yes" : "No"
+    Conv = has_converged(drs.stop) ? "Yes" : "No"
     as = _callbacks_summary(drs)
     P = drs.parallel ? "Parallel " : ""
     s = """
@@ -130,7 +130,7 @@ function status_summary(drs::DouglasRachfordState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(drs.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 get_iterate(drs::DouglasRachfordState) = drs.p

--- a/src/solvers/DouglasRachford.jl
+++ b/src/solvers/DouglasRachford.jl
@@ -119,7 +119,6 @@ function status_summary(drs::DouglasRachfordState; context::Symbol = :default)
     (context === :inline) && return "A solver state for the Douglas Rachford solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(drs.stop) ? "Yes" : "No"
-    _is_inline(context) && (return "$(repr(drs)) – $(Iter) $(has_converged(drs) ? "(converged)" : "")")
     as = _callbacks_summary(drs)
     P = drs.parallel ? "Parallel " : ""
     s = """

--- a/src/solvers/FrankWolfe.jl
+++ b/src/solvers/FrankWolfe.jl
@@ -292,11 +292,14 @@ the obtained (approximate) minimizer ``p^*``, see [`get_solver_return`](@ref) fo
 Frank_Wolfe_method(M::AbstractManifold, args...; kwargs...)
 function Frank_Wolfe_method(
         M::AbstractManifold, f, grad_f, p = rand(M);
+        differential = missing,
         evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
     p_ = maybe_wrap_variable(p)
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation = evaluation, p = p)
+    mgo = ManifoldGradientObjective(
+        f, grad_f; differential = differential, evaluation = evaluation, p = p
+    )
     rs = Frank_Wolfe_method(M, mgo, p_; evaluation = evaluation, kwargs...)
     return maybe_unwrap_variable(p, rs)
 end
@@ -313,7 +316,7 @@ calls_with_kwargs(::typeof(Frank_Wolfe_method)) = (Frank_Wolfe_method!,)
 Frank_Wolfe_method!(M::AbstractManifold, args...; kwargs...)
 function Frank_Wolfe_method!(
         M::AbstractManifold, f, grad_f, p;
-        differential = nothing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
+        differential = missing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
     mgo = ManifoldGradientObjective(

--- a/src/solvers/FrankWolfe.jl
+++ b/src/solvers/FrankWolfe.jl
@@ -71,7 +71,7 @@ $(_fields(:p; add_properties = [:as_Iterate]))
 $(_fields(:X; add_properties = [:as_Gradient]))
 $(_fields([:inverse_retraction_method, :sub_problem, :sub_state]))
 $(_fields(:stopping_criterion; name = "stop"))
-$(_fields([:stepsize, :retraction_method, :vector_transport_method]))
+$(_fields([:stepsize, :retraction_method]))
 
 The sub task requires a method to solve
 

--- a/src/solvers/FrankWolfe.jl
+++ b/src/solvers/FrankWolfe.jl
@@ -192,10 +192,10 @@ end
 function status_summary(fws::FrankWolfeState; context::Symbol = :default)
     (context === :short) && return repr(fws)
     i = get_count(fws, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(fws.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(fws.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the Frank Wolfe algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(fws.stop) ? "Yes" : "No"
+    Conv = has_converged(fws.stop) ? "Yes" : "No"
     sub = _in_str(status_summary(fws.sub_state; context = context); indent = 1, headers = 1, indent_end = "| ")
     as = _callbacks_summary(fws)
     return """
@@ -212,7 +212,7 @@ function status_summary(fws::FrankWolfeState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(fws.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
 end
 
 #

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -380,11 +380,11 @@ end
 function (c::StopWhenAllLanczosVectorsUsed)(
         ::AbstractManoptProblem,
         arcs::AdaptiveRegularizationState{P, T, Pr, <:LanczosState},
-        i::Int,
+        k::Int,
     ) where {P, T, Pr}
-    (i == 0) && (c.at_iteration = -1) # reset on init
-    if (i > 0) && length(arcs.sub_state.Lanczos_vectors) == c.maxLanczosVectors
-        c.at_iteration = i
+    (k == 0) && (c.at_iteration = -1) # reset on init
+    if (k > 0) && length(arcs.sub_state.Lanczos_vectors) == c.maxLanczosVectors
+        c.at_iteration = k
         return true
     end
     return false

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -103,7 +103,7 @@ function status_summary(ls::LanczosState; context::Symbol = :default)
     (context === :short) && return repr(ls)
     i = get_count(ls, :Iterations)
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(ls.stop) ? "Yes" : "No"
+    Conv = has_converged(ls.stop) ? "Yes" : "No"
     as = _callbacks_summary(ls)
     vectors = length(ls.Lanczos_vectors)
     return """
@@ -118,7 +118,7 @@ function status_summary(ls::LanczosState; context::Symbol = :default)
     $(status_summary(ls.stop))
     (b) For the Newton sub solver
     $(status_summary(ls.stop_newton))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
 end
 
 #

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -42,12 +42,12 @@ mutable struct LanczosState{T, R, SC, SCN, B, TM, C, CA} <: AbstractManoptSolver
     σ::R
     stop::SC
     stop_newton::SCN
-    Lanczos_vectors::B # ``q_i``
-    tridig_matrix::TM  # `T``
-    coefficients::C     # `y``
-    Hp::T              # `Hess_f`` A temporary vector for evaluations of the Hessian
-    Hp_residual::T     # A residual vector
-    S::T               # store the tangent vector that solves the minimization problem
+    Lanczos_vectors::B  # ``q_i``
+    tridig_matrix::TM   # ``T``
+    coefficients::C     # ``y``
+    Hp::T               # ``Hess f`` a temporary vector for evaluations of the Hessian
+    Hp_residual::T      # a residual vector
+    S::T                # store the tangent vector that solves the minimization problem
     function LanczosState(;
             callbacks::CA, X::T, σ::R, stopping_criterion::SC, stopping_criterion_newton::SCN, Lanczos_vectors::B,
             tridig_matrix::TM, coefficients::C, Hp::T, Hp_residual::T, S::T

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -161,10 +161,10 @@ get_callbacks(lms::LevenbergMarquardtState) = lms.callbacks
 function status_summary(lms::LevenbergMarquardtState; context::Symbol = :default)
     (context === :short) && return repr(lms)
     i = get_count(lms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(lms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(lms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the Levenberg–Marquardt algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(lms.stop) ? "Yes" : "No"
+    Conv = has_converged(lms.stop) ? "Yes" : "No"
     as = _callbacks_summary(lms)
     return """
     # Solver state for `Manopt.jl`s Levenberg Marquardt Algorithm
@@ -181,7 +181,7 @@ function status_summary(lms::LevenbergMarquardtState; context::Symbol = :default
     ## Stopping criterion
 
     $(status_summary(lms.stop; context = context))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
 end
 function show(io::IO, lms::LevenbergMarquardtState)
     print(io, "LevenbergMarquardtState(", lms.sub_problem, ", ", lms.sub_state, "; ")

--- a/src/solvers/LevenbergMarquardt.jl
+++ b/src/solvers/LevenbergMarquardt.jl
@@ -202,7 +202,7 @@ _doc_LM = """
     LevenbergMarquardt!(M, vgf, p; kwargs...)
     LevenbergMarquardt!(M, nlso, p; kwargs...)
 
-compute the the Riemannian Levenberg-Marquardt algorithm [Peeters:1993, AdachiOkunoTakeda:2022, BaranBergmann:2026](@cite)
+compute the Riemannian Levenberg-Marquardt algorithm [Peeters:1993, AdachiOkunoTakeda:2022, BaranBergmann:2026](@cite)
 to solve
 
 $(_problem(:NonLinearLeastSquares))

--- a/src/solvers/NelderMead.jl
+++ b/src/solvers/NelderMead.jl
@@ -154,10 +154,10 @@ end
 function status_summary(nms::NelderMeadState; context::Symbol = :default)
     (context === :short) && return repr(nms)
     i = get_count(nms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(nms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(nms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the Nelder-Mead solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(nms.stop) ? "Yes" : "No"
+    Conv = has_converged(nms.stop) ? "Yes" : "No"
     as = _callbacks_summary(nms)
     s = """
     # Solver state for `Manopt.jl`s Nelder Mead Algorithm
@@ -172,7 +172,7 @@ function status_summary(nms::NelderMeadState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(nms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 get_iterate(O::NelderMeadState) = O.p

--- a/src/solvers/NelderMead.jl
+++ b/src/solvers/NelderMead.jl
@@ -279,7 +279,7 @@ function NelderMead!(
         inverse_retraction_method::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, eltype(population.pts)),
         kwargs..., #collect rest
     ) where {O <: Union{AbstractManifoldCostObjective, AbstractDecoratedManifoldObjective}}
-    keywords_accepted(NelderMead; kwargs...)
+    keywords_accepted(NelderMead!; kwargs...)
     dmco = decorate_objective!(M, mco; kwargs...)
     mp = DefaultManoptProblem(M, dmco)
     s = NelderMeadState(

--- a/src/solvers/NelderMead.jl
+++ b/src/solvers/NelderMead.jl
@@ -62,7 +62,6 @@ after the description
 $(_fields(:callbacks; add_properties = [:as_dict]))
 * `population::`[`NelderMeadSimplex`](@ref): a population (set) of ``d+1`` points ``x_i``, ``i=1,…,n+1``, where ``d``
   is the $(_link(:manifold_dimension; M = "")) of `M`.
-$(_fields(:stepsize))
 * `α`: the reflection parameter ``α > 0``:
 * `γ` the expansion parameter ``γ > 0``:
 * `ρ`: the contraction parameter, ``0 < ρ ≤ \\frac{1}{2}``,

--- a/src/solvers/NelderMead.jl
+++ b/src/solvers/NelderMead.jl
@@ -85,8 +85,8 @@ $(_kwargs([:inverse_retraction_method, :retraction_method]))
 * `population=`[`NelderMeadSimplex`](@ref)`(M)`
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(2000)`$(_sc(:Any))[`StopWhenPopulationConcentrated`](@ref)`()"))
   a [`StoppingCriterion`](@ref)
-* `α=1.0`: reflection parameter ``α > 0``:
-* `γ=2.0` expansion parameter ``γ``:
+* `α=1.0`: reflection parameter, ``α > 0``
+* `γ=2.0`: expansion parameter, ``γ > 1``
 * `ρ=1/2`: contraction parameter, ``0 < ρ ≤ \\frac{1}{2}``,
 * `σ=1/2`: shrink coefficient, ``0 < σ ≤ 1``
 """
@@ -196,18 +196,16 @@ The algorithm consists of the following steps. Let ``d`` denote the dimension of
 
 1. Order the simplex vertices ``p_i, i=1,…,d+1`` by increasing cost, such that we have ``f(p_1) ≤ f(p_2) ≤ … ≤ f(p_{d+1})``.
 2. Compute the Riemannian center of mass [Karcher:1977](@cite), cf. [`mean`](@extref Statistics.mean-Tuple{AbstractManifold, Vararg{Any}}), ``p_{$(_tex(:text, "m"))}``
-    of the simplex vertices ``p_1,…,p_{d+1}``.
+    of the simplex vertices ``p_1,…,p_{d}``, that is, of all but the worst point.
 3. Reflect the point with the worst point at the mean ``p_{$(_tex(:text, "r"))} = $(_tex(:retr))_{p_{$(_tex(:text, "m"))}}\\bigl( - α$(_tex(:invretr))_{p_{$(_tex(:text, "m"))}} (p_{d+1}) \\bigr)``
     If ``f(p_1) ≤ f(p_{$(_tex(:text, "r"))}) ≤ f(p_{d})`` then set ``p_{d+1} = p_{$(_tex(:text, "r"))}`` and go to step 1.
 4. Expand the simplex if ``f(p_{$(_tex(:text, "r"))}) < f(p_1)`` by computing the expansion point ``p_{$(_tex(:text, "e"))} = $(_tex(:retr))_{p_{$(_tex(:text, "m"))}}\\bigl( - γα$(_tex(:invretr))_{p_{$(_tex(:text, "m"))}} (p_{d+1}) \\bigr)``,
     which in this formulation allows to reuse the tangent vector from the inverse retraction from before.
-    If ``f(p_{$(_tex(:text, "e"))}) < f(p_{$(_tex(:text, "r"))})`` then set ``p_{d+1} = p_{$(_tex(:text, "e"))}`` otherwise set set ``p_{d+1} = p_{$(_tex(:text, "r"))}``. Then go to Step 1.
-5. Contract the simplex if ``f(p_{$(_tex(:text, "r"))}) ≥ f(p_d)``.
-    1. If ``f(p_{$(_tex(:text, "r"))}) < f(p_{d+1})`` set the step ``s = -ρ``
-    2. otherwise set ``s=ρ``.
+    If ``f(p_{$(_tex(:text, "e"))}) < f(p_{$(_tex(:text, "r"))})`` then set ``p_{d+1} = p_{$(_tex(:text, "e"))}`` otherwise set ``p_{d+1} = p_{$(_tex(:text, "r"))}``. Then go to Step 1.
+5. Contract the simplex if ``f(p_{$(_tex(:text, "r"))}) > f(p_d)``.
+    Set the step ``s = -ρ`` if ``f(p_{$(_tex(:text, "r"))}) < f(p_{d+1})`` and ``s = ρ`` otherwise.
     Compute the contraction point ``p_{$(_tex(:text, "c"))} = $(_tex(:retr))_{p_{$(_tex(:text, "m"))}}\\bigl(s$(_tex(:invretr))_{p_{$(_tex(:text, "m"))}} p_{d+1} \\bigr)``.
-    1. in this case if ``f(p_{$(_tex(:text, "c"))}) < f(p_{$(_tex(:text, "r"))})`` set ``p_{d+1} = p_{$(_tex(:text, "c"))}`` and go to step 1
-    2. in this case if ``f(p_{$(_tex(:text, "c"))}) < f(p_{d+1})`` set ``p_{d+1} = p_{$(_tex(:text, "c"))}`` and go to step 1
+    If ``f(p_{$(_tex(:text, "c"))}) < f(p_{d+1})`` set ``p_{d+1} = p_{$(_tex(:text, "c"))}`` and go to step 1, otherwise continue with step 6.
 6. Shrink all points (closer to ``p_1``). For all ``i=2,...,d+1`` set
     ``p_{i} = $(_tex(:retr))_{p_{1}}\\bigl( σ$(_tex(:invretr))_{p_{1}} p_{i} \\bigr).``
 
@@ -227,8 +225,8 @@ $(_kwargs(:callbacks; add_properties = [:process_note]))
 $(_kwargs([:inverse_retraction_method, :retraction_method]))
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(2000)`$(_sc(:Any))[`StopWhenPopulationConcentrated`](@ref)`()"))
   a [`StoppingCriterion`](@ref)
-* `α=1.0`: reflection parameter ``α > 0``:
-* `γ=2.0` expansion parameter ``γ``:
+* `α=1.0`: reflection parameter, ``α > 0``
+* `γ=2.0`: expansion parameter, ``γ > 1``
 * `ρ=1/2`: contraction parameter, ``0 < ρ ≤ \\frac{1}{2}``,
 * `σ=1/2`: shrink coefficient, ``0 < σ ≤ 1``
 
@@ -315,7 +313,7 @@ function step_solver!(mp::AbstractManoptProblem, s::NelderMeadState, ::Any)
     Costr = get_cost(mp, xr)
     continue_steps = true
     # is it better than the worst but not better than the best?
-    if Costr >= s.costs[1] && Costr < s.costs[end - 1]
+    if Costr >= s.costs[1] && Costr <= s.costs[end - 1]
         # store as last
         s.population.pts[end] = xr
         s.costs[end] = Costr
@@ -366,14 +364,14 @@ end
 A stopping criterion for [`NelderMead`](@ref) to indicate to stop when
 both
 
-* the maximal distance of the first to the remaining the cost values and
-* the maximal distance of the first to the remaining the population points
+* the maximal distance of the first to the remaining cost values and
+* the maximal distance of the first to the remaining population points
 
 drops below a certain tolerance `tol_f` and `tol_p`, respectively.
 
 # Constructor
 
-    StopWhenPopulationConcentrated(tol_f::Real=1e-8, tol_x::Real=1e-8)
+    StopWhenPopulationConcentrated(tol_f::Real=1e-8, tol_p::Real=1e-8)
 
 """
 mutable struct StopWhenPopulationConcentrated{F <: Real} <: StoppingCriterion

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -161,7 +161,7 @@ Construct the solver state with all fields stated as keyword arguments and the f
 * `γ1=0.1`
 * `γ2=2.0`
 * `σ=100/manifold_dimension(M)`
-* `σmin=1e-7
+* `σmin=1e-7`
 * `ρ_regularization=1e3`
 $(_kwargs([:evaluation, :p, :retraction_method]))
 $(_kwargs(:callbacks; show_type = false, add_properties = [:as_dict]))

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -261,10 +261,10 @@ end
 function status_summary(arcs::AdaptiveRegularizationState; context::Symbol = :default)
     (context === :short) && (return repr(arcs))
     i = get_count(arcs, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(arcs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(arcs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the adaptive regularization with cubics solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(arcs.stop) ? "Yes" : "No"
+    Conv = has_converged(arcs.stop) ? "Yes" : "No"
     as = _callbacks_summary(arcs)
     sub = status_summary(arcs.sub_state; context = context)
     sub = replace(sub, "\n" => "\n    | ", "\n#" => "\n$(_MANOPT_INDENT)##")
@@ -282,7 +282,7 @@ function status_summary(arcs::AdaptiveRegularizationState; context::Symbol = :de
 
     ## Stopping criterion
     $(_in_str(status_summary(arcs.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -354,10 +354,10 @@ the cost `f` and its gradient and Hessian might also be provided as a [`Manifold
 $(_kwargs(:evaluation))
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `initial_tangent_vector=zero_vector(M, p)`: initialize any tangent vector data,
-* `maxIterLanczos=200`: a shortcut to set the stopping criterion in the sub solver,
+* `maxIterLanczos=min(300, manifold_dimension(M))`: a shortcut to set the stopping criterion in the sub solver,
 * `ρ_regularization=1e3`: a regularization to avoid dividing by zero for small values of cost and model
 $(_kwargs(:retraction_method)):
-$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(40)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(1e-9)`$(_sc(:Any))[`StopWhenAllLanczosVectorsUsed`](@ref)`(maxIterLanczos)"))
+$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(40)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(1e-9)`$(_sc(:Any))[`StopWhenAllLanczosVectorsUsed`](@ref)`(maxIterLanczos-1)"))
 $(_kwargs(:sub_kwargs))
 * `sub_objective=nothing`: a shortcut to modify the objective of the subproblem used within in the `sub_problem=` keyword
   By default, this is initialized as a [`AdaptiveRegularizationWithCubicsModelObjective`](@ref), which can further be decorated by using the `sub_kwargs=` keyword.

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -71,7 +71,7 @@ $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, AlternatingGradi
 $(_kwargs(:X))
 
 Generate the options for point `p` and where `inner_iterations`, `order_type`, `order`,
-`retraction_method`, `stopping_criterion`, and `stepsize`` are keyword arguments.
+`retraction_method`, `stopping_criterion`, and `stepsize` are keyword arguments.
 
 For internal use, there also exists a constructor solely having the fields as keyword arguments,
 but then all of them are mandatory.

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -46,7 +46,7 @@ see also [`alternating_gradient_descent`](@ref).
 
 $(_fields(:callbacks; add_properties = [:as_dict]))
 * `direction::`[`DirectionUpdateRule`](@ref)
-* `evaluation_order::Symbol`: whether to use a randomly permuted sequence (`:FixedRandom`),
+* `order_type::Symbol`: whether to use a randomly permuted sequence (`:FixedRandom`),
   a per cycle newly permuted sequence (`:Random`) or the default `:Linear` evaluation order.
 * `inner_iterations`: how many gradient steps to take in a component before alternating to the next
 * `order`: the current permutation

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -138,7 +138,7 @@ end
 function status_summary(agds::AlternatingGradientDescentState; context::Symbol = :default)
     (context === :short) && return repr(agds)
     Iter = (agds.i > 0) ? "After $(agds.i) iterations\n" : ""
-    Conv = indicates_convergence(agds.stop) ? "Yes" : "No"
+    Conv = has_converged(agds.stop) ? "Yes" : "No"
     _is_inline(context) && (return "$(repr(agds)) – $(Iter) $(has_converged(agds) ? "(converged)" : "")")
     as = _callbacks_summary(agds)
     s = """
@@ -154,7 +154,7 @@ function status_summary(agds::AlternatingGradientDescentState; context::Symbol =
 
     ## Stopping criterion
     $(_in_str(status_summary(agds.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 function get_message(agds::AlternatingGradientDescentState)

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -102,6 +102,9 @@ mutable struct AlternatingGradientDescentState{
             stopping_criterion::StoppingCriterion = StopAfterIteration(1000),
             stepsize::Stepsize = default_stepsize(M, AlternatingGradientDescentState),
         ) where {P, T, C <: AbstractDict{Symbol}}
+        (order_type in (:Linear, :FixedRandom, :Random)) || throw(
+            DomainError(order_type, "The order type has to be one of :Linear, :FixedRandom, or :Random.")
+        )
         return AlternatingGradientDescentState(;
             callbacks = callbacks,
             p = p, X = X, direction = _produce_type(AlternatingGradient(; p = p, X = X), M),
@@ -244,8 +247,8 @@ $(_args(:p))
 # Keyword arguments
 
 $(_kwargs(:evaluation))
-* `evaluation_order=:Linear`: whether to use a randomly permuted sequence (`:FixedRandom`),
-  a per cycle permuted sequence (`:Random`) or the default `:Linear` one.
+* `order_type=:Linear`: whether to use a randomly permuted sequence (`:FixedRandom`),
+  a per cycle permuted sequence (`:Random`, default) or the default `:Linear` one.
 * `inner_iterations=5`:  how many gradient steps to take in a component before alternating to the next
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(1000)"))
 $(_kwargs(:stepsize; default = "`[`ArmijoLinesearch`](@ref)`()"))

--- a/src/solvers/alternating_gradient_descent.jl
+++ b/src/solvers/alternating_gradient_descent.jl
@@ -54,7 +54,7 @@ $(_fields([:retraction_method, :stepsize]))
 $(_fields(:stopping_criterion; name = "stop"))
 $(_fields(:p; add_properties = [:as_Iterate]))
 $(_fields(:X; add_properties = [:as_Gradient]))
-* `k`, ì`: internal counters for the outer and inner iterations, respectively.
+* `k`, `i`: internal counters for the outer and inner iterations, respectively.
 
 # Constructors
 
@@ -247,7 +247,7 @@ $(_kwargs(:evaluation))
 * `evaluation_order=:Linear`: whether to use a randomly permuted sequence (`:FixedRandom`),
   a per cycle permuted sequence (`:Random`) or the default `:Linear` one.
 * `inner_iterations=5`:  how many gradient steps to take in a component before alternating to the next
-$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(1000)`)"))
+$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(1000)"))
 $(_kwargs(:stepsize; default = "`[`ArmijoLinesearch`](@ref)`()"))
 * `order=[1:n]`:         the initial permutation, where `n` is the number of gradients in `gradF`.
 $(_kwargs(:retraction_method))

--- a/src/solvers/augmented_Lagrangian_method.jl
+++ b/src/solvers/augmented_Lagrangian_method.jl
@@ -49,7 +49,7 @@ manifold- or objective specific defaults, and `sub_problem` is a closed form sol
 
 the following keyword arguments are available to initialize the corresponding fields
 
-* `ϵ=1e–3`
+* `ϵ=1e-3`
 * `ϵ_min=1e-6`
 * `λ=ones(n)`: `n` is the number of equality constraints in the [`ConstrainedManifoldObjective`](@ref) `co`.
 * `λ_max=20.0`
@@ -315,7 +315,7 @@ $(_kwargs(:evaluation))
 * `sub_cost=[`AugmentedLagrangianCost± (@ref)`(cmo, ρ, μ, λ):` use augmented Lagrangian cost, based on the [`ConstrainedManifoldObjective`](@ref) build from the functions provided.
    $(_note(:KeywordUsedIn, "sub_problem"))
 
-* `sub_grad=[`AugmentedLagrangianGrad`](@ref)`(cmo, ρ, μ, λ)`: use augmented Lagrangian gradient, based on the [`ConstrainedManifoldObjective`](@ref) build from the functions provided.
+* `sub_grad=`[`AugmentedLagrangianGrad`](@ref)`(cmo, ρ, μ, λ)`: use augmented Lagrangian gradient, based on the [`ConstrainedManifoldObjective`](@ref) build from the functions provided.
   $(_note(:KeywordUsedIn, "sub_problem"))
 
 $(_kwargs(:sub_kwargs))

--- a/src/solvers/augmented_Lagrangian_method.jl
+++ b/src/solvers/augmented_Lagrangian_method.jl
@@ -165,10 +165,10 @@ end
 function status_summary(alms::AugmentedLagrangianMethodState; context::Symbol = :default)
     (context === :short) && (return repr(alms))
     i = get_count(alms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(alms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(alms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the augmented Lagrandigan method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(alms.stop) ? "Yes" : "No"
+    Conv = has_converged(alms.stop) ? "Yes" : "No"
     as = _callbacks_summary(alms)
     s = """
     # Solver state for `Manopt.jl`s Augmented Lagrangian Method
@@ -183,7 +183,7 @@ function status_summary(alms::AugmentedLagrangianMethodState; context::Symbol = 
 
     ## Stopping criterion
     $(_in_str(status_summary(alms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -324,10 +324,10 @@ function step_solver!(mp::AbstractManoptProblem, s::CMAESState, k::Int)
         w_i = s.recombination_weights[i]
         wᵒi = w_i # Eq. (46)
         if w_i < 0
-            mul!(cinv_y, cov_invsqrt, s.ys_c[i])
+            mul!(cinv_y, cov_invsqrt, ys_c_sorted[i])
             wᵒi *= n_coords / norm(cinv_y)^2
         end
-        mul!(s.covariance_matrix, s.ys_c[i], s.ys_c[i]', s.c_μ * wᵒi, true) # Eq. (47), rank μ update
+        mul!(s.covariance_matrix, ys_c_sorted[i], ys_c_sorted[i]', s.c_μ * wᵒi, true) # Eq. (47), rank μ update
     end
     # move covariance matrix, `p_c`, and `p_σ` to new mean point
     s.last_variances .= D2

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -204,10 +204,10 @@ get_callbacks(state::CMAESState) = state.callbacks
 function status_summary(s::CMAESState; context::Symbol = :default)
     (context === :short) && return repr(s)
     i = get_count(s, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(s.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(s.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the conjugate gradient descent solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(s.stop) ? "Yes" : "No"
+    Conv = has_converged(s.stop) ? "Yes" : "No"
     s = """
     # Solver state for `Manopt.jl`s Covariance Matrix Adaptation Evolutionary Strategy
     $Iter
@@ -236,7 +236,7 @@ function status_summary(s::CMAESState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(s.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 #

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -445,7 +445,7 @@ function cma_es!(
         callbacks = Dict{Symbol, Function}(),
         kwargs..., #collect rest
     ) where {O <: Union{AbstractManifoldCostObjective, AbstractDecoratedManifoldObjective}}
-    keywords_accepted(cma_es; kwargs...)
+    keywords_accepted(cma_es!; kwargs...)
     dmco = decorate_objective!(M, mco; kwargs...)
     mp = DefaultManoptProblem(M, dmco)
     n_coords = number_of_coordinates(M, basis)

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -252,7 +252,7 @@ function initialize_solver!(mp::AbstractManoptProblem, s::CMAESState)
     s.covariance_matrix_eigen = eigen(Symmetric(s.covariance_matrix))
     return s
 end
-function step_solver!(mp::AbstractManoptProblem, s::CMAESState, iteration::Int)
+function step_solver!(mp::AbstractManoptProblem, s::CMAESState, k::Int)
     M = get_manifold(mp)
     n_coords = number_of_coordinates(M, s.basis)
 
@@ -309,7 +309,7 @@ function step_solver!(mp::AbstractManoptProblem, s::CMAESState, iteration::Int)
 
     # covariance matrix adaptation
     s.p_c .*= 1 - s.c_c # Eq. (45), part 1
-    if norm(s.p_σ) / sqrt(1 - (1 - s.c_σ)^(2 * (iteration + 1))) <
+    if norm(s.p_σ) / sqrt(1 - (1 - s.c_σ)^(2 * (k + 1))) <
             (1.4 + 2 / (n_coords + 1)) * s.e_mv_norm # h_σ criterion
         s.p_c .+= sqrt(s.c_c * (2 - s.c_c) * s.μ_eff) .* s.buffer # Eq. (45), part 2
         δh_σ = zero(s.c_c) # Appendix A

--- a/src/solvers/cma_es.jl
+++ b/src/solvers/cma_es.jl
@@ -258,7 +258,7 @@ function step_solver!(mp::AbstractManoptProblem, s::CMAESState, iteration::Int)
 
     # sampling and evaluation of new solutions
 
-    # `D2, B = eigen(Symmetric(s.covariance_matrix))``
+    # `D2, B = eigen(Symmetric(s.covariance_matrix))`
     D2, B = s.covariance_matrix_eigen # assuming eigendecomposition has already been completed
     min_eigval, max_eigval = extrema(abs.(D2))
     if minimum(D2) <= 0

--- a/src/solvers/conjugate_gradient_descent.jl
+++ b/src/solvers/conjugate_gradient_descent.jl
@@ -107,10 +107,15 @@ function conjugate_gradient_descent(M::AbstractManifold, f, grad_f; kwargs...)
     return conjugate_gradient_descent(M, f, grad_f, rand(M); kwargs...)
 end
 function conjugate_gradient_descent(
-        M::AbstractManifold, f::TF, grad_f::TDF, p; evaluation = AllocatingEvaluation(), kwargs...
+        M::AbstractManifold, f::TF, grad_f::TDF, p;
+        differential = missing,
+        evaluation = AllocatingEvaluation(),
+        kwargs...,
     ) where {TF, TDF}
     p_ = maybe_wrap_variable(p)
-    mgo = ManifoldGradientObjective(f, grad_f; evaluation = evaluation, p = p)
+    mgo = ManifoldGradientObjective(
+        f, grad_f; differential = differential, evaluation = evaluation, p = p
+    )
     rs = conjugate_gradient_descent(M, mgo, p_; evaluation = evaluation, kwargs...)
     return maybe_unwrap_variable(p, rs)
 end

--- a/src/solvers/conjugate_gradient_descent.jl
+++ b/src/solvers/conjugate_gradient_descent.jl
@@ -11,10 +11,10 @@ end
 function status_summary(cgds::ConjugateGradientDescentState; context::Symbol = :default)
     (context === :short) && (return repr(cgds))
     i = get_count(cgds, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(cgds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(cgds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the conjugate gradient descent solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(cgds.stop) ? "Yes" : "No"
+    Conv = has_converged(cgds.stop) ? "Yes" : "No"
     as = _callbacks_summary(cgds)
     return """
     # Solver state for `Manopt.jl`s Conjugate Gradient Descent Solver
@@ -30,7 +30,7 @@ function status_summary(cgds::ConjugateGradientDescentState; context::Symbol = :
 
     ## Stopping criterion
     $(_in_str(status_summary(cgds.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
 end
 
 _doc_CG_formula = raw"""

--- a/src/solvers/conjugate_residual.jl
+++ b/src/solvers/conjugate_residual.jl
@@ -91,7 +91,7 @@ end
 function status_summary(crs::ConjugateResidualState; context::Symbol = :default)
     i = get_count(crs, :Iterations)
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(crs.stop) ? "Yes" : "No"
+    Conv = has_converged(crs.stop) ? "Yes" : "No"
     _is_inline(context) && (return "$(repr(crs)) – $(Iter) $(has_converged(crs) ? "(converged)" : "")")
     as = _callbacks_summary(crs)
     s = """
@@ -103,7 +103,7 @@ function status_summary(crs::ConjugateResidualState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(crs.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv
+    The algorithm converged: $Conv
     """
     return s
 end

--- a/src/solvers/conjugate_residual.jl
+++ b/src/solvers/conjugate_residual.jl
@@ -136,7 +136,7 @@ from the [`conjugate_residual`](@ref)
 $(_fields(:at_iteration))
 * `c`: the initial norm
 * `ε`: the threshold
-* `norm_rk`: the last computed norm of the residual
+* `norm_r`: the last computed norm of the residual
 
 # Constructor
 

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -639,16 +639,16 @@ $(_args([:M, :f, :subgrad_f, :p]))
 
 # Keyword arguments
 
-* `atol_errors=eps()`: : tolerance parameter for the linearization errors.
-* `atol_λ=eps()` : tolerance parameter for the convex coefficients in ``λ``.
+* `atol_errors=sqrt(eps())`: tolerance parameter for the linearization errors.
+* `atol_λ=sqrt(eps())`: tolerance parameter for the convex coefficients in ``λ``.
 * `bundle_cap=25``
 $(_kwargs(:callbacks; add_properties = [:process_note]))
-* `diameter=50.0`: estimate for the diameter of the level set of the objective function at the starting point.
+* `diameter=π/3`: estimate for the diameter of the level set of the objective function at the starting point.
 * `domain=(M, p) -> isfinite(f(M, p))`: a function to that evaluates to true when the current candidate is in the domain of the objective `f`, and false otherwise.
 $(_kwargs(:evaluation))
 $(_kwargs(:inverse_retraction_method))
 * `k_max=0`: upper bound on the sectional curvature of the manifold.
-* `m=1e-3`: : the parameter to test the decrease of the cost: ``f(q_{k+1}) ≤ f(p_k) + m ξ``.
+* `m=1e-3`: the parameter to test the decrease of the cost: ``f(q_{k+1}) ≤ f(p_k) + m ξ``.
 $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, `[`ConvexBundleMethodState`](@ref)`)"))
 $(_kwargs(:stopping_criterion; default = "`[`StopWhenLagrangeMultiplierLess`](@ref)`(1e-8)`$(_sc(:Any))[`StopAfterIteration`](@ref)`(5000)"))
 $(_kwargs(:sub_problem; default = "`[`AllocatingEvaluation`](@ref)´ "))

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -109,8 +109,8 @@ $(_fields(:vector_transport_method))
 $(_fields(:X; add_properties = [:as_Subgradient]))
 $(_fields(:stepsize))
 * `ε::R`:                      convex combination of the linearization errors
-* `λ:::AbstractVector{<:R}`:   convex coefficients from the slution of the subproblem
-* `ξ`:                         the stopping parameter given by ``ξ = -$(_tex(:norm, "g"))^2 – ε``
+* `λ::AbstractVector{<:R}`:    convex coefficients from the solution of the subproblem
+* `ξ`:                         the stopping parameter given by ``ξ = -$(_tex(:norm, "g"))^2 - ε``
 $(_fields([:sub_problem, :sub_state]))
 
 # Constructor
@@ -472,7 +472,7 @@ Specify a step size that performs a backtracking to the interior of the domain o
 * `candidate_point=allocate_result(M, rand)`:
   specify a point to be used as memory for the candidate points.
 * `contraction_factor`: how to update ``s`` in the decrease step
-* `initial_stepsize``: specify an initial step size
+* `initial_stepsize`: specify an initial step size
 $(_kwargs(:retraction_method))
 
 $(_note(:ManifoldDefaultsFactory, "DomainBackTrackingStepsize"))
@@ -651,7 +651,7 @@ $(_kwargs(:inverse_retraction_method))
 * `m=1e-3`: the parameter to test the decrease of the cost: ``f(q_{k+1}) ≤ f(p_k) + m ξ``.
 $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, `[`ConvexBundleMethodState`](@ref)`)"))
 $(_kwargs(:stopping_criterion; default = "`[`StopWhenLagrangeMultiplierLess`](@ref)`(1e-8)`$(_sc(:Any))[`StopAfterIteration`](@ref)`(5000)"))
-$(_kwargs(:sub_problem; default = "`[`convex_bundle_method_subsolver`](@ref)"))
+$(_kwargs(:sub_problem; default = "`[`convex_bundle_method_subsolver`](@ref)` "))
 $(_kwargs(:sub_state; default = "`[`AllocatingEvaluation`](@ref)`()"))
 $(_kwargs(:vector_transport_method))
 $(_kwargs(:X))

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -86,15 +86,15 @@ Stores option values for a [`convex_bundle_method`](@ref) solver.
 # Fields
 
 THe following fields require a (real) number type `R`, as well as
-point type `P` and a tangent vector type `T``
+point type `P` and a tangent vector type `T`
 
 $(_fields(:callbacks; add_properties = [:as_dict]))
 * `atol_λ::R`:                 tolerance parameter for the convex coefficients in λ
-* `atol_errors::R:             tolerance parameter for the linearization errors
+* `atol_errors::R`:            tolerance parameter for the linearization errors
 * `bundle<:AbstractVector{Tuple{<:P,<:T}}`: bundle that collects each iterate with the computed subgradient at the iterate
 * `bundle_cap::Int`: the maximal number of elements the bundle is allowed to remember
 * `diameter::R`: estimate for the diameter of the level set of the objective function at the starting point
-* `domain: the domain of ``f`` as a function `(M,p) -> b`that evaluates to true when the current candidate is in the domain of `f`, and false otherwise,
+* `domain`: the domain of ``f`` as a function `(M, p) -> b` that evaluates to true when the current candidate is in the domain of `f`, and false otherwise,
 * `g::T`:                      descent direction
 $(_fields(:inverse_retraction_method))
 * `k_max::R`:                  upper bound on the sectional curvature of the manifold
@@ -130,7 +130,7 @@ Most of the following keyword arguments set default values for the fields mentio
 
 * `atol_errors=eps()`
 * `atol_λ=eps()`
-* `bundle_cap=25``
+* `bundle_cap=25`
 $(_kwargs(:callbacks; show_type = false, add_properties = [:as_dict]))
 * `diameter=50.0`
 * `domain=(M, p) -> isfinite(f(M, p))`
@@ -641,7 +641,7 @@ $(_args([:M, :f, :subgrad_f, :p]))
 
 * `atol_errors=sqrt(eps())`: tolerance parameter for the linearization errors.
 * `atol_λ=sqrt(eps())`: tolerance parameter for the convex coefficients in ``λ``.
-* `bundle_cap=25``
+* `bundle_cap=25`
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `diameter=π/3`: estimate for the diameter of the level set of the objective function at the starting point.
 * `domain=(M, p) -> isfinite(f(M, p))`: a function to that evaluates to true when the current candidate is in the domain of the objective `f`, and false otherwise.
@@ -651,8 +651,8 @@ $(_kwargs(:inverse_retraction_method))
 * `m=1e-3`: the parameter to test the decrease of the cost: ``f(q_{k+1}) ≤ f(p_k) + m ξ``.
 $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, `[`ConvexBundleMethodState`](@ref)`)"))
 $(_kwargs(:stopping_criterion; default = "`[`StopWhenLagrangeMultiplierLess`](@ref)`(1e-8)`$(_sc(:Any))[`StopAfterIteration`](@ref)`(5000)"))
-$(_kwargs(:sub_problem; default = "`[`AllocatingEvaluation`](@ref)´ "))
-$(_kwargs(:sub_state; default = "`[`convex_bundle_method_subsolver`](@ref)"))
+$(_kwargs(:sub_problem; default = "`[`convex_bundle_method_subsolver`](@ref)"))
+$(_kwargs(:sub_state; default = "`[`AllocatingEvaluation`](@ref)`()"))
 $(_kwargs(:vector_transport_method))
 $(_kwargs(:X))
 

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -675,14 +675,14 @@ calls_with_kwargs(::typeof(convex_bundle_method)) = (convex_bundle_method!,)
 @doc "$(_doc_convex_bundle_method)"
 function convex_bundle_method!(
         M::AbstractManifold, f::TF, ∂f!::TdF, p;
-        atol_λ::R = sqrt(eps()),
-        atol_errors::R = sqrt(eps()),
+        atol_λ::Real = sqrt(eps()),
+        atol_errors::Real = sqrt(eps()),
         bundle_cap::Int = 25,
         callbacks = Dict{Symbol, Function}(),
         contraction_factor = 0.975,
-        diameter::R = π / 3, # was `k_max -> k_max === nothing ? π/2 : (k_max ≤ zero(R) ? typemax(R) : π/3)`,
+        diameter::Real = π / 3, # was `k_max -> k_max === nothing ? π/2 : (k_max ≤ zero(R) ? typemax(R) : π/3)`,
         domain = (M, p) -> isfinite(f(M, p)),
-        m::R = 1.0e-3,
+        m::Real = 1.0e-3,
         k_max = 0,
         k_min = 0,
         p_estimate = p,
@@ -701,7 +701,7 @@ function convex_bundle_method!(
         sub_state::Union{AbstractEvaluationType, AbstractManoptSolverState} = evaluation,
         ϱ = nothing,
         kwargs...,
-    ) where {R <: Real, TF, TdF, TRetr, IR, VTransp}
+    ) where {TF, TdF, TRetr, IR, VTransp}
     keywords_accepted(convex_bundle_method!; kwargs...)
     sgo = ManifoldSubgradientObjective(f, ∂f!; evaluation = evaluation, p = p)
     dsgo = decorate_objective!(M, sgo; kwargs...)

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -644,7 +644,7 @@ $(_args([:M, :f, :subgrad_f, :p]))
 * `bundle_cap=25`
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `diameter=π/3`: estimate for the diameter of the level set of the objective function at the starting point.
-* `domain=(M, p) -> isfinite(f(M, p))`: a function to that evaluates to true when the current candidate is in the domain of the objective `f`, and false otherwise.
+* `domain=(M, p) -> isfinite(f(M, p))`: a function that evaluates to true when the current candidate is in the domain of the objective `f`, and false otherwise.
 $(_kwargs(:evaluation))
 $(_kwargs(:inverse_retraction_method))
 * `k_max=0`: upper bound on the sectional curvature of the manifold.

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -342,7 +342,6 @@ function status_summary(cbms::ConvexBundleMethodState; context::Symbol = :defaul
     (context === :inline) && return "A solver state for the Convex Bundle Method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(cbms.stop) ? "Yes" : "No"
-    _is_inline(context) && (return "$(repr(cbms)) – $(Iter) $(has_converged(cbms) ? "(converged)" : "")")
     as = _callbacks_summary(cbms)
     s = """
     # Solver state for `Manopt.jl`s Convex Bundle Method

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -338,10 +338,10 @@ end
 function status_summary(cbms::ConvexBundleMethodState; context::Symbol = :default)
     (context === :short) && return repr(cbms)
     i = get_count(cbms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(cbms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(cbms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the Convex Bundle Method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(cbms.stop) ? "Yes" : "No"
+    Conv = has_converged(cbms.stop) ? "Yes" : "No"
     as = _callbacks_summary(cbms)
     s = """
     # Solver state for `Manopt.jl`s Convex Bundle Method
@@ -362,7 +362,7 @@ function status_summary(cbms::ConvexBundleMethodState; context::Symbol = :defaul
 
     ## Stopping criterion
     $(_in_str(status_summary(cbms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -870,7 +870,6 @@ function (d::DebugWarnIfLagrangeMultiplierIncreases)(
             Consider decreasing either the `diameter` keyword argument, or one
             of the parameters involved in the estimation of the sectional curvature, such as
             `k_min`, `k_max`, `diameter`, or `ϱ` in the `convex_bundle_method` call.
-            of the parameters involved in the estimation of the sectional curvature, such as `k_min`, `k_max`, `diameter`, or `ϱ` in the `convex_bundle_method` call.
             """
             if d.status === :Once
                 @warn "Further warnings will be suppressed, use DebugWarnIfLagrangeMultiplierIncreases(:Always) to get all warnings."
@@ -883,7 +882,6 @@ function (d::DebugWarnIfLagrangeMultiplierIncreases)(
             Consider increasing either the `diameter` keyword argument, or changing
             one of the parameters involved in the estimation of the sectional curvature, such as
             `k_min`, `k_max`, `diameter`, or `ϱ` in the `convex_bundle_method` call.
-            one of the parameters involved in the estimation of the sectional curvature, such as `k_min`, `k_max`, `diameter`, or `ϱ` in the `convex_bundle_method` call.
             """
         else
             d.old_value = min(d.old_value, new_value)

--- a/src/solvers/cyclic_proximal_point.jl
+++ b/src/solvers/cyclic_proximal_point.jl
@@ -78,10 +78,10 @@ end
 function status_summary(cpps::CyclicProximalPointState; context::Symbol = :default)
     (context === :short) && return repr(cpps)
     i = get_count(cpps, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(cpps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(cpps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the cyclic proximal point algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(cpps.stop) ? "Yes" : "No"
+    Conv = has_converged(cpps.stop) ? "Yes" : "No"
     as = _callbacks_summary(cpps)
     s = """
     # Solver state for `Manopt.jl`s Cyclic Proximal Point Algorithm
@@ -91,7 +91,7 @@ function status_summary(cpps::CyclicProximalPointState; context::Symbol = :defau
 
     ## Stopping criterion
     $(_in_str(status_summary(cpps.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/difference_of_convex_algorithm.jl
+++ b/src/solvers/difference_of_convex_algorithm.jl
@@ -220,10 +220,10 @@ end
 function status_summary(dcs::DifferenceOfConvexState; context::Symbol = :default)
     (context === :short) && return repr(dcs)
     i = get_count(dcs, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(dcs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(dcs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the differencce of convex algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(dcs.stop) ? "Yes" : "No"
+    Conv = has_converged(dcs.stop) ? "Yes" : "No"
     as = _callbacks_summary(dcs)
     sub = status_summary(dcs.sub_state; context = context)
     sub = replace(sub, "\n" => "\n    | ", "\n#" => "\n$(_MANOPT_INDENT)##")
@@ -236,7 +236,7 @@ function status_summary(dcs::DifferenceOfConvexState; context::Symbol = :default
 
     ## Stopping criterion
     $(_in_str(status_summary(dcs.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/difference_of_convex_proximal_point.jl
+++ b/src/solvers/difference_of_convex_proximal_point.jl
@@ -59,7 +59,7 @@ end
     get_subtrahend_gradient!(M::AbstractManifold, X, dcpo::ManifoldDifferenceOfConvexProximalObjective, p)
 
 Evaluate the gradient of the subtrahend ``h`` from within
-a [`ManifoldDifferenceOfConvexProximalObjective`](@ref)` `P` at the point `p` (in place of X).
+a [`ManifoldDifferenceOfConvexProximalObjective`](@ref) `P` at the point `p` (in place of X).
 """
 get_subtrahend_gradient(M::AbstractManifold, dcpo::ManifoldDifferenceOfConvexProximalObjective, p)
 
@@ -150,7 +150,7 @@ $(_kwargs(:p; add_properties = [:as_Initial]))
 $(_kwargs(:retraction_method))
 
 $(_kwargs(:stepsize; default = "`[`ConstantLength`](@ref)`()"))
-$(_kwargs(:stopping_criterion; default = "`[StopWhenChangeLess`](@ref)`(1e-8)"))
+$(_kwargs(:stopping_criterion; default = "`[`StopWhenChangeLess`](@ref)`(1e-8)"))
 $(_kwargs(:X; add_properties = [:as_Memory]))
 """
 mutable struct DifferenceOfConvexProximalState{

--- a/src/solvers/difference_of_convex_proximal_point.jl
+++ b/src/solvers/difference_of_convex_proximal_point.jl
@@ -122,7 +122,7 @@ $(_fields(:p; name = "r"))
 $(_fields(:retraction_method))
 $(_fields(:stepsize))
 $(_fields(:stopping_criterion; name = "stop"))
-* `X`, `Y`: the current gradient and descent direction, respectively
+* `X`: the current gradient
   their common type is set by the keyword `X`
 $(_fields([:sub_problem, :sub_state]))
 

--- a/src/solvers/difference_of_convex_proximal_point.jl
+++ b/src/solvers/difference_of_convex_proximal_point.jl
@@ -248,7 +248,6 @@ function status_summary(dcps::DifferenceOfConvexProximalState; context::Symbol =
     (context === :inline) && return "A solver state for the difference of convex proximal point algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(dcps.stop) ? "Yes" : "No"
-    _is_inline(context) && (return "$(repr(dcps)) – $(Iter) $(has_converged(dcps) ? "(converged)" : "")")
     as = _callbacks_summary(dcps)
     sub = repr(dcps.sub_state)
     sub = replace(sub, "\n" => "\n    | ", "\n#" => "\n$(_MANOPT_INDENT)##")

--- a/src/solvers/difference_of_convex_proximal_point.jl
+++ b/src/solvers/difference_of_convex_proximal_point.jl
@@ -13,7 +13,7 @@ where both ``g`` and ``h`` are convex, lower semicontinuous and proper.
 # Fields
 
 * `cost`:     implementation of ``f(p) = g(p)-h(p)``
-* `gradient`: the gradient of the cost
+* `gradient!`: the gradient of the cost
 * `grad_h!`: a function ``$(_tex(:grad))h: $(_math(:Manifold)) → T$(_math(:Manifold))``,
 
 Note that both the gradients might be given in two possible signatures

--- a/src/solvers/difference_of_convex_proximal_point.jl
+++ b/src/solvers/difference_of_convex_proximal_point.jl
@@ -244,10 +244,10 @@ end
 function status_summary(dcps::DifferenceOfConvexProximalState; context::Symbol = :default)
     (context === :short) && return repr(dcps)
     i = get_count(dcps, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(dcps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(dcps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the difference of convex proximal point algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(dcps.stop) ? "Yes" : "No"
+    Conv = has_converged(dcps.stop) ? "Yes" : "No"
     as = _callbacks_summary(dcps)
     sub = repr(dcps.sub_state)
     sub = replace(sub, "\n" => "\n    | ", "\n#" => "\n$(_MANOPT_INDENT)##")
@@ -265,7 +265,7 @@ function status_summary(dcps::DifferenceOfConvexProximalState; context::Symbol =
 
     ## Stopping criterion
     $(_in_str(status_summary(dcps.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 #

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -138,10 +138,10 @@ end
 function status_summary(epms::ExactPenaltyMethodState; context::Symbol = :default)
     (context === :short) && return repr(epms)
     i = get_count(epms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(epms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(epms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the exact panelty method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(epms.stop) ? "Yes" : "No"
+    Conv = has_converged(epms.stop) ? "Yes" : "No"
     (context === :inline) && (return "An exact penalty method state – $(Iter) $(has_converged(epms) ? "(converged)" : "")")
     as = _callbacks_summary(epms)
     s = """
@@ -154,7 +154,7 @@ function status_summary(epms::ExactPenaltyMethodState; context::Symbol = :defaul
 
     ## Stopping criterion
     $(_in_str(status_summary(epms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -257,7 +257,7 @@ $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(300)`$(
 * `sub_grad=`[`ExactPenaltyGrad`](@ref)`(problem, ρ, u; smoothing=smoothing)`: gradient to use in the sub solver
   $(_note(:KeywordUsedIn, "sub_problem"))
 $(_kwargs(:sub_kwargs))
-$(_kwargs(:sub_state; default = "`[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
+$(_kwargs(:sub_problem; default = "`[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
 $(_kwargs(:sub_state; default = "`[`QuasiNewtonState`](@ref)` "))
   where a [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used
 * `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping cirterion for the sub solver

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -260,7 +260,7 @@ $(_kwargs(:sub_kwargs))
 $(_kwargs(:sub_problem; default = "`[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
 $(_kwargs(:sub_state; default = "`[`QuasiNewtonState`](@ref)` "))
   where a [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used
-* `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping cirterion for the sub solver
+* `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping criterion for the sub solver
   $(_note(:KeywordUsedIn, "sub_state"))
 * `u=1e-1`: the smoothing parameter and threshold for violation of the constraints
 * `u_exponent=1/100`: exponent of the u update factor;

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -262,11 +262,11 @@ $(_kwargs(:sub_state; default = "`[`QuasiNewtonState`](@ref)` "))
   where a [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used
 * `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping cirterion for the sub solver
   $(_note(:KeywordUsedIn, "sub_state"))
-* `u=1e–1`: the smoothing parameter and threshold for violation of the constraints
+* `u=1e-1`: the smoothing parameter and threshold for violation of the constraints
 * `u_exponent=1/100`: exponent of the u update factor;
 * `u_min=1e-6`: the lower bound for the smoothing parameter and threshold for violation of the constraints
 * `ρ=1.0`: the penalty parameter
-* `ϵ=1e–3`: the accuracy tolerance
+* `ϵ=1e-3`: the accuracy tolerance
 * `ϵ_exponent=1/100`: exponent of the ϵ update factor;
 * `ϵ_min=1e-6`: the lower bound for the accuracy tolerance
 

--- a/src/solvers/exact_penalty_method.jl
+++ b/src/solvers/exact_penalty_method.jl
@@ -259,7 +259,7 @@ $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(300)`$(
 $(_kwargs(:sub_kwargs))
 $(_kwargs(:sub_state; default = "`[`DefaultManoptProblem`](@ref)`(M, `[`ManifoldGradientObjective`](@ref)`(sub_cost, sub_grad; evaluation=evaluation)"))
 $(_kwargs(:sub_state; default = "`[`QuasiNewtonState`](@ref)` "))
-  , where [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used"))
+  where a [`QuasiNewtonLimitedMemoryDirectionUpdate`](@ref) with [`InverseBFGS`](@ref) is used
 * `sub_stopping_criterion=`[`StopAfterIteration`](@ref)`(200)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(ϵ)`$(_sc(:Any))[`StopWhenStepsizeLess`](@ref)`(1e-10)`: a stopping cirterion for the sub solver
   $(_note(:KeywordUsedIn, "sub_state"))
 * `u=1e–1`: the smoothing parameter and threshold for violation of the constraints

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -183,7 +183,7 @@ gradient_descent(M::AbstractManifold, args...; kwargs...)
 
 function gradient_descent(
         M::AbstractManifold, f, grad_f, p = rand(M);
-        differential = nothing,
+        differential = missing,
         evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
@@ -207,7 +207,7 @@ gradient_descent!(M::AbstractManifold, args...; kwargs...)
 
 function gradient_descent!(
         M::AbstractManifold, f, grad_f, p;
-        differential = nothing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
+        differential = missing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
     keywords_accepted(gradient_descent; kwargs...)

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -239,7 +239,7 @@ function gradient_descent!(
         X = zero_vector(M, p),
         kwargs..., #collect rest
     ) where {O <: Union{AbstractManifoldFirstOrderObjective, AbstractDecoratedManifoldObjective}}
-    # all explicit others others from above are anyways accepted here, so we only have to pass kwargs in
+    # all explicit others from above are anyways accepted here, so we only have to pass kwargs in
     keywords_accepted(gradient_descent!; kwargs...)
     dmgo = decorate_objective!(M, mgo; kwargs...)
     dmp = DefaultManoptProblem(M, dmgo)

--- a/src/solvers/gradient_descent.jl
+++ b/src/solvers/gradient_descent.jl
@@ -109,10 +109,10 @@ end
 function status_summary(gds::GradientDescentState; context::Symbol = :default)
     (context === :short) && return repr(gds)
     i = get_count(gds, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(gds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(gds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the gradient descent solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(gds.stop) ? "Yes" : "No"
+    Conv = has_converged(gds.stop) ? "Yes" : "No"
     as = _callbacks_summary(gds)
     s = """
     # Solver state for `Manopt.jl`s Gradient Descent
@@ -126,7 +126,7 @@ function status_summary(gds::GradientDescentState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(gds.stop; context = context); indent = 1, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/gradient_sampling.jl
+++ b/src/solvers/gradient_sampling.jl
@@ -349,7 +349,7 @@ function gradient_sampling!(
         vector_transport_method::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
         kwargs..., #collect rest
     ) where {O <: Union{AbstractManifoldFirstOrderObjective, AbstractDecoratedManifoldObjective}}
-    # all explicit others others from above are anyways accepted here, so we only have to pass kwargs in
+    # all explicit others from above are anyways accepted here, so we only have to pass kwargs in
     keywords_accepted(gradient_sampling!; kwargs...)
     dmgo = decorate_objective!(M, mgo; kwargs...)
     dmp = DefaultManoptProblem(M, dmgo)

--- a/src/solvers/gradient_sampling.jl
+++ b/src/solvers/gradient_sampling.jl
@@ -36,7 +36,7 @@ The mathematical symbols are adapted from [HosseiniUschmajew:2017](@cite)
 
 # Fields
 $(_fields(:callbacks; add_properties = [:as_dict]))
-* `convex_hull_coefficients<:AbstractVector{R}` store the solution vector of the sub problem, i.e. the coefficients of the result in the convex hull
+* `convex_hull_coeffs<:AbstractVector{R}` store the solution vector of the sub problem, i.e. the coefficients of the result in the convex hull
 $(_fields(:p; add_properties = [:as_Iterate]))
 * `sampled_points<:AbstractVector{P}` memory to store the vector of sampled points
 * `sampled_vectors<:AbstractVector{T}` memory to store the vector of (transported) gradients

--- a/src/solvers/gradient_sampling.jl
+++ b/src/solvers/gradient_sampling.jl
@@ -254,7 +254,7 @@ _doc_gradient_sampling = """
 
 perform the gradient sampling algorithm as introduced in [HosseiniUschmajew:2017](@cite).
 
-The algorithm samples a set of `sampling_size = ```m`` many points in a ball around the current iterate,
+The algorithm samples a set of `sampling_size` = ``m`` many points in a ball around the current iterate,
 evaluates the gradient at these points and transports these to the current iterate.
 It then builds a surrogate in the tangent space consisting of these ``m`` tangent vectors
 and the gradient at the current iterate to determine a new descent direction in the convex

--- a/src/solvers/gradient_sampling.jl
+++ b/src/solvers/gradient_sampling.jl
@@ -221,10 +221,10 @@ end
 function status_summary(gss::GradientSamplingState; context::Symbol = :default)
     (context === :short) && return repr(gss)
     i = get_count(gss, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(gss.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(gss.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the gradient sampling solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(gss.stop) ? "Yes" : "No"
+    Conv = has_converged(gss.stop) ? "Yes" : "No"
     as = _callbacks_summary(gss)
     s = """
     # Solver state for `Manopt.jl`s Gradient Sampling Algorithm
@@ -242,7 +242,7 @@ function status_summary(gss::GradientSamplingState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(gss.stop; context = context); indent = 1, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/gradient_sampling.jl
+++ b/src/solvers/gradient_sampling.jl
@@ -293,7 +293,7 @@ gradient_sampling(M::AbstractManifold, args...; kwargs...)
 
 function gradient_sampling(
         M::AbstractManifold, f, grad_f, p = rand(M);
-        differential = nothing,
+        differential = missing,
         evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
@@ -315,7 +315,7 @@ gradient_sampling!(M::AbstractManifold, args...; kwargs...)
 
 function gradient_sampling!(
         M::AbstractManifold, f, grad_f, p;
-        differential = nothing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
+        differential = missing, evaluation::AbstractEvaluationType = AllocatingEvaluation(),
         kwargs...,
     )
     keywords_accepted(gradient_sampling; kwargs...)

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -349,7 +349,7 @@ get_callbacks(ips::InteriorPointNewtonState) = ips.callbacks
 function status_summary(ips::InteriorPointNewtonState; context::Symbol = :default)
     i = get_count(ips, :Iterations)
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(ips.stop) ? "Yes" : "No"
+    Conv = has_converged(ips.stop) ? "Yes" : "No"
     _is_inline(context) && (return "$(repr(ips)) – $(Iter) $(has_converged(ips) ? "(converged)" : "")")
     as = _callbacks_summary(ips)
     s = """
@@ -364,7 +364,7 @@ function status_summary(ips::InteriorPointNewtonState; context::Symbol = :defaul
     $(_in_str(status_summary(ips.stepsize; context = context); indent = 1, headers = 1))
 
     ## Stopping criterion
-    $(_in_str(status_summary(ips.stop; context = context); indent = 1, headers = 1))    This indicates convergence: $Conv"""
+    $(_in_str(status_summary(ips.stop; context = context); indent = 1, headers = 1))    The algorithm converged: $Conv"""
     return s
 end
 function Base.show(io::IO, ipns::InteriorPointNewtonState)

--- a/src/solvers/interior_point_Newton.jl
+++ b/src/solvers/interior_point_Newton.jl
@@ -204,7 +204,7 @@ $(_kwargs(:retraction_method))
 * `step_problem`: wrap the manifold ``$(_math(:Manifold)) × ℝ^m × ℝ^n × ℝ^m``
 * `step_state`: the [`StepsizeState`](@ref) with point and search direction
 $(_kwargs(:stepsize; default = " `[`ArmijoLinesearch`](@ref)`()"))
-  with the [`InteriorPointCentralityCondition`](@ref) as additional condition to accept a step"))
+  with the [`InteriorPointCentralityCondition`](@ref) as additional condition to accept a step
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(200)`[` | `](@ref StopWhenAny)[`StopWhenChangeLess`](@ref)`(1e-8)"))
 * `vector_space=`[`Rn`](@ref Manopt.Rn): a function that, given an integer, returns the manifold to be used for the vector space components ``ℝ^m,ℝ^n``
 * `W=zero(s)` tangent vector (gradient) for the slack variables
@@ -566,7 +566,7 @@ $(_kwargs(:retraction_method))
   as the problem the line search `stepsize=` employs for determining a step size
 * `step_state`: the [`StepsizeState`](@ref) with point and search direction
 $(_kwargs(:stepsize; default = "`[`ArmijoLinesearch`](@ref)`()"))
-  with the `centrality_condition` keyword as additional criterion to accept a step, if this is provided"))
+  with the `centrality_condition` keyword as additional criterion to accept a step, if this is provided
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(200)`[` | `](@ref StopWhenAny)[`StopWhenKKTResidualLess`](@ref)`(1e-8)"))
   a stopping criterion, by default depending on the residual of the KKT vector field or a maximal number of steps, which ever hits first.
 * `sub_kwargs=(;)`: keyword arguments to decorate the sub options, for example debug, that automatically respects the main solvers debug options (like sub-sampling) as well

--- a/src/solvers/mesh_adaptive_direct_search.jl
+++ b/src/solvers/mesh_adaptive_direct_search.jl
@@ -67,7 +67,7 @@ with two small modifications:
 * `basis`: a basis of the current tangent space with respect to which the mesh is stored
 * `candidate::P`: a memory for a new point/candidate
 * `mesh`: a vector of tangent vectors storing the mesh.
-* `random_vector`: a ``d``-dimensional random vector ``b_l```
+* `random_vector`: a ``d``-dimensional random vector ``b_l``
 * `random_index`: a random index ``ι``
 $(_fields([:retraction_method, :vector_transport_method]))
 * `X::T` the last successful poll direction stored as a tangent vector.

--- a/src/solvers/mesh_adaptive_direct_search.jl
+++ b/src/solvers/mesh_adaptive_direct_search.jl
@@ -16,7 +16,7 @@ as well as to provide functions
 * `get_basepoint(poll!)` that returns the base point at which the mesh is build
 * `get_candidate(poll!)` that returns the last found candidate if the poll was successful.
   Otherwise the base point is returned
-* `get_descent_direction(poll!)` the the vector that points from the base point to the candidate.
+* `get_descent_direction(poll!)` that returns the vector that points from the base point to the candidate.
   If the last poll was not successful, the zero vector is returned
 * `update_basepoint!(M, poll!, p)` that updates the base point to `p` and all necessary
   internal data to a new point to build a mesh at

--- a/src/solvers/mesh_adaptive_direct_search.jl
+++ b/src/solvers/mesh_adaptive_direct_search.jl
@@ -337,7 +337,7 @@ function Base.show(io::IO, dmads::DefaultMeshAdaptiveDirectSearch)
 end
 function status_summary(dmads::DefaultMeshAdaptiveDirectSearch; context::Symbol = :default)
     (context === :short) && return repr(dmads)
-    (context === :inline) && "The default mesh adaptive direct search along a given direction using the $(dmads.retraction_method)"
+    (context === :inline) && return "The default mesh adaptive direct search along a given direction using the $(dmads.retraction_method)"
     return """The default mesh adaptive direct search
     along one given direction X.
 

--- a/src/solvers/mesh_adaptive_direct_search.jl
+++ b/src/solvers/mesh_adaptive_direct_search.jl
@@ -443,10 +443,10 @@ end
 function status_summary(mads::MeshAdaptiveDirectSearchState; context::Symbol = :default)
     (context === :short) && return repr(mads)
     i = get_count(mads, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(mads.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(mads.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the trust region solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(mads.stop) ? "Yes" : "No"
+    Conv = has_converged(mads.stop) ? "Yes" : "No"
     (context === :inline) && (return "A Mesh adaptive direct search state – $(Iter) $(has_converged(trs) ? "(converged)" : "")")
     as = _callbacks_summary(mads)
     s = """
@@ -461,7 +461,7 @@ function status_summary(mads::MeshAdaptiveDirectSearchState; context::Symbol = :
     * search:\n  $(_in_str(status_summary(mads.search; context = context); indent = 1))
 
     ## Stopping criterion
-    $(_in_str(status_summary(mads.stop; context = context); indent = 0, headers = 1))    This indicates convergence: $Conv
+    $(_in_str(status_summary(mads.stop; context = context); indent = 0, headers = 1))    The algorithm converged: $Conv
     """
     return s
 end

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -374,7 +374,6 @@ is less than a threshold.
 # Fields
 * `threshold`:      the threshold
 * `at_iteration`:   store the iteration the stopping criterion was (last) fulfilled
-* `reason`:         store the reason why the stopping criterion was fulfilled, see [`get_reason`](@ref)
 * `velocity_norms`: interim vector to store the norms of the velocities before computing its norm
 
 # Constructor

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -134,10 +134,10 @@ end
 function status_summary(pss::ParticleSwarmState; context::Symbol = :default)
     (context === :short) && return repr(pss)
     i = get_count(pss, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(pss.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(pss.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the particle swarm solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pss.stop) ? "Yes" : "No"
+    Conv = has_converged(pss.stop) ? "Yes" : "No"
     as = _callbacks_summary(pss)
     s = """
     # Solver state for `Manopt.jl`s Particle Swarm Optimization Algorithm
@@ -152,7 +152,7 @@ function status_summary(pss::ParticleSwarmState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(pss.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 #

--- a/src/solvers/particle_swarm.jl
+++ b/src/solvers/particle_swarm.jl
@@ -138,7 +138,6 @@ function status_summary(pss::ParticleSwarmState; context::Symbol = :default)
     (context === :inline) && return "A solver state for the particle swarm solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(pss.stop) ? "Yes" : "No"
-    _is_inline(context) && (return "$(repr(pss)) – $(Iter) $(has_converged(pss) ? "(converged)" : "")")
     as = _callbacks_summary(pss)
     s = """
     # Solver state for `Manopt.jl`s Particle Swarm Optimization Algorithm

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -270,10 +270,10 @@ end
 function status_summary(pdsns::PrimalDualSemismoothNewtonState; context::Symbol = :default)
     (context === :short) && return repr(pdsns)
     i = get_count(pdsns, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(pdsns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(pdsns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the primal dual semismooth Newton solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pdsns.stop) ? "Yes" : "No"
+    Conv = has_converged(pdsns.stop) ? "Yes" : "No"
     as = _callbacks_summary(pdsns)
     s = """
     # Solver state for `Manopt.jl`s primal dual semismooth Newton
@@ -288,7 +288,7 @@ function status_summary(pdsns::PrimalDualSemismoothNewtonState; context::Symbol 
 
     ## Stopping criterion
     $(_in_str(status_summary(pdsns.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 function Base.show(io::IO, pdmssno::PrimalDualManifoldSemismoothNewtonObjective)

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -10,7 +10,7 @@ Describes a Problem for the Primal-dual Riemannian semismooth Newton algorithm. 
 * `adjoint_linearized_operator!`: the adjoint differential ``(DΛ)^* : $(_math(:Manifold; M = "N")) → $(_math(:TangentBundle))``
 * `prox_f!`:                     the proximal map belonging to ``F``
 * `diff_prox_f!`:                the (Clarke Generalized) differential of the proximal maps of ``F``
-* `prox_g_dual!`:                the proximal map belonging to `G^$(_tex(:ast))_n``
+* `prox_g_dual!`:                the proximal map belonging to ``G^$(_tex(:ast))_n``
 * `diff_prox_g_dual!`:           the (Clarke Generalized) differential of the proximal maps of ``G^$(_tex(:ast))_n``
 * `Λ!`:                          the exact forward operator. This operator is required if `Λ(m)=n` does not hold.
 

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -12,7 +12,7 @@ Describes a Problem for the Primal-dual Riemannian semismooth Newton algorithm. 
 * `diff_prox_f!`:                the (Clarke Generalized) differential of the proximal maps of ``F``
 * `prox_g_dual!`:                the proximal map belonging to `G^$(_tex(:ast))_n``
 * `diff_prox_g_dual!`:           the (Clarke Generalized) differential of the proximal maps of ``G^$(_tex(:ast))_n``
-* `Λ`:                           the exact forward operator. This operator is required if `Λ(m)=n` does not hold.
+* `Λ!`:                          the exact forward operator. This operator is required if `Λ(m)=n` does not hold.
 
 # Constructor
 

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -6,12 +6,12 @@ Describes a Problem for the Primal-dual Riemannian semismooth Newton algorithm. 
 # Fields
 
 * `cost`:                        ``F + G(Λ(⋅))`` to evaluate interim cost function values
-* `linearized_operator`:         the linearization ``DΛ(⋅)[⋅]`` of the operator ``Λ(⋅)``.
-* `linearized_adjoint_operator`: the adjoint differential ``(DΛ)^* : $(_math(:Manifold; M = "N")) → $(_math(:TangentBundle))``
-* `prox_F`:                      the proximal map belonging to ``F``
-* `diff_prox_F`:                 the (Clarke Generalized) differential of the proximal maps of ``F``
-* `prox_G_dual`:                 the proximal map belonging to `G^$(_tex(:ast))_n``
-* `diff_prox_dual_G`:            the (Clarke Generalized) differential of the proximal maps of ``G^$(_tex(:ast))_n``
+* `linearized_forward_operator!`: the linearization ``DΛ(⋅)[⋅]`` of the operator ``Λ(⋅)``.
+* `adjoint_linearized_operator!`: the adjoint differential ``(DΛ)^* : $(_math(:Manifold; M = "N")) → $(_math(:TangentBundle))``
+* `prox_f!`:                     the proximal map belonging to ``F``
+* `diff_prox_f!`:                the (Clarke Generalized) differential of the proximal maps of ``F``
+* `prox_g_dual!`:                the proximal map belonging to `G^$(_tex(:ast))_n``
+* `diff_prox_g_dual!`:           the (Clarke Generalized) differential of the proximal maps of ``G^$(_tex(:ast))_n``
 * `Λ`:                           the exact forward operator. This operator is required if `Λ(m)=n` does not hold.
 
 # Constructor
@@ -60,7 +60,7 @@ $(_fields(:p; name = "m"))
 $(_fields(:p; type = "Q", name = "n", M = "N"))
 $(_fields(:p; add_properties = [:as_Iterate]))
 * `primal_stepsize::Float64`:  proximal parameter of the primal prox
-* `reg_param::Float64`:        regularization parameter for the Newton matrix
+* `regularization_parameter::Float64`: regularization parameter for the Newton matrix
 $(_fields(:retraction_method))
 $(_fields(:stopping_criterion; name = "stop"))
 * `update_dual_base`:          function to update the dual base

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -90,7 +90,7 @@ $(Manopt._kwargs([:inverse_retraction_method]))
 * `primal_stepsize=1/sqrt(8)`
 * `reg_param=1e-5`
 $(Manopt._kwargs([:retraction_method]))
-$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(50)`"))
+$(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(50)"))
 * `update_dual_base=(amp, ams, k) -> o.n`
 * `update_primal_base=(amp, ams, k) -> o.m`
 $(_kwargs(:vector_transport_method))

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -75,7 +75,7 @@ If you activate these to be different from the default identity, you have to pro
 
 # Constructor
 
-    PrimalDualSemismoothNewtonState(M::AbstractManifold; kwargs...)
+    PrimalDualSemismoothNewtonState(M::AbstractManifold, N::AbstractManifold; kwargs...)
 
 Generate a state for the [`primal_dual_semismooth_Newton`](@ref).
 
@@ -115,7 +115,7 @@ mutable struct PrimalDualSemismoothNewtonState{
     vector_transport_method::VTM
     X::T
     function PrimalDualSemismoothNewtonState(
-            M::AbstractManifold;
+            M::AbstractManifold, N::AbstractManifold;
             callbacks::C = Dict{Symbol, Function}(),
             dual_stepsize::Float64 = 1 / sqrt(8),
             m::P = rand(M), n::Q = rand(N), p::P = rand(M),
@@ -423,7 +423,7 @@ function primal_dual_semismooth_Newton!(
     dpdmsno = decorate_objective!(M, pdmsno; kwargs...)
     tmp = TwoManifoldProblem(M, N, dpdmsno)
     pdsn = PrimalDualSemismoothNewtonState(
-        M;
+        M, N;
         callbacks = process_callbacks_arg(callbacks, PrimalDualSemismoothNewtonState),
         m = m,
         n = n,

--- a/src/solvers/primal_dual_semismooth_Newton.jl
+++ b/src/solvers/primal_dual_semismooth_Newton.jl
@@ -485,8 +485,8 @@ function primal_dual_step!(tmp::TwoManifoldProblem, pdsn::PrimalDualSemismoothNe
     return pdsn.X = pdsn.X + dξ
 end
 
-raw"""
-    construct_primal_dual_residual_vector(p, o)
+@doc raw"""
+    construct_primal_dual_residual_vector(tmp::TwoManifoldProblem, pdsn::PrimalDualSemismoothNewtonState)
 
 Constructs the vector representation of ``X(p^{(k)}, ξ_{n}^{(k)}) ∈ \mathcal{T}_{p^{(k)}} \mathcal{M} \times \mathcal{T}_{n}^{*} \mathcal{N}``
 """
@@ -540,8 +540,8 @@ function construct_primal_dual_residual_vector(
     return [X₁; X₂]
 end
 
-raw"""
-onstruct_primal_dual_residual_covariant_derivative_matrix(p, o)
+@doc raw"""
+    construct_primal_dual_residual_covariant_derivative_matrix(tmp::TwoManifoldProblem, pdsn::PrimalDualSemismoothNewtonState)
 
 Constructs the matrix representation of ``V^{(k)}:\mathcal{T}_{p^{(k)}} \mathcal{M} \times \mathcal{T}_{n}^{*} \mathcal{N}\rightarrow \mathcal{T}_{p^{(k)}} \mathcal{M} \times \mathcal{T}_{n}^{*} \mathcal{N}``
 """

--- a/src/solvers/projected_gradient_method.jl
+++ b/src/solvers/projected_gradient_method.jl
@@ -229,7 +229,7 @@ function projected_gradient_method(M, f, grad_f, proj; kwargs...)
     return projected_gradient_method(M, f, grad_f, proj, rand(M); kwargs...)
 end
 function projected_gradient_method(
-        M, f, grad_f, proj, p; indicator = nothing, evaluation = AllocatingEvaluation(), kwargs...
+        M, f, grad_f, proj, p; indicator = missing, evaluation = AllocatingEvaluation(), kwargs...
     )
     cs_obj = ManifoldConstrainedSetObjective(
         f, grad_f, proj; evaluation = evaluation, indicator = indicator
@@ -245,7 +245,7 @@ calls_with_kwargs(::typeof(projected_gradient_method)) = (projected_gradient_met
 
 @doc "$(_doc_pgm)"
 function projected_gradient_method!(
-        M, f, grad_f, proj, p; indicator = nothing, evaluation = AllocatingEvaluation(), kwargs...
+        M, f, grad_f, proj, p; indicator = missing, evaluation = AllocatingEvaluation(), kwargs...
     )
     cs_obj = ManifoldConstrainedSetObjective(
         f, grad_f, proj; evaluation = evaluation, indicator = indicator

--- a/src/solvers/projected_gradient_method.jl
+++ b/src/solvers/projected_gradient_method.jl
@@ -93,10 +93,10 @@ end
 function status_summary(pgms::ProjectedGradientMethodState; context::Symbol = :default)
     (context === :short) && return repr(pgms)
     i = get_count(pgms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(pgms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(pgms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the projected gradient solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pgms.stop) ? "Yes" : "No"
+    Conv = has_converged(pgms.stop) ? "Yes" : "No"
     as = _callbacks_summary(pgms)
     s = """
     # Solver state for `Manopt.jl`s Projected Gradient Method
@@ -113,7 +113,7 @@ function status_summary(pgms::ProjectedGradientMethodState; context::Symbol = :d
 
     ## Stopping criterion
     $(_in_str(status_summary(pgms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/projected_gradient_method.jl
+++ b/src/solvers/projected_gradient_method.jl
@@ -3,7 +3,7 @@
 
 # Fields
 
-$(_fields(:stepsize; name = "backtracking")) to determine the step size ``β_k`` step size from ``p_k`` to the candidate ``q_k``
+$(_fields(:stepsize; name = "backtrack")) to determine the step size ``β_k`` step size from ``p_k`` to the candidate ``q_k``
 $(_fields(:callbacks; add_properties = [:as_dict]))
 $(_fields(:inverse_retraction_method))
 $(_fields(:p; add_properties = [:as_Iterate]))

--- a/src/solvers/proximal_bundle_method.jl
+++ b/src/solvers/proximal_bundle_method.jl
@@ -278,7 +278,7 @@ $(_kwargs(:evaluation))
 $(_kwargs(:inverse_retraction_method))
 * `m=0.0125`:        a real number that controls the decrease of the cost function
 $(_kwargs(:retraction_method))
-$(_kwargs(:stopping_criterion; default = "`[`StopWhenLagrangeMultiplierLess`](@ref)`(1e-8)`$(_sc(:Any))[`StopAfterIteration`](@ref)`(5000)`"))
+$(_kwargs(:stopping_criterion; default = "`[`StopWhenLagrangeMultiplierLess`](@ref)`(1e-8)`$(_sc(:Any))[`StopAfterIteration`](@ref)`(5000)"))
 $(_kwargs(:sub_problem; default = "`[`proximal_bundle_method_subsolver`](@ref)`"))
 $(_kwargs(:sub_state; default = "`[`AllocatingEvaluation`](@ref)` "))
 $(_kwargs(:vector_transport_method))

--- a/src/solvers/proximal_bundle_method.jl
+++ b/src/solvers/proximal_bundle_method.jl
@@ -181,10 +181,10 @@ end
 function status_summary(pbms::ProximalBundleMethodState; context::Symbol = :default)
     (context === :short) && return repr(pbms)
     i = get_count(pbms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(pbms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(pbms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the proximal bundle method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pbms.stop) ? "Yes" : "No"
+    Conv = has_converged(pbms.stop) ? "Yes" : "No"
     as = _callbacks_summary(pbms)
     s = """
     # Solver state for `Manopt.jl`s Proximal Bundle Method
@@ -204,7 +204,7 @@ function status_summary(pbms::ProximalBundleMethodState; context::Symbol = :defa
 
     ## Stopping criterion
     $(_in_str(status_summary(pbms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/proximal_gradient_method.jl
+++ b/src/solvers/proximal_gradient_method.jl
@@ -241,7 +241,7 @@ end
 function status_summary(pgms::ProximalGradientMethodState; context::Symbol = :default)
     i = get_count(pgms, :Iterations)
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pgms.stop) ? "Yes" : "No"
+    Conv = has_converged(pgms.stop) ? "Yes" : "No"
     _is_inline(context) && (return "$(repr(pgms)) – $(Iter) $(has_converged(pgms) ? "(converged)" : "")")
     as = _callbacks_summary(pgms)
     s = """
@@ -254,7 +254,7 @@ function status_summary(pgms::ProximalGradientMethodState; context::Symbol = :de
 
     ## Stopping criterion
     $(_in_str(status_summary(pgms.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/proximal_gradient_method.jl
+++ b/src/solvers/proximal_gradient_method.jl
@@ -362,7 +362,7 @@ function status_summary(pgb::ProximalGradientMethodBacktrackingStepsize; context
     """
 end
 function (s::ProximalGradientMethodBacktrackingStepsize)(
-        mp::AbstractManoptProblem, st::ProximalGradientMethodState, i::Int, args...; kwargs...
+        mp::AbstractManoptProblem, st::ProximalGradientMethodState, k::Int, args...; kwargs...
     )
     # Initialization
     M = get_manifold(mp)
@@ -371,7 +371,7 @@ function (s::ProximalGradientMethodBacktrackingStepsize)(
 
     # For the convex case, start with the last stepsize (warm start)
     # For the nonconvex case, reset to initial stepsize
-    λ = if s.strategy === :convex && i > 1
+    λ = if s.strategy === :convex && k > 1
         min(s.initial_stepsize, s.warm_start_factor * s.last_stepsize)
     else
         s.initial_stepsize
@@ -567,19 +567,19 @@ end
 #
 # Stopping Criterion
 function (sc::StopWhenGradientMappingNormLess)(
-        mp::AbstractManoptProblem, s::ProximalGradientMethodState, i::Int
+        mp::AbstractManoptProblem, s::ProximalGradientMethodState, k::Int
     )
     M = get_manifold(mp)
-    if i == 0 # reset on init
+    if k == 0 # reset on init
         sc.at_iteration = -1
     end
-    if (i > 0)
+    if (k > 0)
         sc.last_change =
             1 / s.last_stepsize * norm(
             M, s.q, inverse_retract(M, s.q, get_iterate(s), s.inverse_retraction_method)
         )
         if sc.last_change < sc.threshold
-            sc.at_iteration = i
+            sc.at_iteration = k
             return true
         end
     end

--- a/src/solvers/proximal_point.jl
+++ b/src/solvers/proximal_point.jl
@@ -56,10 +56,10 @@ end
 function status_summary(pps::ProximalPointState; context::Symbol = :default)
     (context === :short) && return repr(pps)
     i = get_count(pps, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(pps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(pps.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the proximal point algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(pps.stop) ? "Yes" : "No"
+    Conv = has_converged(pps.stop) ? "Yes" : "No"
     as = _callbacks_summary(pps)
     (length(as) > 0) && (as = "## Parameters\n$(as)\n\n")
     s = """
@@ -67,7 +67,7 @@ function status_summary(pps::ProximalPointState; context::Symbol = :default)
     $Iter$(as)
     ## Stopping criterion
     $(_in_str(status_summary(pps.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 #

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -214,7 +214,7 @@ $(_args([:M, :f, :grad_f, :p]))
 # Keyword arguments
 
 * `basis::AbstractBasis=`[`DefaultOrthonormalBasis`](@extref ManifoldsBase.DefaultOrthonormalBasis)`()`:
-  basis to use within each of the the tangent spaces to represent
+  basis to use within each of the tangent spaces to represent
   the Hessian (inverse) for the cases where it is stored in full (matrix) form.
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `cautious_update::Bool=false`:

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -198,7 +198,7 @@ Perform a quasi Newton iteration to solve
 
 $(_problem(:Default))
 
-with start point `p`. The iterations can be done in-place of `p```=p^{(0)}``.
+with start point `p`. The iterations can be done in-place of `p`, which is used as ``p^{(0)}``.
 The ``k``th iteration consists of
 
 1. Compute the search direction ``η^{(k)} = -$(_tex(:Cal, "B"))_k [$(_tex(:grad))f (p^{(k)})]`` or solve ``$(_tex(:Cal, "H"))_k [η^{(k)}] = -$(_tex(:grad))f (p^{(k)})]``.

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -155,10 +155,10 @@ end
 function status_summary(qns::QuasiNewtonState; context::Symbol = :default)
     (context === :short) && return repr(qns)
     i = get_count(qns, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(qns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(qns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the quasi Newton solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(qns.stop) ? "Yes" : "No"
+    Conv = has_converged(qns.stop) ? "Yes" : "No"
     as = _callbacks_summary(qns)
     s = """
     # Solver state for `Manopt.jl`s Quasi Newton Method
@@ -173,7 +173,7 @@ function status_summary(qns::QuasiNewtonState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(qns.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 get_iterate(qns::QuasiNewtonState) = qns.p

--- a/src/solvers/quasi_Newton.jl
+++ b/src/solvers/quasi_Newton.jl
@@ -164,7 +164,7 @@ function status_summary(qns::QuasiNewtonState; context::Symbol = :default)
     # Solver state for `Manopt.jl`s Quasi Newton Method
     $Iter
     ## Parameters$(as)
-    * direction update:        $(status_summary(qns.direction_update))
+    * direction update:        $(status_summary(qns.direction_update; context = :inline))
     * retraction method:       $(qns.retraction_method)
     * vector transport method: $(qns.vector_transport_method)
 

--- a/src/solvers/stochastic_gradient_descent.jl
+++ b/src/solvers/stochastic_gradient_descent.jl
@@ -11,7 +11,7 @@ $(_fields(:p; add_properties = [:as_Iterate]))
 * `direction`:  a direction update to use
 $(_fields(:stopping_criterion; name = "stop"))
 $(_fields(:stepsize))
-* `evaluation_order`: specify whether to use a randomly permuted sequence (`:FixedRandom`:),
+* `order_type`: specify whether to use a randomly permuted sequence (`:FixedRandom`:),
   a per cycle permuted sequence (`:Linear`) or the default, a `:Random` sequence.
 * `order`: stores the current permutation
 $(_fields(:retraction_method))

--- a/src/solvers/stochastic_gradient_descent.jl
+++ b/src/solvers/stochastic_gradient_descent.jl
@@ -96,10 +96,10 @@ end
 function status_summary(sgds::StochasticGradientDescentState; context::Symbol = :default)
     (context === :short) && return repr(sgds)
     i = get_count(sgds, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(sgds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(sgds.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the stochastic gradient descent algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(sgds.stop) ? "Yes" : "No"
+    Conv = has_converged(sgds.stop) ? "Yes" : "No"
     as = _callbacks_summary(sgds)
     s = """
     # Solver state for `Manopt.jl`s Stochastic Gradient Descent
@@ -114,7 +114,7 @@ function status_summary(sgds::StochasticGradientDescentState; context::Symbol = 
 
     ## Stopping criterion
     $(_in_str(status_summary(sgds.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 """

--- a/src/solvers/stochastic_gradient_descent.jl
+++ b/src/solvers/stochastic_gradient_descent.jl
@@ -26,7 +26,7 @@ Create a `StochasticGradientDescentState` with start point `p`.
 
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `direction=`[`StochasticGradientRule`](@ref)`(M, `$(_link(:zero_vector))`)`
-* `order_type=:RandomOrder``
+* `order_type=:RandomOrder`
 * `order=Int[]`: specify how to store the order of indices for the next epoche
 $(_kwargs(:retraction_method))
 $(_kwargs(:p; add_properties = [:as_Initial]))

--- a/src/solvers/stochastic_gradient_descent.jl
+++ b/src/solvers/stochastic_gradient_descent.jl
@@ -11,8 +11,9 @@ $(_fields(:p; add_properties = [:as_Iterate]))
 * `direction`:  a direction update to use
 $(_fields(:stopping_criterion; name = "stop"))
 $(_fields(:stepsize))
-* `order_type`: specify whether to use a randomly permuted sequence (`:FixedRandom`:),
-  a per cycle permuted sequence (`:Linear`) or the default, a `:Random` sequence.
+* `order_type`: specify whether to use a fixed randomly permuted sequence (`:FixedRandom`),
+  the sequence as given in `order` (`:Linear`), or the default `:Random` one,
+  which chooses a random gradient in every step.
 * `order`: stores the current permutation
 $(_fields(:retraction_method))
 
@@ -26,7 +27,7 @@ Create a `StochasticGradientDescentState` with start point `p`.
 
 $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `direction=`[`StochasticGradientRule`](@ref)`(M, `$(_link(:zero_vector))`)`
-* `order_type=:RandomOrder`
+* `order_type=:Random`
 * `order=Int[]`: specify how to store the order of indices for the next epoche
 $(_kwargs(:retraction_method))
 $(_kwargs(:p; add_properties = [:as_Initial]))
@@ -65,7 +66,7 @@ function StochasticGradientDescentState(
         p::P = rand(M),
         X::T = zero_vector(M, p),
         direction::D = StochasticGradientRule(M; X = copy(M, p, X)),
-        order_type::Symbol = :RandomOrder,
+        order_type::Symbol = :Random,
         order::Vector{<:Int} = Int[],
         retraction_method::RM = default_retraction_method(M, typeof(p)),
         stopping_criterion::SC = StopAfterIteration(1000),
@@ -73,6 +74,9 @@ function StochasticGradientDescentState(
     ) where {
         P, T, C <: AbstractDict{Symbol}, D <: DirectionUpdateRule, RM <: AbstractRetractionMethod, SC <: StoppingCriterion, S <: Stepsize,
     }
+    (order_type in (:Random, :FixedRandom, :Linear)) || throw(
+        DomainError(order_type, "The order type has to be one of :Random, :FixedRandom, or :Linear.")
+    )
     return StochasticGradientDescentState(;
         callbacks = callbacks, p = p, X = X, direction = direction, stopping_criterion = stopping_criterion,
         stepsize = stepsize, order_type = order_type, order = order, retraction_method = retraction_method, k = 0,
@@ -214,10 +218,8 @@ $(_kwargs(:callbacks; add_properties = [:process_note]))
 * `direction=`[`StochasticGradient`](@ref)`(`$(_link(:zero_vector))`)` add a post-processor to
   the direction obtained from evaluating the sub-gradient.
 $(_kwargs(:evaluation))
-* `evaluation_order=:Random`: specify whether to use a randomly permuted sequence (`:FixedRandom`:,
-  a per cycle permuted sequence (`:Linear`) or the default `:Random` one.
-* `order_type=:RandomOrder`: a type of ordering of gradient evaluations.
-  Possible values are `:RandomOrder`, a `:FixedPermutation`, `:LinearOrder`
+* `order_type=:Linear`: whether to use a randomly permuted sequence (`:FixedRandom`),
+  a per cycle permuted sequence (`:Random`, default) or the default `:Linear` one.
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(1000)"))
 $(_kwargs(:stepsize; default = "`[`default_stepsize`](@ref)`(M, `[`StochasticGradientDescentState`](@ref)`)"))
 * `order=[1:n]`: the initial permutation, where `n` is the number of gradients in `gradF`.

--- a/src/solvers/subgradient.jl
+++ b/src/solvers/subgradient.jl
@@ -72,10 +72,10 @@ end
 function status_summary(sgms::SubGradientMethodState; context::Symbol = :default)
     (context === :short) && return repr(sgms)
     i = get_count(sgms, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(sgms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(sgms.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the subgradient method$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(sgms.stop) ? "Yes" : "No"
+    Conv = has_converged(sgms.stop) ? "Yes" : "No"
     as = _callbacks_summary(sgms)
     s = """
     # Solver state for `Manopt.jl`s Subgradient Method
@@ -88,7 +88,7 @@ function status_summary(sgms::SubGradientMethodState; context::Symbol = :default
 
     ## Stopping criterion
     $(_in_str(status_summary(sgms.stop; context = context); indent = 1, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 get_iterate(sgs::SubGradientMethodState) = sgs.p

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -321,8 +321,6 @@ yield a reduction of the model.
 
 $(_fields(:at_iteration))
 * `value` store the value of the inner product.
-* `reason`: stores a reason of stopping if the stopping criterion has been reached,
-  see [`get_reason`](@ref).
 
 # Constructor
 

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -11,13 +11,11 @@ $(_fields(:callbacks; add_properties = [:as_dict]))
 * `δ::T`:                     the conjugate gradient search direction
 * `δHδ`, `YPδ`, `δPδ`, `YPδ`: temporary inner products with `Hδ` and preconditioned inner products.
 * `Hδ`, `HY`:                 temporary results of the Hessian applied to `δ` and `Y`, respectively.
-* `κ::R`:                     the linear convergence target rate.
 * `project!`:                 for numerical stability it is possible to project onto the tangent space after every iteration.
   the function has to work inplace of `Y`, that is `(M, Y, p, X) -> Y`, where `X` and `Y` can be the same memory.
 * `randomize`:          indicate whether `X` is initialized to a random vector or not
 * `residual::T`:                 the gradient of the model ``m(Y)``
 $(_fields(:stopping_criterion; name = "stop"))
-* `θ::R`:                     the superlinear convergence target rate of ``1+θ``
 * `trust_region_radius::R`:   the trust-region radius
 * `X::T`:                     the gradient ``$(_tex(:grad))f(p)``
 * `Y::T`:                     current iterate tangent vector

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -124,10 +124,10 @@ end
 function status_summary(tcgs::TruncatedConjugateGradientState; context::Symbol = :default)
     (context === :short) && return repr(tcgs)
     i = get_count(tcgs, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(tcgs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(tcgs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the truncated conjugate gradient descent$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(tcgs.stop) ? "Yes" : "No"
+    Conv = has_converged(tcgs.stop) ? "Yes" : "No"
     as = _callbacks_summary(tcgs)
     return """
     # Solver state for `Manopt.jl`s Truncated Conjugate Gradient Descent
@@ -138,7 +138,7 @@ function status_summary(tcgs::TruncatedConjugateGradientState; context::Symbol =
 
     ## Stopping criterion
     $(_in_str(status_summary(tcgs.stop; context = context); indent = 1, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
 end
 get_callbacks(tcgs::TruncatedConjugateGradientState) = tcgs.callbacks
 function set_parameter!(tcgs::TruncatedConjugateGradientState, ::Val{:Iterate}, Y)

--- a/src/solvers/truncated_conjugate_gradient_descent.jl
+++ b/src/solvers/truncated_conjugate_gradient_descent.jl
@@ -127,7 +127,7 @@ function status_summary(tcgs::TruncatedConjugateGradientState; context::Symbol =
     (context === :short) && return repr(tcgs)
     i = get_count(tcgs, :Iterations)
     conv_inl = (i > 0) ? (indicates_convergence(tcgs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
-    (context === :inline) && "A solver state for the truncated conjugate gradient descent$(conv_inl)"
+    (context === :inline) && return "A solver state for the truncated conjugate gradient descent$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(tcgs.stop) ? "Yes" : "No"
     as = _callbacks_summary(tcgs)
@@ -416,7 +416,7 @@ function get_reason(c::StopWhenModelIncreased)
     return ""
 end
 function status_summary(c::StopWhenModelIncreased; context::Symbol = :default)
-    (context === :short) && (repr(c))
+    (context === :short) && return repr(c)
     has_stopped = (c.at_iteration >= 0)
     s = has_stopped ? "reached" : "not reached"
     (context === :inline) && (return "Model Increased:$(_MANOPT_INDENT)$s")

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -8,7 +8,7 @@ Store the state of the trust-regions solver.
 * `acceptance_rate`:         a lower bound of the performance ratio for the iterate
   that decides if the iteration is accepted or not.
 $(_fields(:callbacks; add_properties = [:as_dict]))
-* `HX`, `HY`, `HZ`:          interim storage (to avoid allocation) of ``$(_tex(:Hess)) f(p)[⋅]` of `X`, `Y`, `Z`
+* `HX`, `HY`, `HZ`:          interim storage (to avoid allocation) of ``$(_tex(:Hess)) f(p)[⋅]`` for `X`, `Y`, `Z`
 * `max_trust_region_radius`: the maximum trust-region radius
 $(_fields(:p; add_properties = [:as_Iterate]))
 * `project!`:                for numerical stability it is possible to project onto the tangent space after every iteration.

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -236,10 +236,10 @@ end
 function status_summary(trs::TrustRegionsState; context::Symbol = :default)
     (context === :short) && return repr(trs)
     i = get_count(trs, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(trs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(trs.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the trust region solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(trs.stop) ? "Yes" : "No"
+    Conv = has_converged(trs.stop) ? "Yes" : "No"
     (context === :inline) && (return "A trust regions method state – $(Iter) $(has_converged(trs) ? "(converged)" : "")")
     sub = _in_str(status_summary(trs.sub_state; context = context); indent = 1, headers = 1, indent_end = "| ")
     as = _callbacks_summary(trs)
@@ -259,7 +259,7 @@ function status_summary(trs::TrustRegionsState; context::Symbol = :default)
 
     ## Stopping criterion
     $(_in_str(status_summary(trs.stop; context = context); indent = 1, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/trust_regions.jl
+++ b/src/solvers/trust_regions.jl
@@ -309,7 +309,7 @@ $(_kwargs(:retraction_method))
 $(_kwargs(:stopping_criterion; default = "`[`StopAfterIteration`](@ref)`(1000)`$(_sc(:Any))[`StopWhenGradientNormLess`](@ref)`(1e-6)"))
 $(_kwargs(:sub_kwargs))
 $(_kwargs(:stopping_criterion; name = "sub_stopping_criterion", default = "`( see [`truncated_conjugate_gradient_descent`](@ref))` "))
-* `sub_objective` : the subojective do solve, by default the [`TrustRegionModelObjective`](@ref)`(mho)` possibly decorated with `sub_kwargs``
+* `sub_objective`: the sub objective to solve, by default the [`TrustRegionModelObjective`](@ref)`(mho)` possibly decorated with `sub_kwargs`
   Note that this keyword has no effect if you set the `sub_problem` directly.
 $(_kwargs(:sub_problem; default = "`[`DefaultManoptProblem`](@ref)`(`[`TangentSpace`](@extref `ManifoldsBase.TangentSpace`)`(M,p), sub_objective)"))
 $(_kwargs(:sub_state; default = "`[`TruncatedConjugateGradientState`](@ref)` "))

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -206,10 +206,10 @@ default_stepsize(M::AbstractManifold, ::Type{VectorBundleNewtonState}) = Constan
 function status_summary(vbns::VectorBundleNewtonState; context::Symbol = :default)
     (context === :short) && return repr(vbns)
     i = get_count(vbns, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(vbns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(vbns.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the vector bundle Newton solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(vbns.stop) ? "Yes" : "No"
+    Conv = has_converged(vbns.stop) ? "Yes" : "No"
     as = _callbacks_summary(vbns)
     s = """
     # Solver state for `Manopt.jl`s Vector bundle Newton method
@@ -222,7 +222,7 @@ function status_summary(vbns::VectorBundleNewtonState; context::Symbol = :defaul
 
     ## Stopping criterion
     $(_in_str(status_summary(vbns.stop; context = context); indent = 0, headers = 1))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -324,10 +324,12 @@ $(_kwargs(:X; add_properties = [:as_Memory]))
 
 @doc "$(doc_vector_bundle_newton)"
 function vectorbundle_newton(M::AbstractManifold, E::AbstractManifold, NE, p; kwargs...)
+    keywords_accepted(vectorbundle_newton; kwargs...)
     #replace type of E with VectorBundle once this is available in ManifoldsBase
     q = copy(M, p)
     return vectorbundle_newton!(M, E, NE, q; kwargs...)
 end
+calls_with_kwargs(::typeof(vectorbundle_newton)) = (vectorbundle_newton!,)
 
 
 @doc "$(doc_vector_bundle_newton)"
@@ -344,6 +346,7 @@ function vectorbundle_newton!(
         X::T = zero_vector(M, p),
         kwargs...,
     ) where {O, P, T, Pr, Op, RM <: AbstractRetractionMethod, SC <: StoppingCriterion}
+    keywords_accepted(vectorbundle_newton!; kwargs...)
     isnothing(sub_problem) && error("Please provide a sub_problem (method that solves the Newton equation)")
     vbp = VectorBundleManoptProblem(M, E, NE)
     vbs = VectorBundleNewtonState(
@@ -358,6 +361,7 @@ function vectorbundle_newton!(
     solve!(vbp, dvbs)
     return get_solver_return(dvbs)
 end
+calls_with_kwargs(::typeof(vectorbundle_newton!)) = (decorate_state!,)
 
 function initialize_solver!(::VectorBundleManoptProblem, s::VectorBundleNewtonState)
     return s

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -270,17 +270,17 @@ returns the range vector bundle stored within a [`VectorBundleManoptProblem`](@r
 """
 get_vectorbundle(vbp::VectorBundleManoptProblem) = vbp.vectorbundle
 
-raw"""
+"""
     get_manifold(vbp::VectorBundleManoptProblem)
 
-    returns the domain manifold stored within a [`VectorBundleManoptProblem`](@ref)
+returns the domain manifold stored within a [`VectorBundleManoptProblem`](@ref)
 """
 get_manifold(vbp::VectorBundleManoptProblem) = vbp.manifold
 
-raw"""
+"""
     get_newton_equation(mp::VectorBundleManoptProblem)
 
-returns the Newton equation [`newton_equation`](@ref) stored within an [`VectorBundleManoptProblem`](@ref).
+returns the Newton equation `newton_equation` stored within a [`VectorBundleManoptProblem`](@ref).
 """
 function get_newton_equation(vbp::VectorBundleManoptProblem)
     return vbp.newton_equation

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -153,7 +153,7 @@ function Base.show(io::IO, acs::AffineCovariantStepsize)
     return print(io, ")")
 end
 function status_summary(acs::AffineCovariantStepsize; context = :default)
-    (context === :short) && repr(acs)
+    (context === :short) && return repr(acs)
     (context === :inline) && return "An affine covariant step size (last step size: $(acs.last_stepsize))"
     on = ismissing(acs.outer_norm) ? "" : "\n* outer norm:       $(_MANOPT_INDENT)$(acs.outer_norm)"
     return """

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -105,7 +105,7 @@ by a predictor-corrector-loop using an affine covariant quantity ``θ`` to measu
 
 On an $(_link(:AbstractPowerManifold)) like ``$(_math(:Manifold)) = $(_math(:Manifold; M = "N"))^n``
 any point ``p = (p_1,…,p_n) ∈ $(_math(:Manifold))`` is a vector of length ``n`` with of points ``p_i ∈ $(_math(:Manifold; M = "N"))``.
-Then, denoting the `outer_norm` by ``r``, the distance of two points ``p,q ∈ $(_math(:Manifold))`
+Then, denoting the `outer_norm` by ``r``, the distance of two points ``p,q ∈ $(_math(:Manifold))``
 is given by
 
 ```math

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -210,7 +210,6 @@ function status_summary(vbns::VectorBundleNewtonState; context::Symbol = :defaul
     (context === :inline) && return "A solver state for the vector bundle Newton solver$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
     Conv = indicates_convergence(vbns.stop) ? "Yes" : "No"
-    _is_inline(context) && (return "$(repr(vbns)) – $(Iter) $(has_converged(vbns) ? "(converged)" : "")")
     as = _callbacks_summary(vbns)
     s = """
     # Solver state for `Manopt.jl`s Vector bundle Newton method

--- a/src/solvers/vectorbundle_newton.jl
+++ b/src/solvers/vectorbundle_newton.jl
@@ -104,7 +104,7 @@ by a predictor-corrector-loop using an affine covariant quantity ``θ`` to measu
 # Example
 
 On an $(_link(:AbstractPowerManifold)) like ``$(_math(:Manifold)) = $(_math(:Manifold; M = "N"))^n``
-any point ``p = (p_1,…,p_n) ∈ $(_math(:Manifold))`` is a vector of length ``n`` with of points ``p_i ∈ $(_math(:Manifold; M = "N"))``.
+any point ``p = (p_1,…,p_n) ∈ $(_math(:Manifold))`` is a vector of length ``n`` of points ``p_i ∈ $(_math(:Manifold; M = "N"))``.
 Then, denoting the `outer_norm` by ``r``, the distance of two points ``p,q ∈ $(_math(:Manifold))``
 is given by
 

--- a/test/commons/test_primal_dual_objectives.jl
+++ b/test/commons/test_primal_dual_objectives.jl
@@ -82,7 +82,7 @@ using RecursiveArrayTools
     @test all(get_iterate(s_exact) .== p0)
 
     osm = PrimalDualSemismoothNewtonState(
-        M; m = m, n = n, p = zero.(p0), X = X0,
+        M, N; m = m, n = n, p = zero.(p0), X = X0,
         primal_stepsize = 0.0, dual_stepsize = 0.0, regularization_parameter = 0.0,
     )
     set_iterate!(osm, p0)

--- a/test/commons/test_stepsizes.jl
+++ b/test/commons/test_stepsizes.jl
@@ -93,9 +93,9 @@ end
     s2 = NonmonotoneLinesearch()(M)
     @test startswith(repr(s2), "NonmonotoneLinesearch(;")
     @test Manopt.get_message(s2) == ""
-    @test startswith(repr(s2.bb_stepsize), "BarzileiBorweinStepsize(; ")
+    @test startswith(repr(s2.bb_stepsize), "BarzilaiBorweinStepsize(; ")
     @test startswith(Manopt.status_summary(s2), "Non-monotone linesearch")
-    @test startswith(Manopt.status_summary(s2.bb_stepsize), "Barzilei–Borwein stepsize\n")
+    @test startswith(Manopt.status_summary(s2.bb_stepsize), "Barzilai–Borwein stepsize\n")
 
 
     s3 = WolfePowellBinaryLinesearch()(M)
@@ -199,7 +199,7 @@ end
         @test abs_const_step(mp, gds, 1) ==
             1.0 / norm(get_manifold(mp), get_iterate(gds), get_gradient(gds))
     end
-    @testset "BarzileiBorwein" begin
+    @testset "BarzilaiBorwein" begin
         M = Euclidean(2)
         f(M, p) = sum(p .^ 2)
         grad_f(M, p) = 2 .* p
@@ -207,7 +207,7 @@ end
         p = [2.0, 2.0]
         X = grad_f(M, p)
         # Create stepsize with factory
-        bb = BarzileiBorwein()(M) #
+        bb = BarzilaiBorwein()(M) #
         gds = GradientDescentState(M; p = p, stepsize = bb)
         # Check both modes to use BB
         # (1) vector transport when providing a last stepsize – no history -> max
@@ -238,7 +238,7 @@ end
         gs = GradientDescentState(M; p = p, X = grad_f(M, p))
         clbs = CubicBracketingLinesearch()(M)
         @test startswith(repr(clbs), "CubicBracketingLinesearch(;")
-        @test startswith(Manopt.status_summary(clbs), repr(clbs))
+        @test startswith(Manopt.status_summary(clbs), "Cubic bracketing stepsize")
         @test clbs(dmp, gs, 1) ≈ 0.5 atol = 4 * 1.0e-8
 
         #edge cases of interval bracketing

--- a/test/commons/test_stepsizes.jl
+++ b/test/commons/test_stepsizes.jl
@@ -97,6 +97,7 @@ end
     @test startswith(Manopt.status_summary(s2), "Non-monotone linesearch")
     @test startswith(Manopt.status_summary(s2.bb_stepsize), "Barzilei–Borwein stepsize\n")
 
+
     s3 = WolfePowellBinaryLinesearch()(M)
     @test Manopt.get_message(s3) == ""
     @test startswith(repr(s3), "WolfePowellBinaryLinesearchStepsize(;")
@@ -197,6 +198,22 @@ end
         abs_const_step = Manopt.ConstantStepsize(M, 1.0; type = :absolute)
         @test abs_const_step(mp, gds, 1) ==
             1.0 / norm(get_manifold(mp), get_iterate(gds), get_gradient(gds))
+    end
+    @testset "BarzileiBorwein" begin
+        M = Euclidean(2)
+        f(M, p) = sum(p .^ 2)
+        grad_f(M, p) = 2 .* p
+        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        p = [2.0, 2.0]
+        X = grad_f(M, p)
+        # Create stepsize with factory
+        bb = BarzileiBorwein()(M) #
+        gds = GradientDescentState(M; p = p, stepsize = bb)
+        # Check both modes to use BB
+        # (1) vector transport when providing a last stepsize – no history -> max
+        bb(dmp, gds, 1; last_stepsize = 1.0) == bb.max_stepsize
+        # (1) vector transport when providing a last stepsize - we did not actually move - still max
+        bb(dmp, gds, 1) == bb.max_stepsize
     end
     @testset "Polyak Stepsize" begin
         M = Euclidean(2)

--- a/test/commons/test_stepsizes.jl
+++ b/test/commons/test_stepsizes.jl
@@ -62,6 +62,16 @@ using ManifoldsBase, Manopt, Manifolds, Test
         @test Manopt.default_point_distance(Euclidean(2), p1) == 2.0
         @test Manopt.default_vector_norm(Euclidean(2), p1, X1) == 2.0
     end
+    @testset "Initial Guess Stepsize" begin
+        M = ManifoldsBase.DefaultManifold(2)
+        sig = Manopt.StepsizeInitialGuess(Manopt.ConstantStepsize(1.0, :relative))
+        f(M, p) = sum((p .- 1) .^ 2)
+        grad_f(M, p) = 2 .* (p .- 1)
+        dmp = DefaultManoptProblem(M, ManifoldGradientObjective(f, grad_f))
+        gds1 = GradientDescentState(M)
+
+        @test sig(dmp, gds1, 1) == 1.0
+    end
 end
 
 
@@ -83,6 +93,9 @@ end
     s2 = NonmonotoneLinesearch()(M)
     @test startswith(repr(s2), "NonmonotoneLinesearch(;")
     @test Manopt.get_message(s2) == ""
+    @test startswith(repr(s2.bb_stepsize), "BarzileiBorweinStepsize(; ")
+    @test startswith(Manopt.status_summary(s2), "Non-monotone linesearch")
+    @test startswith(Manopt.status_summary(s2.bb_stepsize), "Barzilei–Borwein stepsize\n")
 
     s3 = WolfePowellBinaryLinesearch()(M)
     @test Manopt.get_message(s3) == ""

--- a/test/commons/test_stepsizes.jl
+++ b/test/commons/test_stepsizes.jl
@@ -104,6 +104,14 @@ end
     @test get_last_stepsize(s3) == 0.0
     @test startswith(Manopt.status_summary(s3), "A Wolfe Powell bisection line search")
     # no stepsize yet so `repr` and summary are the same
+    # regression: with a too-long first trial the search must bisect until Armijo holds
+    f3(M, p) = 100 * sum(p .^ 2)
+    grad_f3(M, p) = 200 .* p
+    dmp3 = DefaultManoptProblem(M, ManifoldGradientObjective(f3, grad_f3))
+    gds3 = GradientDescentState(M; p = [1.0, 1.0])
+    gds3.X = grad_f3(M, gds3.p)
+    t3 = s3(dmp3, gds3, 1, -gds3.X)
+    @test f3(M, gds3.p .- t3 .* gds3.X) <= f3(M, gds3.p) - 1.0e-4 * t3 * norm(gds3.X)^2
     s4 = WolfePowellLinesearch()(M)
     @test startswith(repr(s4), "WolfePowellLinesearchStepsize(;")
     @test startswith(Manopt.status_summary(s4), "A Wolfe Powell line search")

--- a/test/solvers/test_alternating_gradient.jl
+++ b/test/solvers/test_alternating_gradient.jl
@@ -75,6 +75,7 @@ using Manopt, Manifolds, Test, RecursiveArrayTools
             "# Solver state for `Manopt.jl`s Alternating Gradient Descent Solver"
         )
         @test startswith(repr(r), "AlternatingGradientDescentState(; ")
+        @test_throws DomainError AlternatingGradientDescentState(N; order_type = :WrongSymbol)
         # r has the same message as the internal stepsize
         @test Manopt.get_message(r) == Manopt.get_message(r.stepsize)
         @test isapprox(N, q3, q)

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -37,6 +37,7 @@ using ManifoldDiff: grad_distance
         )
         @test p == p2
         step = NonmonotoneLinesearch(;
+            p=p,
             stepsize_reduction = 0.99,
             sufficient_decrease = 0.1,
             memory_size = 2,

--- a/test/solvers/test_gradient_descent.jl
+++ b/test/solvers/test_gradient_descent.jl
@@ -37,7 +37,7 @@ using ManifoldDiff: grad_distance
         )
         @test p == p2
         step = NonmonotoneLinesearch(;
-            p=p,
+            p = p,
             stepsize_reduction = 0.99,
             sufficient_decrease = 0.1,
             memory_size = 2,

--- a/test/solvers/test_proximal_gradient_method.jl
+++ b/test/solvers/test_proximal_gradient_method.jl
@@ -21,6 +21,7 @@ using Manopt, Manifolds, Test, ManifoldDiff
         # Trigger manually
         sc1.at_iteration = 2
         @test length(get_reason(sc1)) > 0
+        @test Manopt.indicates_convergence(sc1)
 
         pgms.last_stepsize = 1.0
         g(M, q) = distance(M, q, p)^2

--- a/test/solvers/test_quasi_Newton.jl
+++ b/test/solvers/test_quasi_Newton.jl
@@ -32,11 +32,23 @@ end
         M = Euclidean(4)
         qnu = InverseBFGS()
         d = QuasiNewtonMatrixDirectionUpdate(M, qnu)
-        @test Manopt.status_summary(d) ==
-            "$(qnu) with initial scaling 1.0 and vector transport method ParallelTransport()."
+        @test startswith(
+            Manopt.status_summary(d), "A quasi Newton direction update stored as a matrix"
+        )
+        @test Manopt.status_summary(d; context = :inline) ==
+            "A quasi Newton direction update using $(qnu), stored as a matrix."
+        @test Manopt.status_summary(d; context = :short) == repr(d)
         s = "QuasiNewtonMatrixDirectionUpdate(DefaultOrthonormalBasis(ℝ), [1.0 0.0 0.0 0.0; 0.0 1.0 0.0 0.0; 0.0 0.0 1.0 0.0; 0.0 0.0 0.0 1.0], 1.0, InverseBFGS(), ParallelTransport())\n"
         @test repr(d) == s
         @test Manopt.get_message(d) == ""
+        c = QuasiNewtonCautiousDirectionUpdate(d)
+        @test startswith(
+            Manopt.status_summary(c), "A cautious quasi Newton direction update"
+        )
+        @test startswith(
+            Manopt.status_summary(c; context = :inline), "A cautious direction update with θ = "
+        )
+        @test startswith(repr(c), "QuasiNewtonCautiousDirectionUpdate with θ = ")
     end
 
     @testset "Mean of 3 Matrices" begin

--- a/test/solvers/test_quasi_Newton_box.jl
+++ b/test/solvers/test_quasi_Newton_box.jl
@@ -96,7 +96,14 @@ using RecursiveArrayTools
         st = QuasiNewtonState(M)
 
         @test startswith(repr(ha), "QuasiNewtonLimitedMemoryBoxDirectionUpdate with internal state:")
-        @test startswith(Manopt.status_summary(ha), "limited memory direction update with support for box constraints; internal direction update status: ")
+        @test startswith(
+            Manopt.status_summary(ha),
+            "A limited memory quasi Newton direction update with support for box constraints",
+        )
+        @test startswith(
+            Manopt.status_summary(ha; context = :inline),
+            "A limited memory direction update with support for box constraints; internally: ",
+        )
 
         f(M, p) = sum(p .^ 2)
         grad_f(M, p) = 2 * p

--- a/test/solvers/test_stochastic_gradient_descent.jl
+++ b/test/solvers/test_stochastic_gradient_descent.jl
@@ -79,6 +79,7 @@ using Manopt, Manifolds, Test
         @test_throws MethodError get_gradient!(dmp1i, X, p)
         @test_throws MethodError get_gradients(dmp1i, p)
         @test_throws MethodError get_gradient!(dmp1i, Z4, p, 1)
+        @test_throws DomainError StochasticGradientDescentState(M; order_type = :WrongSymbol)
         sgds = StochasticGradientDescentState(
             M; p = deepcopy(p), X = zero_vector(M, p), direction = StochasticGradient(; p = p)(M)
         )

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,7 +4,7 @@ using Aqua, Manopt, Test
     Aqua.test_all(
         Manopt;
         ambiguities = (broken = false,),
-        # We define reflect! 8from LInearAlgebra) on an AbstractManifold (from ManifoldsBase).
+        # We define reflect! (from LinearAlgebra) on an AbstractManifold (from ManifoldsBase).
         # This formally could be considered piracy; in the long run one could move this to ManifoldsBase.
         piracies = (treat_as_own = [reflect, reflect!],)
     )

--- a/tutorials/ImplementASolver.qmd
+++ b/tutorials/ImplementASolver.qmd
@@ -248,7 +248,7 @@ We can introduce these here as well with just a few lines of code. There are usu
 We further need three internal function from `Manopt.jl`
 
 ```{julia}
-using Manopt: get_solver_return, indicates_convergence, status_summary
+using Manopt: get_solver_return, has_converged, status_summary
 ```
 
 ### A high level interface using the objective
@@ -313,10 +313,10 @@ import Manopt: status_summary
 function status_summary(rws::RandomWalkState; context::Symbol = :default)
     (context === :short) && return repr(rws)
     i = get_count(rws, :Iterations)
-    conv_inl = (i > 0) ? (indicates_convergence(rws.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
+    conv_inl = (i > 0) ? (has_converged(rws.stop) ? " (converged" : " (stopped") * " after $i iterations)" : ""
     (context === :inline) && return "A solver state for the random walk algorithm$(conv_inl)"
     Iter = (i > 0) ? "After $i iterations\n" : ""
-    Conv = indicates_convergence(rws.stop) ? "Yes" : "No"
+    Conv = has_converged(rws.stop) ? "Yes" : "No"
     s = """
     # Solver state for `Manopt.jl`s Tutorial Random Walk
     $Iter
@@ -326,7 +326,7 @@ function status_summary(rws::RandomWalkState; context::Symbol = :default)
 
     ## Stopping criterion
     $(status_summary(rws.stop; context = context))
-    This indicates convergence: $Conv"""
+    The algorithm converged: $Conv"""
     return s
 end
 ```


### PR DESCRIPTION
this closes #537.

The main modelling of the idea to solve this are done – but a few details are still missing:

* [x] introduce `BarzileiBorweinStepsize` as its own separate stepsize (not only in nonmonotone line searches
* [x] isolate its docs
* [x] introduce a `BarzileiBorwein` factory
* [x] move docs of the formulae to the factory
* [x] add `show`/ `status_summary` for the new stepsize
* [x] refactor `NonMonotoneLinesearch` to internally use the new  `BarzileiBorweinStepsize` internally as a field
* [x] make sure the `NonMonotoneLinesearch` also works on the circle again. Currently it seems to accidentally produce a `Float64` point on which one can of course not work in-place in the linesearch
* [x] update `show`/ `status_summary` for the `NonMonotoneLinesearch`
* [x] introduce a new `AbstractInitialLinesearchGuess` – maybe as generic as that it allows to use another line search as initial guess – then BB is just a special case here
* [x] Check docs that all renders fine
* [x] Check test coverage
* [x] Fix that Benchmark is really only running if the tag is present.