### PR TITLE
A bug in adaptive regularization algorithm working on manifolds in complex numbers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ They are still listed here in detail in case (a) someone elses code breaks of (b
 * since we introduced the differential in the first order objectives,
 they were not fully supported in all places. This was now fixed and unified.
 * for a nicer printing on REPL, a few more `status_summary` functions were added (with the help of an AI)
+* Non-AI assisted: Minor bug fix in the solver `adaptive_regularization_with_cubics` to work on complex manifolds
 
 ## [0.6.6] August 25, 2026
 

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -38,6 +38,7 @@ The following packages are using `Manopt.jl`:
 The following papers are using `Manopt.jl`:
 
 * [GlaubitzIskeLampertOeffner:2026](@citet*)
+* [Locally Purified Maximally Mixed States At Scale: Entanglement Pruning and Symmetries](https://doi.org/10.1063/5.0317339): Explores integration of Manopt.jl with ITensors.jl and Zygote.jl to optimize the tensor network representation of quantum states
 
 If you are missing a package or paper, that uses `Manopt.jl`, please [open an issue](https://github.com/JuliaManifolds/Manopt.jl/issues/new).
 It would be great to collect anything and anyone using `Manopt.jl` in this list.

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -193,8 +193,8 @@ function step_solver!(dmp::AbstractManoptProblem{<:TangentSpace}, ls::LanczosSta
         ls.Hp_residual .= ls.Hp_residual - α * ls.Lanczos_vectors[k]
         # Update tridiagonal matrix
         ls.tridig_matrix[k, k] = α
-        ls.tridig_matrix[k - 1, k] = real(β)
-        ls.tridig_matrix[k, k - 1] = real(β)
+        ls.tridig_matrix[k - 1, k] = β
+        ls.tridig_matrix[k, k - 1] = β
         min_cubic_Newton!(dmp, ls, k)
     end
     copyto!(M, ls.S, p, sum(ls.Lanczos_vectors[k] * ls.coefficients[k] for k in 1:k))

--- a/src/solvers/Lanczos.jl
+++ b/src/solvers/Lanczos.jl
@@ -152,7 +152,7 @@ function step_solver!(dmp::AbstractManoptProblem{<:TangentSpace}, ls::LanczosSta
             copyto!(M, ls.Lanczos_vectors[1], p, ls.X / nX)
         end
         get_objective_hessian!(M, ls.Hp, arcmo, p, ls.Lanczos_vectors[1])
-        α = inner(M, p, ls.Lanczos_vectors[1], ls.Hp)
+        α = real(inner(M, p, ls.Lanczos_vectors[1], ls.Hp))
         # This is also the first coefficient in the tridiagonal matrix
         ls.tridig_matrix[1, 1] = α
         ls.Hp_residual .= ls.Hp - α * ls.Lanczos_vectors[1]
@@ -189,12 +189,12 @@ function step_solver!(dmp::AbstractManoptProblem{<:TangentSpace}, ls::LanczosSta
         # Update Hessian and residual
         get_objective_hessian!(M, ls.Hp, arcmo, p, ls.Lanczos_vectors[k])
         ls.Hp_residual .= ls.Hp - β * ls.Lanczos_vectors[k - 1]
-        α = inner(M, p, ls.Hp_residual, ls.Lanczos_vectors[k])
+        α = real(inner(M, p, ls.Hp_residual, ls.Lanczos_vectors[k]))
         ls.Hp_residual .= ls.Hp_residual - α * ls.Lanczos_vectors[k]
         # Update tridiagonal matrix
         ls.tridig_matrix[k, k] = α
-        ls.tridig_matrix[k - 1, k] = β
-        ls.tridig_matrix[k, k - 1] = β
+        ls.tridig_matrix[k - 1, k] = real(β)
+        ls.tridig_matrix[k, k - 1] = real(β)
         min_cubic_Newton!(dmp, ls, k)
     end
     copyto!(M, ls.S, p, sum(ls.Lanczos_vectors[k] * ls.coefficients[k] for k in 1:k))

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -538,10 +538,10 @@ function step_solver!(dmp::AbstractManoptProblem, arcs::AdaptiveRegularizationSt
     cost = get_cost(M, mho, arcs.p)
     ρ_num = cost - get_cost(M, mho, arcs.q)
     ρ_vec = arcs.X + 0.5 * get_hessian(M, mho, arcs.p, arcs.s)
-    ρ_den = -inner(M, arcs.p, arcs.s, ρ_vec)
+    ρ_den = -real(inner(M, arcs.p, arcs.s, ρ_vec))
     ρ_reg = arcs.ρ_regularization * eps(Float64) * max(abs(cost), 1)
-    arcs.ρ_denominator = real(ρ_den + ρ_reg) # <= 0 -> the default debug kicks in
-    arcs.ρ = real((ρ_num + ρ_reg) / (ρ_den + ρ_reg))
+    arcs.ρ_denominator = ρ_den + ρ_reg # <= 0 -> the default debug kicks in
+    arcs.ρ = (ρ_num + ρ_reg) / (ρ_den + ρ_reg)
     #Update iterate
     if arcs.ρ >= arcs.η1
         copyto!(M, arcs.p, arcs.q)

--- a/src/solvers/adaptive_regularization_with_cubics.jl
+++ b/src/solvers/adaptive_regularization_with_cubics.jl
@@ -540,8 +540,8 @@ function step_solver!(dmp::AbstractManoptProblem, arcs::AdaptiveRegularizationSt
     ρ_vec = arcs.X + 0.5 * get_hessian(M, mho, arcs.p, arcs.s)
     ρ_den = -inner(M, arcs.p, arcs.s, ρ_vec)
     ρ_reg = arcs.ρ_regularization * eps(Float64) * max(abs(cost), 1)
-    arcs.ρ_denominator = ρ_den + ρ_reg # <= 0 -> the default debug kicks in
-    arcs.ρ = (ρ_num + ρ_reg) / (ρ_den + ρ_reg)
+    arcs.ρ_denominator = real(ρ_den + ρ_reg) # <= 0 -> the default debug kicks in
+    arcs.ρ = real((ρ_num + ρ_reg) / (ρ_den + ρ_reg))
     #Update iterate
     if arcs.ρ >= arcs.η1
         copyto!(M, arcs.p, arcs.q)


### PR DESCRIPTION
Hi, 

We have been integrating different solvers from Manopt.jl to optimize tensor network representations using ITensors.jl (a sample of this integration has been published in one of our recent works [1]). I have further tested these optimization routines with different solvers and in the process noticed that Adaptive Regularization with Cubics results in an error,  a sample to reproduce the error is at [2]. From my understanding this is possibly due to a comparison involving complex numbers (the values are real as expected but the variables in the algorithm get assigned as complex numbers with a negligible complex part). I have tried to fix these occurrences in this PR and haves tested it with the above sample and also on some other examples that we are currently working on (which we hope to put out on arXiv soon).

Thanks for the nice package!

[1] https://doi.org/10.1063/5.0317339
[2] https://gist.github.com/amitjamadagni/bb84ca867df1a19e6f5c846efbab8ad4 