### PR TITLE
Fix runic formatting.

### DIFF
--- a/src/commons/objectives.jl
+++ b/src/commons/objectives.jl
@@ -1393,10 +1393,10 @@ function get_equality_constraint(M::AbstractManifold, co::ManifoldCachedObjectiv
     if haskey(co.cache, :EqualityConstraint) # storing the index constraints
         return [
             copy(
-                    get!(co.cache[:EqualityConstraint], (key, j)) do
-                        get_equality_constraint(M, co.objective, p, j)
+                get!(co.cache[:EqualityConstraint], (key, j)) do
+                    get_equality_constraint(M, co.objective, p, j)
                 end,
-                ) for j in _to_iterable_indices(1:equality_constraints_length(co.objective), i)
+            ) for j in _to_iterable_indices(1:equality_constraints_length(co.objective), i)
         ]
     end # neither cache: pass down to objective
     return get_equality_constraint(M, co.objective, p, i)
@@ -1434,10 +1434,10 @@ function get_inequality_constraint(M::AbstractManifold, co::ManifoldCachedObject
     if haskey(co.cache, :InequalityConstraint) # storing the index constraints
         return [
             copy(
-                    get!(co.cache[:InequalityConstraint], (key, j)) do
-                        get_inequality_constraint(M, co.objective, p, j)
+                get!(co.cache[:InequalityConstraint], (key, j)) do
+                    get_inequality_constraint(M, co.objective, p, j)
                 end,
-                ) for
+            ) for
                 j in _to_iterable_indices(1:inequality_constraints_length(co.objective), i)
         ]
     end # neither cache: pass down to objective

--- a/src/solvers/convex_bundle_method.jl
+++ b/src/solvers/convex_bundle_method.jl
@@ -228,18 +228,18 @@ mutable struct ConvexBundleMethodState{
             if (k_max === nothing)
                 estimation_points = [
                     close_point(
-                            M, p_estimate, diameter / 3; retraction_method = retraction_method
-                        ) for _ in 1:k_size
+                        M, p_estimate, diameter / 3; retraction_method = retraction_method
+                    ) for _ in 1:k_size
                 ]
                 estimation_vectors_1 = [rand(M; vector_at = pe) for pe in estimation_points]
                 estimation_vectors_2 = [rand(M; vector_at = pe) for pe in estimation_points]
                 s = [
                     sectional_curvature(
-                            M,
-                            estimation_points[i],
-                            estimation_vectors_1[i],
-                            estimation_vectors_2[i],
-                        ) for i in 1:k_size
+                        M,
+                        estimation_points[i],
+                        estimation_vectors_1[i],
+                        estimation_vectors_2[i],
+                    ) for i in 1:k_size
                 ]
             end
             (k_min === nothing) && (k_min = minimum(s))

--- a/src/solvers/proximal_bundle_method.jl
+++ b/src/solvers/proximal_bundle_method.jl
@@ -367,10 +367,10 @@ function step_solver!(mp::AbstractManoptProblem, pbms::ProximalBundleMethodState
     v = [
         -2 * ej /
             norm(
-                M,
-                pbms.p_last_serious,
-                inverse_retract(M, pbms.p_last_serious, qj, pbms.inverse_retraction_method),
-            )^2 for
+            M,
+            pbms.p_last_serious,
+            inverse_retract(M, pbms.p_last_serious, qj, pbms.inverse_retraction_method),
+        )^2 for
             (ej, (qj, Xj)) in zip(pbms.lin_errors, pbms.bundle) if !(qj ≈ pbms.p_last_serious)
     ]
     if !isempty(v)

--- a/test/commons/test_constrained_sets.jl
+++ b/test/commons/test_constrained_sets.jl
@@ -10,15 +10,15 @@ using Manifolds, Manopt, Random, Test
     # N random points moved to top left to have a mean outside
     pts = [
         exp(
+            M,
+            c,
+            get_vector(
                 M,
                 c,
-                get_vector(
-                    M,
-                    c,
-                    σ .* randn(manifold_dimension(M)) .+ [2.5, 2.5],
-                    DefaultOrthonormalBasis(),
-                ),
-            ) for _ in 1:N
+                σ .* randn(manifold_dimension(M)) .+ [2.5, 2.5],
+                DefaultOrthonormalBasis(),
+            ),
+        ) for _ in 1:N
     ]
     f(M, p) = 1 / (2 * length(pts)) .* sum(distance(M, p, q)^2 for q in pts)
     grad_f(M, p) = -1 / length(pts) .* sum(log(M, p, q) for q in pts)

--- a/test/solvers/test_cyclic_proximal_point.jl
+++ b/test/solvers/test_cyclic_proximal_point.jl
@@ -45,11 +45,11 @@ using ManifoldDiff: prox_distance, prox_distance!
         N = PowerManifold(M, NestedPowerRepresentation(), n)
         q = [ #Adapted Lemniscate
             exp(
-                    M,
-                    [0.0, 0.0, 1.0],
-                    π / 2.0 * (cos(t) / (sin(t)^2 + 1.0)) * [1.0, 0.0, 0.0] +
+                M,
+                [0.0, 0.0, 1.0],
+                π / 2.0 * (cos(t) / (sin(t)^2 + 1.0)) * [1.0, 0.0, 0.0] +
                     π / 2.0 * (cos(t) * sin(t) / (sin(t)^2 + 1.0)) * [0.0, 1.0, 0.0],
-                ) for t in range(0, 2π; length = n)
+            ) for t in range(0, 2π; length = n)
         ]
         f(N, p) = Manopt.Test.L2_Total_Variation(N, q, 0.5, p)
         proxes! = (
@@ -107,11 +107,11 @@ using ManifoldDiff: prox_distance, prox_distance!
         N = PowerManifold(M, NestedPowerRepresentation(), n)
         q = [ #Adapted Lemniscate
             exp(
-                    M,
-                    [0.0, 0.0, 1.0],
-                    π / 2.0 * (cos(t) / (sin(t)^2 + 1.0)) * [1.0, 0.0, 0.0] +
+                M,
+                [0.0, 0.0, 1.0],
+                π / 2.0 * (cos(t) / (sin(t)^2 + 1.0)) * [1.0, 0.0, 0.0] +
                     π / 2.0 * (cos(t) * sin(t) / (sin(t)^2 + 1.0)) * [0.0, 1.0, 0.0],
-                ) for t in range(0, 2π; length = n)
+            ) for t in range(0, 2π; length = n)
         ]
         f(N, x) = Manopt.Test.L2_Total_Variation(N, q, 0.5, x)
         proxes! = (

--- a/test/solvers/test_projected_gradient.jl
+++ b/test/solvers/test_projected_gradient.jl
@@ -10,12 +10,12 @@ using Manifolds, Manopt, Random, Test
     # N random points moved to top left to have a mean outside
     pts = [
         exp(
-                M, c,
-                get_vector(
-                    M, c, σ .* randn(manifold_dimension(M)) .+ [2.5, 2.5],
-                    DefaultOrthonormalBasis(),
-                ),
-            ) for _ in 1:N
+            M, c,
+            get_vector(
+                M, c, σ .* randn(manifold_dimension(M)) .+ [2.5, 2.5],
+                DefaultOrthonormalBasis(),
+            ),
+        ) for _ in 1:N
     ]
     f(M, p) = 1 / (2 * length(pts)) .* sum(distance(M, p, q)^2 for q in pts)
     grad_f(M, p) = -1 / length(pts) .* sum(log(M, p, q) for q in pts)

--- a/test/solvers/test_stochastic_gradient_descent.jl
+++ b/test/solvers/test_stochastic_gradient_descent.jl
@@ -21,9 +21,9 @@ using Manopt, Manifolds, Test
     sgrad_f2 = [((M, y) -> -log(M, y, x)) for x in pts]
     sgrad_f2! = [
         function f!(M, X, y)
-                log!(M, X, y, x)
-                X .*= -1
-                return X
+            log!(M, X, y, x)
+            X .*= -1
+            return X
         end for x in pts
     ]
 


### PR DESCRIPTION
Runic surely never claimed to be “nonbreaking” in its formatting. From 1.9 to 1.10 the following changed, so that on master it last broke. This PR fixes that.